### PR TITLE
Fix double-label bug in grouped questions template 

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_grouped_questions.html
+++ b/crt_portal/cts_forms/templates/forms/report_grouped_questions.html
@@ -23,7 +23,9 @@
       {% endif %}
 
       {% for field in question_group %}
-        <label class="margin-bottom-0">{{ field.label_tag }}</label>
+        <label for="{{ field.id_for_label }}" class="margin-bottom-0">
+          {{ field.label }}
+        </label>
         <em>{{ field.help_text }}</em>
         {{ field.errors }}
         <div {% if forloop.last %}{% else %}class="margin-bottom-2"{% endif %}>


### PR DESCRIPTION
## Before
<img width="432" alt="double-label" src="https://user-images.githubusercontent.com/3209501/66608658-b5cb9180-eb7c-11e9-821a-76acc0cc0c20.png">

## After

<img width="495" alt="single-label" src="https://user-images.githubusercontent.com/3209501/66608769-f88d6980-eb7c-11e9-9996-5b5087a26b97.png">
