### PR TITLE
Sass improvement: Factor out shared styles in table.scss

### DIFF
--- a/crt_portal/cts_forms/templates/forms/index.html
+++ b/crt_portal/cts_forms/templates/forms/index.html
@@ -43,7 +43,11 @@
     {% if data_dict %}
       {% for datum in data_dict %}
         <tr class="tr-status-{{ datum.report.status }}">
-          <td><span class="status-{{ datum.report.status }} row-status-{{ datum.report.status }}">{{ datum.report.status }}</span></td>
+          <td>
+            <span class="status-tag status-{{ datum.report.status }} row-status-{{ datum.report.status }}">
+              {{ datum.report.status }}
+            </span>
+          </td>
           <td>{{ datum.report.assigned_section }}</td>
           <td>{{ datum.report.create_date|date:"SHORT_DATE_FORMAT" }}</td>
           <td>

--- a/crt_portal/cts_forms/templates/forms/index.html
+++ b/crt_portal/cts_forms/templates/forms/index.html
@@ -44,7 +44,7 @@
       {% for datum in data_dict %}
         <tr class="tr-status-{{ datum.report.status }}">
           <td>
-            <span class="status-tag status-{{ datum.report.status }} row-status-{{ datum.report.status }}">
+            <span class="status-tag status-{{ datum.report.status }}">
               {{ datum.report.status }}
             </span>
           </td>

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -28,23 +28,17 @@
 .status-new {
   color: $white !important;
   background-color: $blue-warm-vivid-70;
-  padding: 4px;
-  padding-left: 10px;
-  padding-right: 10px;
-  border-radius: 1.5rem;
 }
 
 .status-open {
   background-color: $gold;
-  font-weight: bold;
-  padding: 4px;
-  padding-left: 10px;
-  padding-right: 10px;
-  border-radius: 1.5rem;
 }
 
 .status-closed {
   background-color: $gray-warm-10;
+}
+
+.status-tag {
   font-weight: bold;
   padding: 4px;
   padding-left: 10px;


### PR DESCRIPTION
## What does this change?

+ When I was factoring our Sass into different files, I noticed a quick opportunity to refactor by pulling shared styles into a single class.
+ This should be a pure refactor PR and should not have any effect on the front-end styling. 

## Checklist:

### Author

+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

+ Please check to make sure this doesn't introduce any style regressions ... thank you! 