### PR TITLE
Potential fix for IE 11 alert screen reader support

### DIFF
--- a/crt_portal/static/js/focus_alert.js
+++ b/crt_portal/static/js/focus_alert.js
@@ -1,11 +1,13 @@
 function triggerAlert() {
   // querySelector() will find the first element matching the
   // CSS selector; the JS that follows will announce it.
-  var alertEl = document.querySelector('.usa-alert__text');
+  var alertEl = document.querySelectorAll('.usa-alert__text');
 
-  if (alertEl) {
-    alertEl.setAttribute('role', 'alert');
+  if (alertEl.length) {
+    Array.prototype.slice.call(alertEl).forEach(function(el) {
+      el.setAttribute('role', 'alert');
+    });
   }
 }
 
-window.onload = triggerAlert();
+window.addEventListener('DOMContentLoaded', triggerAlert);


### PR DESCRIPTION
## What does this change?

This patch fixes a potential bug in the `focus_alert` javascript, and leverages the `addEventListener` method of the window object to attach our accessibility focus handler. Additionally, the code now uses the `DOMContentLoaded` event to ensure the handler executes after the HTML elements on the page are loaded.

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

I think we'll just have to merge this and have someone from the DOJ test on IE. VirtualBox for mac unfortunately does not provide support for audio (at least on my machine / os version), so I can't test  this behavior locally ☹️ 
