### PR TITLE
Add sortable location field to complaint table

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index.html
@@ -20,7 +20,7 @@
 {% block main_class %} class="page-header-background"{% endblock %}
 
 {% block content %}
-<div class="grid-container">
+<div class="grid-container-widescreen">
   <div class="grid-col-auto">
     <a class="usa-button margin-top-2" href="/report" label="first step" name="Create record">
         + Add new record
@@ -36,13 +36,14 @@
         {% render_sortable_heading 'Submitted' sort_state %}
         {% render_sortable_heading 'Contact Name' sort_state %}
         {% render_sortable_heading 'Contact Details' sort_state %}
-        {% render_sortable_heading 'Summary' sort_state %}
+        {% render_sortable_heading 'Incident Location' sort_state %}
+        {% render_sortable_heading 'Violation Summary' sort_state %}
         {% render_sortable_heading 'Class' sort_state %}
       </tr>
     </thead>
     {% if data_dict %}
       {% for datum in data_dict %}
-        <tr class="tr-status-{{ datum.report.status }} tr--hover">
+        <tr class="tr-status-{{ datum.report.status }} tr--hover{% cycle ' stripe' '' %}">
           <td>
             <a class="td-link display-block" href="{{datum.url}}">
               <span class="status-tag status-{{ datum.report.status }}">
@@ -72,9 +73,16 @@
             </a>
           </td>
           <td>
+            <a class="td-link display-block" href="{{datum.url">
+              <b>
+                {{ datum.report.location_city_town }}, {{ datum.report.location_state }}
+              </b>
+            </a>
+          </td>
+          <td>
             <a class="td-link display-block" href="{{datum.url}}">
               {% with summary=datum.report.violation_summary|default:"—" %}
-                {{ summary|truncatechars:120 }}
+                {{ summary|truncatechars:60 }}
               {% endwith %}
             </a>
           </td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index.html
@@ -1,7 +1,7 @@
 {% extends "forms/base.html" %}
 {% load sortable_table_heading %}
 {% block page_header %}
-<header class="page-header-background">
+<header class="page-background">
     <div class="grid-container">
       <div class="grid-row">
         <div class="grid-col-12">
@@ -17,7 +17,7 @@
   </header>
 {% endblock %}
 
-{% block main_class %} class="page-header-background"{% endblock %}
+{% block main_class %} class="page-background"{% endblock %}
 
 {% block content %}
 <div class="grid-container-widescreen">
@@ -82,7 +82,7 @@
           <td>
             <a class="td-link display-block" href="{{datum.url}}">
               {% with summary=datum.report.violation_summary|default:"—" %}
-                {{ summary|truncatechars:60 }}
+                {{ summary|truncatechars:120 }}
               {% endwith %}
             </a>
           </td>

--- a/crt_portal/cts_forms/templatetags/sortable_table_heading.py
+++ b/crt_portal/cts_forms/templatetags/sortable_table_heading.py
@@ -6,10 +6,15 @@ sort_lookup = {
     'status': 'status',
     'routed': 'assigned_section',
     'submitted': 'create_date',
-    'contact name': 'contact_last_name'
+    'contact name': 'contact_last_name',
+    'incident location': 'location_city_town'
 }
 sortable_props = [
-    'status', 'assigned_section', 'create_date', 'contact_last_name'
+    'status',
+    'assigned_section',
+    'create_date',
+    'contact_last_name',
+    'location_city_town'
 ]
 
 
@@ -17,6 +22,8 @@ sortable_props = [
 def heading_2_model_prop(heading):
     if heading == 'contact name':
         return ['contact_last_name', 'contact_first_name']
+    elif heading == 'incident location':
+        return ['location_city_town', 'location_state']
     else:
         return [sort_lookup[heading]]
 

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -126,6 +126,10 @@ class Valid_CRT_view_Tests(TestCase):
         # formatting the summary is done in the template
         self.assertTrue(self.test_report.violation_summary[:119] in self.content)
 
+    def test_incident_location(self):
+        self.assertTrue(self.test_report.location_city_town in self.content)
+        self.assertTrue(self.test_report.location_state in self.content)
+
     def test_auto_section_assignment(self):
         # move this to the section assignment once there are clear rules of when it should be assigned to ADM
         self.assertTrue('ADM' in self.content)

--- a/crt_portal/static/sass/custom/header.scss
+++ b/crt_portal/static/sass/custom/header.scss
@@ -3,3 +3,7 @@
 .page-header-background {
   background-color: $light-beige;
 }
+
+.page-background {
+  background-color: $blue-warm-5;
+}

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -129,7 +129,9 @@
 .sort-link {
   @include clickable-table-cell();
   display: inline-block;
+  position: relative;
   vertical-align: middle;
+  z-index: 1;
 
 
   &.sort-up {

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -31,14 +31,28 @@
   thead {
     th {
       background-color: $white;
+      border-bottom: 1px solid $gray-cool-10;
+      border-top: 0;
       font-size: 12px;
       line-height: 25.92px;
       position: relative;
       text-transform: uppercase;
+      white-space: nowrap;
+    }
+  }
+
+  tr.stripe {
+    td {
+      background-color: $gray-2;
     }
   }
 
   &.usa-table {
+    tr, td, th {
+      border-left: 0;
+      border-right: 0;
+    }
+
     td {
       // USWDS adds a lot of complicated styles, and this is the most straightforward
       // way to remove padding from td elements in the table body
@@ -52,6 +66,14 @@
   }
 
   tbody {
+    td {
+      border-bottom: 1px solid $gray-cool-10;
+    }
+
+    tr:last-child {
+      border-bottom: 0;
+    }
+
     .tr-status-new {
       td {
         font-weight: bold;

--- a/crt_portal/static/sass/custom/variables.scss
+++ b/crt_portal/static/sass/custom/variables.scss
@@ -4,6 +4,7 @@ $yellow: #FEE685;
 $gold: #FFBE2E;
 $light-beige: #F6F6F2;
 $blue-warm-vivid-70: #1A4480;
+$blue-warm-5: #ECF1F7;
 $blue-50: #2378C3;
 $blue-vivid-40: #2491FF;
 $blue-warm-5: #ECF1F7;

--- a/crt_portal/static/sass/custom/variables.scss
+++ b/crt_portal/static/sass/custom/variables.scss
@@ -13,6 +13,8 @@ $gray-warm-10: #E6E6E2;
 $gray-90: #171717;
 $gray-70: #454545;
 $gray-60: #5c5c5c;
+$gray-2: #F9F9F9;
+$gray-cool-10: #EBEBEB;
 $gray-cool-4: #F1F3F6;
 $red-vivid-60: #B51D09;
 $white: #FFFFFF;


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/154)

## What does this change?

* Adds the `widescreen` modifier to the `grid-container` class on the `form/view` page so the table has a bit more room to breathe.

* Adds a new column for sorting by `incident location` on city and state. 

* Adds calming blue background ☺️ 

## Screenshots (for front-end PR):

<img width="1435" alt="Screen Shot 2019-12-06 at 3 56 35 PM" src="https://user-images.githubusercontent.com/1421848/70364334-f8d67800-1840-11ea-8f7d-8d142dcedc12.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
