### PR TITLE
Remove extra `)`

### DIFF
--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -44,7 +44,7 @@ PRIMARY_COMPLAINT_CHOICES_TO_EXAMPLES = {
     'commercial_or_public': [
         'A location or website lacking disability accommodations',
         'Denied service or entry because of a percieved personal characteristic like race, sex, or religion',
-        'Blocked from receiving reproductive health services)',
+        'Blocked from receiving reproductive health services',
     ],
     'something_else': []
 }


### PR DESCRIPTION
Noticed there was an extra parentheses after "reproductive health services"

[Link to ZenHub issue.](link-goes-here)

## What does this change?

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
