### PR TITLE
Apply text-transform to status badge only in form viewer

### DIFF
--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -18,12 +18,13 @@
   td {
     vertical-align: top;
   }
-}
-
-.tr-status-new {
-  td {
-    font-weight: bold;
-    text-transform: uppercase;
+  
+  tbody {
+    .tr-status-new {
+      td {
+        font-weight: bold;
+      }
+    }
   }
 }
 
@@ -48,4 +49,5 @@
   padding-left: 10px;
   padding-right: 10px;
   border-radius: 1.5rem;
+  text-transform: uppercase;
 }


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/184)

## What does this change?

* Makes sure only the table headings and the text in the status badges have an `uppercase` text transformed applied.

## Screenshots (for front-end PR):

<img width="641" alt="Screen Shot 2019-11-26 at 12 29 10 PM" src="https://user-images.githubusercontent.com/1421848/69657662-b941ac00-1048-11ea-81b0-15c5751ce218.png">

