### PR TITLE
Removing compress for now

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -199,7 +199,8 @@ COMPRESS_PRECOMPILERS = (
     ('css', 'compressor_toolkit.precompilers.SCSSCompiler'),
 )
 
-COMPRESS_ENABLED = True
+# would like to add this before public release
+COMPRESS_ENABLED = False
 
 if environment == 'LOCAL':
     from .local_settings import *  # noqa: F401,F403

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -1,7 +1,6 @@
 {% extends "forms/base.html" %}
 {% load i18n %}
 {% load static %}
-{% load compress %}
 {% block head %}
   {{ wizard.form.media }}
 {% endblock %}
@@ -97,7 +96,5 @@
 {% endblock %}
 
 {% block page_js %}
-{% compress js file base %}
 <script src="{% static 'js/word_count.js' %}"></script>
-{% endcompress %}
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_class.html
+++ b/crt_portal/cts_forms/templates/forms/report_class.html
@@ -1,6 +1,5 @@
 {% extends "forms/report_base.html" %}
 {% load static %}
-{% load compress %}
 {% block form_questions %}
 <fieldset class="usa-fieldset" aria-label="{{ current_step_name }}">
   <legend class="usa-sr-only">{{ current_step_name }}</legend hidden>
@@ -39,8 +38,6 @@
 {% endblock %}
 
 {% block page_js %}
-{% compress js file base %}
 <script src="{% static 'js/other_show_hide.js' %}"></script>
 <script src="{% static 'js/word_count.js' %}"></script>
-{% endcompress %}
 {% endblock %}


### PR DESCRIPTION
Fixes javascript on dev.

Setting it up on colud.gov wasn't a quick task so we can make that a task for a later date. 