### PR TITLE
Update the page title to match justice.gov/crt

### DIFF
--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -7,7 +7,7 @@
     {# Asking search engines not to index our site while we're in development mode. #}
     <meta name="robots" content="noindex">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>U.S. Department of Justice - Civil Rights Division</title>
+    <title>Contact the Civil Rights Division | Department of Justice</title>
     <link rel="icon" href="{% static "img/us_flag_small.png" %}">
     <link rel="stylesheet" href="{% static "css/styles.css" %}">
     {% block head %}{% endblock %}


### PR DESCRIPTION
Changes page title from: `<title>U.S. Department of Justice - Civil Rights Division</title>` to `Contact the Civil Rights Division | Department of Justice` inspired by our convo with Terri today <3

Reasoning:
The page title for justice.gov/crt is `Civil Rights Division | Department of Justice` if this is a page inside of that, I would expect it to match with the addition of the new context (contacting CRT).  Best a11y practice says to front load the title with the unique information. 

Other pages:
I'm not sure how to do this, but I would expect the title to update on new pages of the form too. 
Maybe we could have the pattern.... Step #: [step name] + "Contact the Civil Rights Division" so `Step 2: Details - Contact the Civil Rights Division | Department of Justice`.

ref:
https://www.w3.org/WAI/test-evaluate/preliminary/#title
https://www.w3.org/WAI/tutorials/forms/multi-page/

[Note in freeform comments too](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/69)

## What does this change?

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests)

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests)

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
