### PR TITLE
Add language attribute to html element

### DIFF
--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -1,6 +1,6 @@
 {% load static %}
 <!DOCTYPE html>
-<html>
+<html lang="en">
  <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
## What does this change?

+ Fixes error caught by a manual/local `pa11y` scan!

## Notes for reviewer:

If you download pa11y, run the site locally, and run `pa11y http://0.0.0.0:8000/report` in another window, you should see:

```
Welcome to Pa11y

 > Running Pa11y on URL http://0.0.0.0:8000/report/

No issues found!
```