### PR TITLE
Update "Other" text pt 2

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -114,8 +114,8 @@ class ProtectedClassForm(ModelForm):
         )
         self.fields['protected_class'].label = 'Do you believe you were treated this way because of any of the following characteristics or statuses that apply to you?'
         self.fields['protected_class'].help_text = 'Civil rights laws protects individuals from being discriminated against based on race, color, sex, religion, and other characteristics.'
-        self.fields['other_class'].label = 'Other'
-        self.fields['other_class'].help_text = 'Please describe'
+        self.fields['other_class'].label = 'Other reason'
+        self.fields['other_class'].help_text = 'Please describe "Other reason"'
         self.fields['other_class'].widget.attrs['class'] = 'usa-input word-count-10'
 
 


### PR DESCRIPTION
- Other to "other reason"
- Help text when other is selected to "Please describe "Other reason" for screen readers

To match master text file: https://docs.google.com/document/d/1bxSRc9CQOHjQhTaYkHncE4tykUEFeC6RzFtP5IQk0Ic/edit#

[Link to ZenHub issue.](link-goes-here)

## What does this change?

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
