### PR TITLE
Removes edit button from correspondent info card

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show.html
@@ -51,11 +51,6 @@
                 <div class="grid-col-fill">
                   <h3 class="complaint-card-heading text-uppercase">Correspondent information</h3>
                 </div>
-                <div class="grid-col-auto">
-                  <button class="usa-button usa-button--outline complaint-card-action">
-                    Edit
-                  </button>
-                </div>
               </div>
               <table class="usa-table usa-table--borderless complaint-card-table">
                 <tr>


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/24#issuecomment-562178274)

## What does this change?

* Because it is out of scope and potentially confusing to testers, this PR removes the `edit` button from the `correspondent information` card.

## Screenshots (for front-end PR):

<img width="537" alt="Screen Shot 2019-12-05 at 11 30 24 AM" src="https://user-images.githubusercontent.com/1421848/70254176-a6b72900-1752-11ea-8c62-8ea5db77eeda.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
