### PR TITLE
De-conflicting 2 migrations labeled 13

### DIFF
--- a/crt_portal/cts_forms/migrations/0014_auto_20191108_1543.py
+++ b/crt_portal/cts_forms/migrations/0014_auto_20191108_1543.py
@@ -6,7 +6,8 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cts_forms', '0012_insert_protected_class_order'),
+        ('cts_forms', '0013_rename_protected_class'),
+
     ]
 
     operations = [


### PR DESCRIPTION
Debugs the issue where we had conflicting migrations https://app.circleci.com/jobs/github/usdoj-crt/crt-portal/484/parallel-runs/0/steps/0-103

It works for me locally and tests pass in circle. Try it locally, it might give you a warning, or it might get confused if your data base already applied them in a different order.