### PR TITLE
Fixes interpolation error in report link

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index.html
@@ -73,7 +73,7 @@
             </a>
           </td>
           <td>
-            <a class="td-link display-block" href="{{datum.url">
+            <a class="td-link display-block" href="{{datum.url}}">
               <b>
                 {{ datum.report.location_city_town }}, {{ datum.report.location_state }}
               </b>


### PR DESCRIPTION
## What does this change?
Super quick fix for the interpolation error @lalitha-jonnalagadda found. One of the table cells didn't have a correctly interpolated variable, leading to a malformed URL when users clicked on that cell.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
