### PR TITLE
Sass improvement: Use USWDS settings to set default ink color 

### DIFF
--- a/crt_portal/static/sass/_uswds-theme-color.scss
+++ b/crt_portal/static/sass/_uswds-theme-color.scss
@@ -32,7 +32,7 @@ $theme-color-base:                  'gray-cool-50';
 $theme-color-base-dark:             'gray-cool-60';
 $theme-color-base-darker:           'gray-cool-70';
 $theme-color-base-darkest:          'gray-90';
-$theme-color-base-ink:              'gray-90';
+$theme-color-base-ink:              'gray-warm-80';
 
 // Primary colors
 $theme-color-primary-family:        'blue';

--- a/crt_portal/static/sass/custom/colors.scss
+++ b/crt_portal/static/sass/custom/colors.scss
@@ -8,7 +8,7 @@ $blue-50: #2378C3;
 $blue-vivid-40: #2491FF;
 $blue-warm-5: #ECF1F7;
 $blue-warm-10: #E1E7F1;
-$gray-warm: #2E2E2A;
+$gray-warm-80: #2E2E2A;
 $gray-warm-10: #E6E6E2;
 $gray-90: #171717;
 $gray-70: #454545;

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -129,7 +129,7 @@ form#report-form {
 
   .question_group_optional_tag {
     font-weight: lighter;
-    color: $gray-warm;
+    color: $gray-warm-80;
   }
 }
 

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -26,7 +26,7 @@
 // Styles for complaint statuses in View All Table
 
 .status-new {
-  color: $white !important;
+  color: $white;
   background-color: $blue-warm-vivid-70;
 }
 

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -1,10 +1,10 @@
 .crt-table {
   @extend .usa-table;
   font-size: 14px;
-  color: $gray-90;
   line-height: 22px;
   background: $white;
   box-shadow: 0 1px 6px 2px rgba(0,0,0,0.14);
+
   thead {
     font-weight: $bold;
     font-size: 12px;

--- a/crt_portal/static/sass/custom/typography.scss
+++ b/crt_portal/static/sass/custom/typography.scss
@@ -16,11 +16,6 @@ h3 {
   @include u-text('primary-dark')
 }
 
-// TODO (ARS): Don't target raw HTML elements with styles.
-p, em, h2, label:not(.em-text), span:not(.em-text) {
-  color: $gray-warm;
-}
-
 .em-text {
   color: $blue-warm-vivid-70;
   font-weight: bold;


### PR DESCRIPTION
## What does this change?

+ Use USWDS settings to set default ink text color instead of manual overrides which set styles on raw HTML elements.
+ This should be a pure refactor PR with one exception: make the text color on the View All table match the text color in the rest of the app.

## Checklist:

### Author

+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
