### PR TITLE
Preserve newlines when trimming Details text to 500 words

### DIFF
--- a/crt_portal/static/js/word_count.js
+++ b/crt_portal/static/js/word_count.js
@@ -15,7 +15,9 @@ function updateWordCount (e) {
     if (words >= 500) {
       // Word count greater than or equal to 500 word limit.
       // Trim the text down to the first 500 words:
-      var trimmed = textAreaElem.value.split(/\s+/, 500).join(" ");
+      var trimmed = textAreaElem.value.split(" ", 500).join(" ")
+                                      .split("\t", 500).join("\t")
+                                      .split("\n", 500).join("\n");
       textAreaElem.value = trimmed;
 
       // Update display for user:


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/69)

## What does this change?

Fix issue that was causing newlines to be stripped out of the Details textarea when a user tried to type more than the 500 allowed words.

Removing newlines would remove paragraph styling, which would be significantly harder for DOJ staff to read (think big block of text versus paragraph text). 

## GIF 

![newlines](https://user-images.githubusercontent.com/3209501/66349398-6c7e0680-e91e-11e9-9388-76d792d00d3c.gif)


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests)

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests)
