### PR TITLE
Rename options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Run unit test on Windows:
 1. Ensure docker is running
 2. Start a powershell as admin (git bash has issue running ssh console in docker)
 3. Find the id for the web container
-   ``` 
+   ```
     docker container ls
-   ``` 
+   ```
 4. Identify the id for the crt-portal_web_1
 5. SSH to web container in docker:
     ```
@@ -70,7 +70,7 @@ Run unit test on Windows:
     python crt_portal/manage.py test cts_forms
     ```
 7. If you lucky your test will result OK or lots of error to work on!
-    
+
 
 You can also run project tests using docker with:
 
@@ -184,6 +184,14 @@ We deploy from CircleCI.
 * The app will deploy to prod when the tests pass and a PR is merged into `master`.
 
 When CircleCI tries to deploy two PRs back-to-back, one of them can fail. In this case, you can restart the failed deploy process by clicking the "Rerun Workflow" button.
+
+## Additional documentation
+
+For more technical documentation see the [docs](https://github.com/usdoj-crt/crt-portal/tree/develop/docs)
+    - A11y testing plan
+    - Branching strategy
+    - Maintenance or infrequent tasks
+    - Pull request instructions
 
 # Background notes
 

--- a/crt_portal/cts_forms/migrations/0013_rename_protected_class.py
+++ b/crt_portal/cts_forms/migrations/0013_rename_protected_class.py
@@ -9,32 +9,28 @@ class Migration(migrations.Migration):
         ('cts_forms', '0012_insert_protected_class_order'),
     ]
 
-    def retrieve_or_create_options(*args, **defaults):
+        def retrieve_or_create_options(*args, **defaults):
         try:
             with transaction.atomic():
                 c = ProtectedClass.objects.filter(protected_class='Immigration/citizenship status (choosing this does not share your status)').update(protected_class='Immigration/citizenship status (choosing this will not share your status)')
         except:  # noqa
-            # if "Other" doesn't exist we don't have to rename it
-            pass  # noqa
+            logger.info('old name for immigration not detected')
         try:
             with transaction.atomic():
                 c = ProtectedClass.objects.filter(protected_class='National Origin (including ancestry, ethnicity, and language)').update(protected_class='National origin (including ancestry, ethnicity, and language)')
             c.update()
         except:  # noqa
-            # if "Other" doesn't exist we don't have to rename it
-            pass  # noqa
+            logger.info('old name for national origin not detected')
         try:
             with transaction.atomic():
                 c = ProtectedClass.objects.filter(protected_class='Disability (including temporary or in recovery)').update(protected_class='Disability (including temporary or recovery)')
         except:  # noqa
-            # if "Other" doesn't exist we don't have to rename it
-            pass  # noqa
+            logger.info('old name for disability not detected')
         try:
             with transaction.atomic():
                 c = ProtectedClass.objects.filter(protected_class='Other').update(protected_class='Other reason')
         except:  # noqa
-            # if "Other" doesn't exist we don't have to rename it
-            pass  # noqa
+            logger.info('old name for other not detected')
 
     operations = [
         migrations.RunPython(retrieve_or_create_options),

--- a/crt_portal/cts_forms/migrations/0013_rename_protected_class.py
+++ b/crt_portal/cts_forms/migrations/0013_rename_protected_class.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+from cts_forms.models import ProtectedClass
+from cts_forms.model_variables import PROTECTED_CLASS_CHOICES
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cts_forms', '0012_insert_protected_class_order'),
+    ]
+
+    def retrieve_or_create_options(*args, **defaults):
+        try:
+            with transaction.atomic():
+                c = ProtectedClass.objects.filter(protected_class='Immigration/citizenship status (choosing this does not share your status)').update(protected_class='Immigration/citizenship status (choosing this will not share your status)')
+        except:  # noqa
+            # if "Other" doesn't exist we don't have to rename it
+            pass  # noqa
+        try:
+            with transaction.atomic():
+                c = ProtectedClass.objects.filter(protected_class='National Origin (including ancestry, ethnicity, and language)').update(protected_class='National origin (including ancestry, ethnicity, and language)')
+            c.update()
+        except:  # noqa
+            # if "Other" doesn't exist we don't have to rename it
+            pass  # noqa
+        try:
+            with transaction.atomic():
+                c = ProtectedClass.objects.filter(protected_class='Disability (including temporary or in recovery)').update(protected_class='Disability (including temporary or recovery)')
+        except:  # noqa
+            # if "Other" doesn't exist we don't have to rename it
+            pass  # noqa
+        try:
+            with transaction.atomic():
+                c = ProtectedClass.objects.filter(protected_class='Other').update(protected_class='Other reason')
+        except:  # noqa
+            # if "Other" doesn't exist we don't have to rename it
+            pass  # noqa
+
+    operations = [
+        migrations.RunPython(retrieve_or_create_options),
+    ]

--- a/crt_portal/cts_forms/migrations/0013_rename_protected_class.py
+++ b/crt_portal/cts_forms/migrations/0013_rename_protected_class.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
         ('cts_forms', '0012_insert_protected_class_order'),
     ]
 
-        def retrieve_or_create_options(*args, **defaults):
+    def retrieve_or_create_options(*args, **defaults):
         try:
             with transaction.atomic():
                 c = ProtectedClass.objects.filter(protected_class='Immigration/citizenship status (choosing this does not share your status)').update(protected_class='Immigration/citizenship status (choosing this will not share your status)')

--- a/crt_portal/cts_forms/migrations/0013_rename_protected_class.py
+++ b/crt_portal/cts_forms/migrations/0013_rename_protected_class.py
@@ -2,6 +2,10 @@ from django.db import migrations, models
 from cts_forms.models import ProtectedClass
 from cts_forms.model_variables import PROTECTED_CLASS_CHOICES
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class Migration(migrations.Migration):
 

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -14,10 +14,10 @@ PRIMARY_COMPLAINT_CHOICES = (
 # This will create the initial order, the form_order data can be directly adjusted after the initial load.
 # See protected maintenance docs: https://github.com/usdoj-crt/crt-portal/blob/develop/docs/maintenance_or_infrequent_tasks.md#change-protected-class-options
 PROTECTED_CLASS_CHOICES = (
-    'Disability (including temporary or in recovery)',
+    'Disability (including temporary or recovery)',
     'Race/color',
     'National origin (including ancestry, ethnicity, and language)',
-    'Immigration/citizenship status (choosing this does not share your status)',
+    'Immigration/citizenship status (choosing this will not share your status)',
     'Religion',
     'Sex or gender identity (including gender stereotypes) or pregnancy',
     'Family, marriage, or parental status',
@@ -25,15 +25,15 @@ PROTECTED_CLASS_CHOICES = (
     'Military status',
     'Age',
     'Genetic information',
-    'Other',
+    'Other reason',
 )
 
 # used in internal CRT view display
 PROTECTED_CLASS_CODES = {
-    'Disability (including temporary or in recovery)': 'Disability',
+    'Disability (including temporary or recovery)': 'Disability',
     'Race/color': 'Race/color',
-    'National origin (including ancestry, ethnicity, and language)': 'National Origin',
-    'Immigration/citizenship status (choosing this does not share your status)': 'Immigration',
+    'National origin (including ancestry, ethnicity, and language)': 'National origin',
+    'Immigration/citizenship status (choosing this will not share your status)': 'Immigration',
     'Religion': 'Religion',
     'Sex or gender identity (including gender stereotypes) or pregnancy': 'Sex',
     'Sexual orientation': 'Orientation',
@@ -41,14 +41,14 @@ PROTECTED_CLASS_CODES = {
     'Military status': 'Military',
     'Age': 'Age',
     'Genetic information': 'Genetic',
-    'Other': 'Other',
+    'Other reason': 'Other',
 }
 
 PROTECTED_MODEL_CHOICES = (
-    ('disability', 'Disability (including temporary or in recovery)'),
+    ('disability', 'Disability (including temporary or recovery)'),
     ('race', 'Race/color'),
     ('origin', 'National origin (including ancestry, ethnicity, and language)'),
-    ('immigration', 'Immigration/citizenship status (choosing this does not share your status)'),
+    ('immigration', 'Immigration/citizenship status (choosing this will not share your status)'),
     ('religion', 'Religion'),
     ('gender', 'Sex or gender identity (including gender stereotypes) or pregnancy'),
     ('orientation', 'Sexual orientation'),
@@ -56,7 +56,7 @@ PROTECTED_MODEL_CHOICES = (
     ('military', 'Military status'),
     ('age', 'Age'),
     ('genetic', 'Genetic information'),
-    ('other', 'Other'),
+    ('other', 'Other reason'),
 )
 
 PROTECTED_CLASS_ERROR = 'Please make a selection to continue. If none of these apply to your situation, please select "Other reason" and explain.'

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -6,10 +6,6 @@ from formtools.wizard.views import SessionWizardView
 from .models import Report, ProtectedClass
 from .model_variables import PROTECTED_CLASS_CODES
 
-import logging
-
-logger = logging.getLogger(__name__)
-
 
 @login_required
 def IndexView(request):

--- a/docs/maintenance_or_infrequent_tasks.md
+++ b/docs/maintenance_or_infrequent_tasks.md
@@ -12,4 +12,6 @@ To do that, we would keep that and add the new classes "National origin" and "Id
 
 If you change the the ProtectedClass model, you may need to squish the migrations and make a new data load script.
 
-You can reorder the form by setting the value in the database or making a data migration to update the protected classes and form_order.
+To rename existing models, change the name in model_variables.py and create a data migration like: crt_portal/cts_forms/migrations/0016_rename_more_protected_class.py
+
+You should be able to reorder the form by setting the value in the database or making a data migration to update the protected classes and form_order. (This might not be working, we may need additional work to override the django built in sort order for models.)


### PR DESCRIPTION
Replaces https://github.com/usdoj-crt/crt-portal/pull/118
## What does this change?
Renames some protected class options
- Other to Other Reason
- Immigration/citizenship status (choosing this **does** not share your status) to  Immigration/citizenship status (choosing this **will** not share your status)
- Disability (including temporary or **in** recovery) to Disability (including temporary or recovery)

All in accordance with:
https://docs.google.com/document/d/1bxSRc9CQOHjQhTaYkHncE4tykUEFeC6RzFtP5IQk0Ic/edit#heading=h.8yoll6pcyuf8

Also added to the docs for this task. Then I noticed that we did not refer to the extra docs in the Readme so I added that. There was also an unused logging statement in views that I cleaned up. 

## Checklist:
Apply the data migration:
`docker-compose run web python /code/crt_portal/manage.py migrate`

- [ ] Make sure the names are updated rather than added and it doesn't mess up your previous data 

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
