### PR TITLE
Remove <br/> that was being read aloud by screen reader

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -99,7 +99,7 @@
                       type="submit"
                       label="previous step"
                       value="{{ wizard.steps.prev }}"
-                      class="look-like-link margin-top-2 back-button">
+                      class="look-like-link margin-top-2 display-block">
                 {% trans "Back" %}
               </button>
             {% endif %}

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -95,12 +95,11 @@
                    value="{% trans 'Next' %}"
                    class="usa-button" />
             {% if wizard.steps.prev %}
-              <br/>
               <button name="wizard_goto_step"
                       type="submit"
                       label="previous step"
                       value="{{ wizard.steps.prev }}"
-                      class="look-like-link margin-top-2">
+                      class="look-like-link margin-top-2 back-button">
                 {% trans "Back" %}
               </button>
             {% endif %}

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -39,6 +39,17 @@ form#report-form {
     }
   }
 
+  .look-like-link {
+    padding: 0;
+    border: none;
+    background: none;
+    text-decoration: underline;
+  }
+
+  .back-button {
+    display: block;
+  }
+
   .blue-left-highlight {
     border-left: 2px solid $blue-warm-vivid-70;
     padding-left: 0.5rem;
@@ -138,13 +149,6 @@ form#report-form {
 // Remove extra dropown error from datalist element
 [list]::-webkit-calendar-picker-indicator {
   display: none;
-}
-
-.look-like-link {
-  padding: 0;
-  border: none;
-  background: none;
-  text-decoration: underline;
 }
 
 .form-help-text {

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -46,10 +46,6 @@ form#report-form {
     text-decoration: underline;
   }
 
-  .back-button {
-    display: block;
-  }
-
   .blue-left-highlight {
     border-left: 2px solid $blue-warm-vivid-70;
     padding-left: 0.5rem;


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/183)

## What does this change?

+ Remove line break that was being read aloud by VoiceOver; replace with pure CSS.

## Notes for reviewer:

To verify this PR, use the instructions that @Jacklynn posted [here](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/183#issuecomment-560937971) to test `develop` and this branch.