### PR TITLE
Remove DOJ seal img alt text to skip

### DIFF
--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -68,7 +68,7 @@
           <div class="usa-footer__logo grid-row grid-gap-2">
             <div class="grid-col-auto">
               <img src="{% static "img/doj-logo-footer.svg" %}"
-                   alt="U.S. Department of Justice Seal, image of an eagle holding a bundle of arrows in one claw and an olive branch in the other, with the Latin words Qui Pro Domina Justitia Sequitur below."
+                   alt=" "
                    height="64" />
             </div>
             <div class="grid-col-auto">


### PR DESCRIPTION
Ran WAVE testing on the website and it flagged the seal as having a long alt text. Indeed it has a long and beautifully detailed description with nuances I didn't realize myself, but it might not be appropriate because it's purely decorative and the name Civil Rights Division is beneath it. 
Reference: https://webaim.org/techniques/alttext/#decorative (Example 2)
If it were functional (ex: links to DOJ home page) we should add a label again.

How m' doin', Lindsay?

[Link to ZenHub issue.](link-goes-here)

## What does this change?

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests)

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests)

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
