### PR TITLE
Fixes correspondent details table overflow bug

### DIFF
--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -49,6 +49,7 @@ $complaint-body-offset: calc(
   }
 
   .complaint-card-table {
+    display: fixed;
     width: 100%;
 
     th {
@@ -57,10 +58,15 @@ $complaint-body-offset: calc(
       font-weight: bold;
       padding-right: 0;
       text-transform: uppercase;
+      width: 40%;
     }
 
     td {
       padding-left: 0;
+      width: 60%;
+      white-space: normal;
+      word-wrap: break-word;
+      word-break: break-all;
     }
 
     th, td {


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/229)

## What does this change?

This PR adds a fixed width layout to tabular `complaint-card` css components to prevent a gnarly text overflow bug. 

## Screenshots (for front-end PR):

![Screen Shot 2019-12-12 at 10 42 58 AM](https://user-images.githubusercontent.com/1421848/70739741-60227b00-1ccc-11ea-8b4e-d9c6ebc2c9e8.png)



## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
