### PR TITLE
Replace trimStart() with a regex for IE compatibility

### DIFF
--- a/crt_portal/static/js/word_count.js
+++ b/crt_portal/static/js/word_count.js
@@ -69,8 +69,10 @@ function updateWordCount(e, max, textAreaElem) {
   // Ignore `e` and read the value directly from the textarea;
   // we want this function to work even if the user hasn't typed
   // anything (e.g. if textarea has initial content).
-  // TrimStart because leading whitespace messes with our word count.
-  var value = textAreaElem.value.trimStart();
+  //
+  // Trim the start of the string because leading whitespace
+  // messes with our word count function.
+  var value = textAreaElem.value.replace(/^\s+/,'');
 
   // Match groups of non-whitespace characters, i.e. words.
   var wordMatch = value.match(/\S+/g);

--- a/crt_portal/static/js/word_count.js
+++ b/crt_portal/static/js/word_count.js
@@ -72,7 +72,7 @@ function updateWordCount(e, max, textAreaElem) {
   //
   // Trim the start of the string because leading whitespace
   // messes with our word count function.
-  var value = textAreaElem.value.replace(/^\s+/,'');
+  var value = textAreaElem.value.replace(/^\s+/, '');
 
   // Match groups of non-whitespace characters, i.e. words.
   var wordMatch = value.match(/\S+/g);


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/166)

## What does this change?

Fixes an Internet Explorer compatibility bug with the word counter functionality. The JS `trimStart()` function is not supported by Internet Explorer: 

https://caniuse.com/#search=trimStart

Note that this PR is probably not a complete fix to the issue but rather addresses a specific IE compatibility bug that I noticed during testing.

## Notes for reviewer:

+ Please review both instances of the word count functionality carefully on this PR. 
+ Please check for any regex issues or improvements, thank you!