### PR TITLE
Add ReportFilter class and specs

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -1,0 +1,35 @@
+# Class to handle filtering Reports by supplied query params,
+# provided they are valid filterable model properties.
+
+
+class ReportFilter:
+    def __init__(self, model, filter_dict):
+        self.model = model
+        self.filterable_fields = ['assigned_section']
+        self.filters = self.__sanitize_filters(filter_dict)
+
+    # Populate internal filters object with valid filterable fields
+    def __sanitize_filters(self, filter_dict):
+        filters = {}
+
+        for field in self.filterable_fields:
+            if field in filter_dict:
+                filters.update({
+                    field: filter_dict[field]
+                })
+
+        return filters
+
+    def get_filters(self):
+        return self.filters
+
+    # Return a QuerySet ready to be filtered on evaluation, or the
+    # original QuerySet supplied to this class on instantiation
+    def filter(self):
+        filtered = self.model.objects
+        filters = self.get_filters()
+
+        if len(filters.keys()):
+            filtered = filtered.filter(**filters)
+
+        return filtered


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/37)

## What does this change?

This PR adds preliminary filtering support for the `Report` model. I wanted to split this issue up into at least two PRs because:
  * the back-end can be tested in isolation
  * the front-end is a pretty significant feature lift!

Let me know if this code seems weird or unidiomatic, I'm still trying to wrap my head around the 'python way'!


## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
