### PR TITLE
Add disability exception to voting logic

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -98,7 +98,9 @@ class Report(models.Model):
         return f'{self.create_date} {self.violation_summary}'
 
     def assign_section(self):
-        if self.primary_complaint == 'voting':
+        protected_classes = [n.protected_class for n in self.protected_class.all()]
+
+        if self.primary_complaint == 'voting' and 'Disability (including temporary or recovery)' not in protected_classes:
             return 'VOT'
 
         return 'ADM'

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -114,14 +114,16 @@ class Valid_CRT_view_Tests(TestCase):
 
 class SectionAssignmentTests(TestCase):
     def test_voting_primary_complaint(self):
-        # Most reports with a primary complaint of voting should be assigned to voting
+        # Unless a protected class of disability is selected, reports
+        # with a primary complaint of voting should be assigned to voting.
         SAMPLE_REPORT['primary_complaint'] = 'voting'
         test_report = Report.objects.create(**SAMPLE_REPORT)
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'VOT')
 
     def test_voting_disability_exception(self):
-        # Reports with a primary complaint of voting and protected class of disability should not be assigned to voting
+        # Reports with a primary complaint of voting and protected class of disability
+        # should not be assigned to voting.
         SAMPLE_REPORT['primary_complaint'] = 'voting'
         test_report = Report.objects.create(**SAMPLE_REPORT)
         disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -128,6 +128,7 @@ class SectionAssignmentTests(TestCase):
         test_report.protected_class.add(disability[0])
         test_report.save()
         self.assertFalse(test_report.assign_section() == 'VOT')
+        self.assertTrue(test_report.assign_section() == 'ADM')
 
 
 class Valid_CRT_Pagnation_Tests(TestCase):

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -112,7 +112,7 @@ class Valid_CRT_view_Tests(TestCase):
         self.assertTrue('ADM' in self.content)
 
 
-class SectionAssigmnetTests(TestCase):
+class SectionAssigmentTests(TestCase):
     def test_voting_primary_complaint(self):
         # Most reports with a primary complaint of voting should be assigned to voting
         SAMPLE_REPORT['primary_complaint'] = 'voting'
@@ -121,7 +121,7 @@ class SectionAssigmnetTests(TestCase):
         self.assertTrue(test_report.assign_section() == 'VOT')
 
     def test_voting_disability_exception(self):
-        # Reports with a primary complaint of voting and protected class of disability should not be assign to voting
+        # Reports with a primary complaint of voting and protected class of disability should not be assigned to voting
         SAMPLE_REPORT['primary_complaint'] = 'voting'
         test_report = Report.objects.create(**SAMPLE_REPORT)
         disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -112,7 +112,7 @@ class Valid_CRT_view_Tests(TestCase):
         self.assertTrue('ADM' in self.content)
 
 
-class SectionAssigmentTests(TestCase):
+class SectionAssignmentTests(TestCase):
     def test_voting_primary_complaint(self):
         # Most reports with a primary complaint of voting should be assigned to voting
         SAMPLE_REPORT['primary_complaint'] = 'voting'

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -113,16 +113,21 @@ class Valid_CRT_view_Tests(TestCase):
 
 
 class SectionAssigmnetTests(TestCase):
-    def setUp(self):
-        for choice in PRIMARY_COMPLAINT_CHOICES:
-            SAMPLE_REPORT['primary_complaint'] = choice[0]
-            test_report = Report.objects.create(**SAMPLE_REPORT)
-            test_report.save()
+    def test_voting_primary_complaint(self):
+        # Most reports with a primary complaint of voting should be assigned to voting
+        SAMPLE_REPORT['primary_complaint'] = 'voting'
+        test_report = Report.objects.create(**SAMPLE_REPORT)
+        test_report.save()
+        self.assertTrue(test_report.assign_section() == 'VOT')
 
-    def test_voting(self):
-        # All reports with a primary complaint of voting should be assigned to voting
-        vote_test = Report.objects.get(primary_complaint='voting')
-        self.assertTrue(vote_test.assign_section() == 'VOT')
+    def test_voting_disability_exception(self):
+        # Reports with a primary complaint of voting and protected class of disability should not be assign to voting
+        SAMPLE_REPORT['primary_complaint'] = 'voting'
+        test_report = Report.objects.create(**SAMPLE_REPORT)
+        disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
+        test_report.protected_class.add(disability[0])
+        test_report.save()
+        self.assertFalse(test_report.assign_section() == 'VOT')
 
 
 class Valid_CRT_Pagnation_Tests(TestCase):

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ValidationError
 from django.urls import reverse
 
 from .models import ProtectedClass, Report
-from .model_variables import PROTECTED_CLASS_CHOICES, PROTECTED_CLASS_ERROR, PROTECTED_CLASS_CODES, PRIMARY_COMPLAINT_CHOICES
+from .model_variables import PROTECTED_CLASS_CHOICES, PROTECTED_CLASS_ERROR, PROTECTED_CLASS_CODES
 from .forms import Where, Who, Details, Contact, ProtectedClassForm
 from .test_data import SAMPLE_REPORT
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -111,13 +111,13 @@ class CRTReportWizard(SessionWizardView):
         form_data_dict = self.get_all_cleaned_data()
         m2mfield = form_data_dict.pop('protected_class')
         r = Report.objects.create(**form_data_dict)
-        r.assigned_section = r.assign_section()
 
         # Many to many fields need to be added or updated to the main model, with a related manager such as add() or update()
         for protected in m2mfield:
             p = ProtectedClass.objects.get(protected_class=protected)
             r.protected_class.add(p)
 
+        r.assigned_section = r.assign_section()
         r.save()
         # adding this back for the save page results
         form_data_dict['protected_class'] = m2mfield.values()


### PR DESCRIPTION
[Assign newly, submitted complaint to Voting#44](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/44)

## What does this change?
Adds disability exception to voting logic
Adds the assigned section after protected class has been added to the report instance. 
Adds a test

## Checklist:
### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
