### PR TITLE
The "close" button takes you back to the link you were looking at

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show.html
@@ -33,7 +33,7 @@
           </p>
         </div>
         <div class="tablet:grid-col-3 tablet:grid-offset-1 text-right">
-          <a class="usa-button usa-button--light close-record" href="/form/view">
+          <a class="usa-button usa-button--light close-record" href="/form/view{{ return_url_args }}">
             <img src="{% static "img/close-blue-50-alt.svg" %}">
             Close record
           </a>
@@ -51,7 +51,7 @@
                 <div class="grid-col-fill">
                   <h3 class="complaint-card-heading text-uppercase">Correspondant information</h3>
                 </div>
-                <div class="grid-col-auto">                
+                <div class="grid-col-auto">
                   <button class="usa-button usa-button--outline complaint-card-action">
                     Edit
                   </button>

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1,3 +1,5 @@
+import urllib.parse
+
 from django.shortcuts import render_to_response, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
@@ -34,6 +36,8 @@ def IndexView(request):
     for sort_item in sort:
         page_args = page_args + f'&sort={sort_item}'
 
+    all_args_encoded = urllib.parse.quote(f'{page_args}&page={page}')
+
     data = []
     # formatting protected class
     for report in requested_reports:
@@ -55,7 +59,7 @@ def IndexView(request):
         data.append({
             "report": report,
             "report_protected_classes": p_class_list,
-            "url": '{}/'.format(report.id)
+            "url": f'{report.id}/?next={all_args_encoded}'
         })
 
     return render_to_response('forms/complaint_view/index.html', {
@@ -71,6 +75,7 @@ def ShowView(request, id):
     report = get_object_or_404(Report.objects, id=id)
     output = {
         'data': report,
+        'return_url_args': request.GET.get('next', ''),
     }
 
     if settings.DEBUG:


### PR DESCRIPTION
Passing the arguments to the detail view so when you close the record you go back to the view you were looking at. If you were on page 600 it will take you back to that page, with your sorts applied. We can update all_args_encoded when we add filtering. 

## Checklist:
Example
got to:
     http://0.0.0.0:8000/form/view?per_page=5&sort=-create_date&page=2

Click on a record once the record loads click the close button.

It should take you to:
   http://0.0.0.0:8000/form/view?per_page=5&sort=-create_date&page=2

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
