### PR TITLE
Changing the blue & help text of the freeform

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -59,10 +59,10 @@ class Details(ModelForm):
     def __init__(self, *args, **kwargs):
         super(ModelForm, self).__init__(*args, **kwargs)
         self.label_suffix = ''
-        self.fields['violation_summary'].label = 'Please describe what happened in your own words'
+        self.fields['violation_summary'].label = 'Tell us what happened'
         self.fields['violation_summary'].widget.attrs['class'] = 'usa-textarea'
         self.fields['violation_summary'].widget.attrs['aria-describedby'] = 'word_count_area'
-        self.fields['violation_summary'].help_text = "This is your opportunity to share any additional details you think would be helpful for us to know like time, names, witnesses to the event, or anything you haven’t already stated. Document upload is not available at this time, but please describe if you have evidence you’d like to include later."
+        self.fields['violation_summary'].help_text = "Do you have more details about the time, location, or people involved with the event? Can you give names of witnesses or materials that would corroborate your concern?"
 
     class Meta:
         model = Report


### PR DESCRIPTION
To make it more succinct and to take out references of document upload.

[Link to ZenHub issue.](link-goes-here)

## What does this change?

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
