### PR TITLE
Pagination style updates

### DIFF
--- a/crt_portal/static/sass/custom/colors.scss
+++ b/crt_portal/static/sass/custom/colors.scss
@@ -6,6 +6,7 @@ $light-beige: #F6F6F2;
 $blue-warm-vivid-70: #1A4480;
 $blue-50: #2378C3;
 $blue-vivid-40: #2491FF;
+$blue-warm-5: #ECF1F7;
 $blue-warm-10: #E1E7F1;
 $gray-warm: #2E2E2A;
 $gray-warm-10: #E6E6E2;

--- a/crt_portal/static/sass/custom/colors.scss
+++ b/crt_portal/static/sass/custom/colors.scss
@@ -6,7 +6,7 @@ $light-beige: #F6F6F2;
 $blue-warm-vivid-70: #1A4480;
 $blue-50: #2378C3;
 $blue-vivid-40: #2491FF;
-$blue-warm-5: #ECF1F7;
+$blue-warm-10: #E1E7F1;
 $gray-warm: #2E2E2A;
 $gray-warm-10: #E6E6E2;
 $gray-90: #171717;

--- a/crt_portal/static/sass/custom/pagination.scss
+++ b/crt_portal/static/sass/custom/pagination.scss
@@ -24,6 +24,7 @@
       height: 44px;
       line-height: 44px;
       text-align: center;
+      color: $blue-warm-vivid-70;
     }
 
     &:hover:not(.disabled-nav) {
@@ -32,7 +33,10 @@
 
     &.current-page {
       background-color: $blue-warm-vivid-70;
-      color: $white;
+
+      div {
+        color: $white;
+      }
     }
 
     &.nav-arrow.disabled-nav {

--- a/crt_portal/static/sass/custom/pagination.scss
+++ b/crt_portal/static/sass/custom/pagination.scss
@@ -27,7 +27,7 @@
     }
 
     &:hover:not(.disabled-nav) {
-      background: $blue-warm-5;
+      background: $blue-warm-10;
     }
 
     &.current-page {


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/28)

## What does this change?

+ Updates to pagination styles based on desk check:
  + Darker hover state shade
  + No "visited"/"unvisited" link styles; all primary dark blue

## Screenshots (for front-end PR):

Hover state a shade darker:

<img width="383" alt="hover-state-tweak" src="https://user-images.githubusercontent.com/3209501/69186972-3ae08980-0adf-11ea-8a74-ae32349a8924.png">

## Checklist:

### Author

+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).
