### PR TITLE
Vertical align form viewer table cells

### DIFF
--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -14,6 +14,10 @@
       background-color: $white;
     }
   }
+
+  td {
+    vertical-align: top;
+  }
 }
 
 .tr-status-new {


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/173)

## What does this change?

Vertically aligns content in form viewer table cells

## Screenshots (for front-end PR):

<img width="1097" alt="Screen Shot 2019-11-20 at 8 46 29 AM" src="https://user-images.githubusercontent.com/1421848/69258974-5d6fb280-0b72-11ea-95e8-8f4754eefb55.png">


## Reviewer Notes

Rebuild the css and this should be easily verifiable!
