### PR TITLE
Sort order defaults to desc, adds specs

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show.html
@@ -25,7 +25,7 @@
       <div class="grid-row grid-gap">
         <div class="tablet:grid-col-8">
           <h2 class="text-uppercase">
-            Complaint <span class="text-gold">{{ data.id }}</span>
+            Complaint
           </h2>
           <p>
             <span class="text-gold text-uppercase">Received:  </span>
@@ -49,7 +49,7 @@
             <div class="complaint-card">
               <div class="grid-row">
                 <div class="grid-col-fill">
-                  <h3 class="complaint-card-heading text-uppercase">Correspondant information</h3>
+                  <h3 class="complaint-card-heading text-uppercase">Correspondent information</h3>
                 </div>
                 <div class="grid-col-auto">
                   <button class="usa-button usa-button--outline complaint-card-action">

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -230,6 +230,15 @@ class Valid_CRT_SORT_Tests(TestCase):
     def tearDown(self):
         self.user.delete()
 
+    def test_default_sort_order_desc(self):
+        response = self.client.get(reverse('crt_forms:crt-forms-index'))
+        expected_list = []
+        for record in response.context['data_dict']:
+            expected_list.append(record['report'].create_date)
+
+        self.assertTrue(expected_list == sorted(expected_list, key=None, reverse=True))
+        self.assertFalse(expected_list == sorted(expected_list))
+
     def test_sort(self):
         # Vote should come after ADM when alphabetical, opposite for reverse
         vote_index_1 = str(self.response_1).find('VOT')

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -20,7 +20,7 @@ from .page_through import pagination
 @login_required
 def IndexView(request):
     # Sort data based on request from params, default to `created_date` of complaint
-    sort = request.GET.getlist('sort', ['create_date'])
+    sort = request.GET.getlist('sort', ['-create_date'])
     per_page = request.GET.get('per_page', 15)
     page = request.GET.get('page', 1)
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/24)

## What does this change?

This adds a '-' to the default sort query in `views.py`, ensuring that the most recently created records appear first. It also adds a test to verify this behavior!

### BONUS
Also removes the complaint id from the complain detail page, as it was out of scope in this issue.

## Screenshots (for front-end PR):
<img width="1038" alt="Screen Shot 2019-12-04 at 1 58 56 PM" src="https://user-images.githubusercontent.com/1421848/70172207-3353df80-169e-11ea-91fa-be2d2337c06c.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
