### PR TITLE
Sass improvement: Use explicit class for emphasis text

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_class.html
+++ b/crt_portal/cts_forms/templates/forms/report_class.html
@@ -5,7 +5,7 @@
 <fieldset class="usa-fieldset" aria-label="{{ current_step_name }}">
   {% for field in wizard.form.visible_fields %}
     {% if field.name == 'protected_class' %}
-      <legend>{{ field.label }}</legend>
+      <legend class="em-text">{{ field.label }}</legend>
       <p class="usa-prose margin-top-0 margin-bottom-4">
         <em>{{ field.help_text }}</em>
       </p>

--- a/crt_portal/cts_forms/templates/forms/report_details.html
+++ b/crt_portal/cts_forms/templates/forms/report_details.html
@@ -4,7 +4,7 @@
   {% for field in wizard.form.visible_fields %}
     <div class="usa-prose margin-bottom-2">
       <label for="{{ field.id_for_label }}"
-             class="big margin-bottom-0">
+             class="em-text margin-bottom-0">
         {{ field.label }}
       </label>
       <p><em>{{ field.help_text }}</em></p>

--- a/crt_portal/cts_forms/templates/forms/report_grouped_questions.html
+++ b/crt_portal/cts_forms/templates/forms/report_grouped_questions.html
@@ -2,7 +2,7 @@
 {% block form_questions %}
   {% for question_group in wizard.form.question_groups %}
     <fieldset class="usa-fieldset margin-bottom-5">
-      <legend>
+      <legend class="em-text">
         {{ question_group.group_name }}
         {% if question_group.optional %}
           <span class="question_group_optional_tag">(optional)</span>

--- a/crt_portal/static/sass/custom/typography.scss
+++ b/crt_portal/static/sass/custom/typography.scss
@@ -17,12 +17,11 @@ h3 {
 }
 
 // TODO (ARS): Don't target raw HTML elements with styles.
-p, em, h2, label:not(.big), span:not(.big) {
+p, em, h2, label:not(.em-text), span:not(.em-text) {
   color: $gray-warm;
 }
 
-// TODO (ARS): Don't target raw HTML elements with styles.
-legend, .page-subtitle, .big {
+.em-text {
   color: $blue-warm-vivid-70;
   font-weight: bold;
   font-size: 1.17em; // Matches h3 size


### PR DESCRIPTION
## What does this change?

+ Incremental Sass cleanup: use explicit class for emphasis text rather than applying styling to raw `<legend>` HTML elements.
+ This should be a pure refactor PR and should not have any effect on the front-end styling. 

## Checklist:

### Author

+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

+ Please check to make sure this doesn't introduce any style regressions ... thank you! 