### PR TITLE
Make punctuation in Primary Issue page screenreader-only

### DIFF
--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -1,50 +1,50 @@
 """Setting the variables that can be reused in models and forms for readability and reuse"""
 
 PRIMARY_COMPLAINT_CHOICES = (
-    ('workplace', 'Workplace discrimination or other employment-related problem.'),
-    ('housing', 'Housing discrimination or harassment.'),
-    ('education', 'Discrimination at a school, educational program, or related to receiving education.'),
-    ('voting', 'Right to vote impacted.'),
-    ('police', 'Mistreated by police, law enforcement, or correctional staff (including while in prison).'),
-    ('commercial_or_public', 'Discriminated against in any other commercial location or public place.'),
-    ('something_else', 'Something else happened.')
+    ('workplace', 'Workplace discrimination or other employment-related problem'),
+    ('housing', 'Housing discrimination or harassment'),
+    ('education', 'Discrimination at a school, educational program, or related to receiving education'),
+    ('voting', 'Right to vote impacted'),
+    ('police', 'Mistreated by police, law enforcement, or correctional staff (including while in prison)'),
+    ('commercial_or_public', 'Discriminated against in any other commercial location or public place'),
+    ('something_else', 'Something else happened')
 )
 
 PRIMARY_COMPLAINT_CHOICES_TO_HELPTEXT = {
-    'commercial_or_public': 'Store, restaurant, bar, hotel, place of worship, library, medical facility, bank, courthouse, government buildings, public park or street, or online.',
-    'something_else': 'You will be able to tell us more later.'
+    'commercial_or_public': 'Store, restaurant, bar, hotel, place of worship, library, medical facility, bank, courthouse, government buildings, public park or street, or online',
+    'something_else': 'You will be able to tell us more later'
 }
 
 PRIMARY_COMPLAINT_CHOICES_TO_EXAMPLES = {
     'workplace': [
-        'Fired, not hired, or demoted for reasons unrelated to job performance or qualifications.',
-        'Retaliated against for reporting discrimination.',
-        'Inappropriately asked to provide immigration documentation.'
+        'Fired, not hired, or demoted for reasons unrelated to job performance or qualifications',
+        'Retaliated against for reporting discrimination',
+        'Inappropriately asked to provide immigration documentation'
     ],
     'housing': [
-        'Denied housing, a permit, or a loan.',
-        'Harmful living conditions or lack accommodations for disability.',
-        'Harassment by a landlord or another tenant.'
+        'Denied housing, a permit, or a loan',
+        'Harmful living conditions or lack accommodations for disability',
+        'Harassment by a landlord or another tenant'
     ],
     'education': [
-        'Harassment based on race, sex, national origin, disability, or religion.',
-        'Denied admission or segregated in an education program or activity.',
-        'Denied services or accommodations for a disability or language barrier.'
+        'Harassment based on race, sex, national origin, disability, or religion',
+        'Denied admission or segregated in an education program or activity',
+        'Denied services or accommodations for a disability or language barrier'
     ],
     'voting': [
-        'Blocked from registering to vote, entering a polling place to vote, or any other voting activity.',
-        'Lack of polling place accommodations for disability.',
-        'Ballot tampering.'
+        'Blocked from registering to vote, entering a polling place to vote, or any other voting activity',
+        'Lack of polling place accommodations for disability',
+        'Ballot tampering'
     ],
     'police': [
-        'Police brutality or use of excessive force, including patterns of police misconduct.',
-        'Searched and arrested under false pretenses, including racial or other discriminatory profiling.',
-        'Denied rights, language access barriers, subjected to harmful living conditions or lack of accessible facilities.'
+        'Police brutality or use of excessive force, including patterns of police misconduct',
+        'Searched and arrested under false pretenses, including racial or other discriminatory profiling',
+        'Denied rights, language access barriers, subjected to harmful living conditions or lack of accessible facilities'
     ],
     'commercial_or_public': [
-        'A location or website lacking disability accommodations.',
-        'Denied service or entry because of a percieved personal characteristic like race, sex, or religion.',
-        'Blocked from receiving reproductive health services).',
+        'A location or website lacking disability accommodations',
+        'Denied service or entry because of a percieved personal characteristic like race, sex, or religion',
+        'Blocked from receiving reproductive health services)',
     ],
     'something_else': []
 }

--- a/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
@@ -7,7 +7,7 @@
   <label class="crt-radio__label_area"
          {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
     <div class="label-text margin-top-2 padding-left-5">
-      <div class="big label-reason">{{ widget.label }}</div>
+      <div class="big label-reason">{{ widget.label }}<span class="usa-sr-only">.</span></div>
       {% if widget.value != None %}
         {% for reason, helptext in widget.attrs.choices_to_helptext.items %}
           {% if widget.value == reason %}
@@ -24,7 +24,9 @@
               </div>
               <ul class="margin-top-1">
                 {% for example in examples %}
-                  <li class="primary-issue-example-li">{{ example }}</li>
+                  <li class="primary-issue-example-li">
+                    {{ example }}<span class="usa-sr-only">.</span>
+                  </li>
                 {% endfor %}
               </ul>
             {% else %}


### PR DESCRIPTION
## What does this change?

Removes periods from the end of phrases on the Primary Issue page, but only visually — keep the periods screenreader-only. This provides a smoother announcement on VoiceOver with proper pauses. Visually, because these phrases are not complete sentences the periods can be excessive and make the phrases seem curt. 

### Audio (no periods at all, "before" state)

https://drive.google.com/open?id=1qL1WlPxR9idj2IR3bOPfaUj_4ZiBG0Gf

### Audio (periods included for screen readers, "after" state)

https://drive.google.com/open?id=1grIuFAsMwxz1vHZE_n2cg_alOWLFWzUh 

## Screenshots (for front-end PR):

![page2](https://user-images.githubusercontent.com/3209501/68785090-3f9ace80-0603-11ea-978a-27fd70176ff8.png)

## Checklist:

### Author

+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).
