### PR TITLE
Fix spacing on Protected Class form

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_class.html
+++ b/crt_portal/cts_forms/templates/forms/report_class.html
@@ -9,7 +9,7 @@
       {% if field.errors %}
         {% include "forms/error_warning.html" with errors=field.errors %}
       {% endif %}
-      <p class="usa-prose margin-bottom-4">
+      <p class="usa-prose margin-top-0 margin-bottom-4">
         <em>{{ field.help_text }}</em>
       </p>
       <div class="margin-bottom-3">


### PR DESCRIPTION
## What does this change?

+ Fix spacing on Protected Class form page. 

## Screenshots (for front-end PR):

<img width="1440" alt="Screen Shot 2019-10-29 at 4 59 14 PM" src="https://user-images.githubusercontent.com/3209501/67812578-84543080-fa6d-11e9-9942-c5a455311832.png">
