### PR TITLE
Add instructions for logging in to Docker database locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ To ssh into your local Docker web container run:
 
     docker exec -it crt-portal_web_1 /bin/bash
 
+### Logging into Docker database locally
+
 To log into your local Docker database for debugging purposes, first run:
 
     docker exec -it crt-portal_db_1 /bin/bash

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Install Docker
 
     https://www.docker.com/get-started
-    
-Create [ssh key](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) and add it to GitHub. 
+
+Create [ssh key](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) and add it to GitHub.
 
 Clone the project locally:
 
@@ -24,7 +24,7 @@ To run the project
 
     docker-compose up
 
-Visit the site locally at [http://0.0.0.0:8000/report] 🎉 
+Visit the site locally at [http://0.0.0.0:8000/report] 🎉
 
 Create a superuser for local admin access
 
@@ -40,11 +40,11 @@ Generate the SASS for the front end with gulp:
 
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
     source ~/.bash_profile
-    
+
 If you get an error, and don't have a `bash_profile` file, create one first with `touch ~/.bash_profile`, then run the command above again.
 
 Then, if this is your first time installing the project or `nvm`, run `nvm install`.
-    
+
 Finally, `nvm use && npm install`
 
 Now to compile the sass files into css, run:
@@ -56,18 +56,33 @@ Also note, that the staticfiles folder is the destination of all static assets w
 
 ## Running common tasks
 
+### Migrations
+
 In Django, when you update the data models you need to create migrations and then apply those migrations, you can do that with:
 
     docker-compose run web python /code/crt_portal/manage.py makemigrations
     docker-compose run web python /code/crt_portal/manage.py migrate
 
-To ssh into your local docker container run:
-
-    docker exec -it crt-django_web_1 /bin/bash
-
-To install a new python package run:
+### Installing a new Python package
+To install a new Python package, run:
 
     docker-compose run web pipenv install name-of-package
+
+### SSH'ing into Docker locally
+
+To ssh into your local Docker web container run:
+
+    docker exec -it crt-portal_web_1 /bin/bash
+
+To log into your local Docker database for debugging purposes, first run:
+
+    docker exec -it crt-portal_db_1 /bin/bash
+
+Then from, within the container, you can run:
+
+    psql -U postgres
+
+As a logged-in local Postgres user, you can run queries directly against the database, for example: `select * from cts_forms_report;` to see report data in your local database.
 
 ## Tests
 


### PR DESCRIPTION
## What does this change?

+ Add steps for logging into the local Postgres database via Docker to the README. I did this earlier today to verify how `i18n` changes would interact with the database and realized the steps were missing from the README.