### PR TITLE
Change text on form navigation buttons to match Sketch designs

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report.html
+++ b/crt_portal/cts_forms/templates/forms/report.html
@@ -93,10 +93,10 @@
             {% endif %}
           </table>
           {% if wizard.steps.prev %}
-            <button name="wizard_goto_step" type="submit" label="first step" value="{{ wizard.steps.first }}" class="usa-button">{% trans "first step" %}</button>
-            <button name="wizard_goto_step" type="submit" label="previous step" value="{{ wizard.steps.prev }}" class="usa-button">{% trans "prev step" %}</button>
+            <button name="wizard_goto_step" type="submit" label="first step" value="{{ wizard.steps.first }}" class="usa-button">{% trans "First" %}</button>
+            <button name="wizard_goto_step" type="submit" label="previous step" value="{{ wizard.steps.prev }}" class="usa-button">{% trans "Back" %}</button>
           {% endif %}
-          <input type="submit" label="submit" value="{% trans "submit" %}" class="usa-button"/>
+          <input type="submit" label="submit" value="{% trans "Next" %}" class="usa-button"/>
         </form>
       </div>
       <div class="grid-col-1"></div>


### PR DESCRIPTION
## What does this change?

Updates the text on form navigation buttons to match the text specified in the Sketch designs.

## Screenshots (for front-end PR):

<img width="285" alt="form-nav-text" src="https://user-images.githubusercontent.com/3209501/63781890-214cee80-c8b0-11e9-9da1-9a9c9bd03be4.png">
