### PR TITLE
Improvements to noscript experience for Details page

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_details.html
+++ b/crt_portal/cts_forms/templates/forms/report_details.html
@@ -13,11 +13,9 @@
       {{ field }}
     </div>
     <noscript>
-      Please enable JavaScript for the best experience using this website.
-      <br/>
-      <br/>
+      <em>500 word limit.</em>
     </noscript>
-    <em>
+    <em id="word_count_area" hidden>
       <span id="display_count">500</span>
       <span id="count_message">word(s) remaining</span>
     </em>

--- a/crt_portal/static/js/word_count.js
+++ b/crt_portal/static/js/word_count.js
@@ -2,6 +2,10 @@ var textAreaElem = document.getElementById("id_1-violation_summary");
 var displayCountElem = document.getElementById("display_count");
 var countMessageElem = document.getElementById("count_message");
 var wordLimitAlert = document.getElementById("word-limit-alert");
+var wordCountArea = document.getElementById("word_count_area");
+
+// Show word count area for JS-enabled browsers:
+wordCountArea.removeAttribute('hidden');
 
 function updateWordCount (e) {
     // Ignore `e` and read the value directly from the textarea here;


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/69)

## What does this change?

If a user does not have JavaScript enabled on their browser: 

+ Show them that they have a 500 word limit for the Details textarea. 
+ Do not show them the dynamic/JS-powered word count box.

## Screenshots (for front-end PR):

### JavaScript disabled, Chrome: 

<img width="534" alt="noscript" src="https://user-images.githubusercontent.com/3209501/66350551-3d1cc900-e921-11e9-8886-b8eead53a93b.png">
