### PR TITLE
Removing H3 marker for the footer name b/c not semantic

### DIFF
--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -72,7 +72,7 @@
                    height="64" />
             </div>
             <div class="grid-col-auto">
-              <h3 class="usa-footer__logo-heading">
+              <p class="usa-footer__logo-heading">
                 Civil Rights Division
                 <br/> U.S. Department of Justice
               </h3>

--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -75,7 +75,7 @@
               <p class="usa-footer__logo-heading">
                 Civil Rights Division
                 <br/> U.S. Department of Justice
-              </h3>
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
# Notes from @Jacklynn 

<H> Heading tags are used by screen readers navigate through a page and should represent semantic value. Visually the "Civil Rights Division" text in the footer may visually look like an h3, but I don't think we should label it that way. The way you can check is evaluating the outline on our page today:

h1 Contact the Department of Justice about a civil rights concern
- h2 Contact
-- h3 Who should we contact about this issue?
-- h3 Name (optional)
-- h3 Contact information (optional)
-- h3 Civil Rights Division U.S. Department of Justice

"Civil Rights Division U.S. Department of Justice" is not like the others and isn't a labeling a group of additional information

Ref that I think explains it clearly: https://www.nomensa.com/blog/2017/how-structure-headings-web-accessibility

[Link to ZenHub issue.](link-goes-here)

## What does this change?

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests)

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests)

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
