### PR TITLE
Turn off form autocomplete

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -44,6 +44,7 @@
           class="usa-form"
           action="/report/"
           method="post"
+          autocomplete="off"
           {% if form_novalidate %}novalidate{% endif %}>
       {% csrf_token %}
       {{ wizard.management_form }}


### PR DESCRIPTION
# Notes 

+ This is a more privacy-friendly setting for user testing participants, and for designers and developers. When recording user testing sessions and demos, this will make it far less likely that users' real names, emails, and phone numbers will enter the recording.
+ We may want to consider leaving autocomplete off in production as well given the highly sensitive nature of many civil rights complaints.
+ Browser compatibility: `autocomplete="off"` is not supported by Internet Explorer. Source: [Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Browser_compatibility).

## Technical background

[How to turn off form autocompletion, Mozilla](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion).

## Process notes 

Discussed this with @Jacklynn Friday 11/29; let's discuss as a dev team next week!