### PR TITLE
Adjust vertical spacing around inputs for more clarity

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report.html
+++ b/crt_portal/cts_forms/templates/forms/report.html
@@ -85,8 +85,8 @@
           <div class="margin-bottom-3"><em>{{ question_group.help_text }}</em></div>
 
           {% for field in question_group %}
-            <fieldset class="usa-fieldset">
-              <legend class="margin-bottom-1">{{ field.label_tag }}</legend>
+            <fieldset class="usa-fieldset margin-bottom-1">
+              <legend class="margin-bottom-0">{{ field.label_tag }}</legend>
               <em>{{ field.help_text }}</em>
               {{ field.errors }}
               <div class="margin-bottom-2">{{ field }}</div>
@@ -96,7 +96,7 @@
       {% else %}
         {% for field in wizard.form.visible_fields %}
           <fieldset class="usa-fieldset">
-            <legend class="margin-bottom-1">{{ field.label_tag }}</legend>
+            <legend class="margin-bottom-0">{{ field.label_tag }}</legend>
             {{ field.errors }}
             <div class="margin-bottom-2">{{ field }}</div>
             {{ field.help_text }}


### PR DESCRIPTION
## What does this change?

Adjusts vertical spacing around `<input />` form elements based on Jacklynn's good feedback and eagle eye! 👀 

This should make it more visually clear which label is associated with which input. 

## Screenshots:

### This branch

<img width="478" alt="this-branch" src="https://user-images.githubusercontent.com/3209501/65358094-581bd900-dbbe-11e9-8031-16c75f6fc8d1.png">


### `master`

<img width="482" alt="master" src="https://user-images.githubusercontent.com/3209501/65358092-56521580-dbbe-11e9-8b05-2182611d45c1.png">
