### PR TITLE
Adds full summary card

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show.html
@@ -46,33 +46,8 @@
         <div class="grid-row">
           <div class="tablet:grid-col-6"></div>
           <div class="tablet:grid-col-6">
-            <div class="complaint-card">
-              <div class="grid-row">
-                <div class="grid-col-fill">
-                  <h3 class="complaint-card-heading text-uppercase">Correspondent information</h3>
-                </div>
-              </div>
-              <table class="usa-table usa-table--borderless complaint-card-table">
-                <tr>
-                  <th>Name</th>
-                  <td>
-                    <strong>
-                      {% with l_name=data.contact_last_name|default:"—" f_name=data.contact_first_name|default:"—" %}
-                      {{ l_name }}, {{ f_name }}
-                      {% endwith %}
-                    </strong>
-                  </td>
-                </tr>
-                <tr>
-                  <th>Email</th>
-                  <td>{{ data.contact_email|default:"—" }}</td>
-                </tr>
-                <tr>
-                  <th>Telephone</th>
-                  <td>{{ data.contact_phone|default:"—" }}</td>
-                </tr>
-              </table>
-            </div>
+            {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}
+            {% include 'forms/complaint_view/show/full_summary.html' with summary=data.violation_summary %}
           </div>
         </div>
       </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/correspondent_info.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/correspondent_info.html
@@ -1,0 +1,23 @@
+<div class="complaint-card">
+  <h3 class="complaint-card-heading text-uppercase">Correspondent information</h3>
+  <table class="usa-table usa-table--borderless complaint-card-table">
+    <tr>
+      <th>Name</th>
+      <td>
+        <strong>
+          {% with l_name=data.contact_last_name|default:"—" f_name=data.contact_first_name|default:"—" %}
+          {{ l_name }}, {{ f_name }}
+          {% endwith %}
+        </strong>
+      </td>
+    </tr>
+    <tr>
+      <th>Email</th>
+      <td>{{ data.contact_email|default:"—" }}</td>
+    </tr>
+    <tr>
+      <th>Telephone</th>
+      <td>{{ data.contact_phone|default:"—" }}</td>
+    </tr>
+  </table>
+</div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/full_summary.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/full_summary.html
@@ -1,4 +1,4 @@
 <div class="complaint-card">
   <h3 class="complaint-card-heading text-uppercase">Full summary</h3>
-  <p>{{ summary }}</p>
+  <p>{{ summary|linebreaks }}</p>
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/full_summary.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/full_summary.html
@@ -1,0 +1,4 @@
+<div class="complaint-card">
+  <h3 class="complaint-card-heading text-uppercase">Full summary</h3>
+  <p>{{ summary }}</p>
+</div>


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/185)

## What does this change?

Tiny PR to add the `full summary` card to the complaint detail view! I think this should be pretty straightforward to review as it encompasses only a single model property.

## Screenshots (for front-end PR):

![Screen Shot 2019-12-06 at 11 51 31 AM](https://user-images.githubusercontent.com/1421848/70352373-dda74080-181f-11ea-9920-bbb0aea0f07e.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
