### PR TITLE
Gitignore all generated CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ node_modules/
 staticfiles/
 pa11y-screenshots/
 # auto-generated files
-crt_portal/static/css/styles.css
-crt_portal/static/css/styles.css.map
+crt_portal/static/css/*


### PR DESCRIPTION
## What does this change?

+ Tiny tweak: Ignore all generated CSS no matter the filename. I had some other generated CSS files hanging out locally from previous front-end development work, this PR will make sure those are `.gitignore`'d and make the `.gitignore` file a little more future-proof against any CSS filename changes.