### PR TITLE
Write down notes on how Docker sets ENV to "LOCAL" automatically

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -17,7 +17,9 @@ import json
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-
+# If ENV is not set explicitly, assume "PROD".
+# Note that when using Docker, ENV is set to "LOCAL" by docker-compose.yml.
+# We are using Docker for local development only.
 environment = os.environ.get('ENV', 'PROD')
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
## What does this change?

Writes down information on how `docker-compose.yml` sets `ENV` automatically in a code comment. @LindsayYoung cleared this up for me in a Slack conversation, adding this to the repo in case others wonder the same thing or in case I forget! 