### PR TITLE
Add proper role="alert" to improve screen reader error announcement

### DIFF
--- a/crt_portal/cts_forms/templates/forms/error_warning.html
+++ b/crt_portal/cts_forms/templates/forms/error_warning.html
@@ -1,5 +1,7 @@
         <div class="usa-alert usa-alert--warning usa-alert--slim">
-          <div class="usa-alert__body"><em class="usa-alert__text">
-            {{ errors }}
-          </em></div>
+          <div class="usa-alert__body">
+            <em role="alert" class="usa-alert__text">
+              {{ errors }}
+            </em>
+          </div>
         </div>


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/167)

## What does this change?

Adds `role="alert"` to error message text. 

When a user tries to select "Next" on the Protected Class page 
And they have no selected checkboxes 
And they have a screen reader turned on
Then they should hear an announcement about the error when the Protected-Class page re-loads. 

## Author 

+ [x] Tested with VoiceOver in Safari and Chrome. 