### PR TITLE
Add text and date filters

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -78,6 +78,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.postgres',
     'cts_forms',
     'compressor',
     'compressor_toolkit',

--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -1,5 +1,7 @@
 # Class to handle filtering Reports by supplied query params,
 # provided they are valid filterable model properties.
+import datetime
+
 from .models import Report
 
 # To add a new filter option for Reports, add the field name and expected filter behavior
@@ -8,6 +10,17 @@ filter_options = {
     'primary_complaint': '__in',
     'status': '__in',
     'location_state': '__in',
+    'primary_complaint': '__in',
+    'contact_first_name': '__search',
+    'contact_last_name': '__search',
+    'contact_email': '__search',
+    'other_class': '__search',
+    'violation_summary': '__search',
+    'location_name': '__search',
+    'location_address_line_1': '__search',
+    'location_address_line_2': '__search',
+    'create_date_start': '__gte',
+    'create_date_end': '__lte',
 }
 
 
@@ -22,6 +35,15 @@ def report_filter(request):
             if filter_options[field] == '__in':
                 # works for one or more options with exact matches
                 kwargs[f'{field}__in'] = request.GET.getlist(field)
+            elif filter_options[field] == '__search':
+                # takes one phrase
+                kwargs[f'{field}__search'] = request.GET.getlist(field)[0]
+            elif field.startswith('create_date'):
+                # filters by a start date or an end date expects ddmmyyyy
+                year = int(request.GET.getlist(field)[0][:4])
+                month = int(request.GET.getlist(field)[0][4:6])
+                day = int(request.GET.getlist(field)[0][6:])
+                kwargs[f'create_date{filter_options[field]}'] = datetime.date(year, month, day)
 
-    # returns a query and a dictionary that we can use to keep track of the filters we apply
-    return Report.objects.filter(**kwargs), filters
+    # returns keyword arguments that will be used for filtering, and a dictionary that we can use to keep track of the filters we apply
+    return kwargs, filters

--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -45,5 +45,5 @@ def report_filter(request):
                 day = int(request.GET.getlist(field)[0][6:])
                 kwargs[f'create_date{filter_options[field]}'] = datetime.date(year, month, day)
 
-    # returns keyword arguments that will be used for filtering, and a dictionary that we can use to keep track of the filters we apply
-    return kwargs, filters
+    # returns a filtered query, and a dictionary that we can use to keep track of the filters we apply
+    return Report.objects.filter(**kwargs), filters

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -74,6 +74,7 @@ class Report(models.Model):
     location_address_line_2 = models.CharField(max_length=225, null=True, blank=True)
     location_city_town = models.CharField(max_length=700, blank=False)
     location_state = models.CharField(max_length=100, blank=False, choices=STATES_AND_TERRITORIES)
+    create_date = models.DateTimeField(auto_now_add=True)
     ###############################################################
     #   These fields have not been implemented in the form yet:   #
     ###############################################################
@@ -92,7 +93,6 @@ class Report(models.Model):
     # previous details form
     when = models.CharField(max_length=700, choices=WHEN_CHOICES, default=None, null=True)
     how_many = models.CharField(max_length=700, null=True, blank=True, choices=HOW_MANY_CHOICES, default=None)
-    create_date = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
         return f'{self.create_date} {self.violation_summary}'

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -1,5 +1,6 @@
 import secrets
 from datetime import date, timedelta
+import copy
 
 from testfixtures import LogCapture
 
@@ -483,18 +484,21 @@ class LoginRequiredTests(TestCase):
             self.client = Client()
             self.test_pass = secrets.token_hex(32)
             self.user2 = User.objects.create_user('DELETE_USER_2', 'mccartney@thebeatles.com', self.test_pass)
+            self.user2_pk = copy.copy(self.user2.pk)
             self.user2.delete()
 
+            create = 'cts_forms.signals', 'INFO', 'ADMIN ACTION by: CLI CLI @ CLI User saved: {pk} permissions: <QuerySet []> staff: False superuser: False active: True'.format(pk=self.user2_pk)
             self.assertEqual(
                 cm.check_present(
-                    ('cts_forms.signals', 'INFO', 'ADMIN ACTION by: CLI CLI @ CLI User saved: 7 permissions: <QuerySet []> staff: False superuser: False active: True')
+                    (create)
                 ),
                 None,
             )
 
+            delete = 'cts_forms.signals', 'INFO', 'ADMIN ACTION by: CLI CLI @ CLI User deleted: {pk} permissions: <QuerySet []> staff: False superuser: False active: True'.format(pk=self.user2_pk)
             self.assertEqual(
                 cm.check_present(
-                    ('cts_forms.signals', 'INFO', 'ADMIN ACTION by: CLI CLI @ CLI User deleted: 7 permissions: <QuerySet []> staff: False superuser: False active: True')
+                    (delete)
                 ),
                 None,
             )

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -487,14 +487,14 @@ class LoginRequiredTests(TestCase):
 
             self.assertEqual(
                 cm.check_present(
-                    ('cts_forms.signals', 'INFO', 'ADMIN ACTION by: CLI CLI @ CLI User saved: 5 permissions: <QuerySet []> staff: False superuser: False active: True')
+                    ('cts_forms.signals', 'INFO', 'ADMIN ACTION by: CLI CLI @ CLI User saved: 7 permissions: <QuerySet []> staff: False superuser: False active: True')
                 ),
                 None,
             )
 
             self.assertEqual(
                 cm.check_present(
-                    ('cts_forms.signals', 'INFO', 'ADMIN ACTION by: CLI CLI @ CLI User deleted: 5 permissions: <QuerySet []> staff: False superuser: False active: True')
+                    ('cts_forms.signals', 'INFO', 'ADMIN ACTION by: CLI CLI @ CLI User deleted: 7 permissions: <QuerySet []> staff: False superuser: False active: True')
                 ),
                 None,
             )

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -1,4 +1,5 @@
 import secrets
+from datetime import date, timedelta
 
 from testfixtures import LogCapture
 
@@ -269,33 +270,77 @@ class CRT_FILTER_Tests(TestCase):
         self.test_pass = secrets.token_hex(32)
         self.user = User.objects.create_user('DELETE_USER', 'george@thebeatles.com', self.test_pass)
         self.client.login(username='DELETE_USER', password=self.test_pass)
-        url_base = reverse('crt_forms:crt-forms-index')
-        url = f'{url_base}?assigned_section=ADM'
-        self.one_filter_response = self.client.get(url)
-        url_1 = f'{url_base}?assigned_section=ADM&status=new'
-        self.two_filter_response = self.client.get(url_1)
-        url_2 = f'{url_base}?assigned_section=ADM&status=closed'
-        self.two_filter_no_match = self.client.get(url_2)
+        self.url_base = reverse('crt_forms:crt-forms-index')
+        self.len_all_results = len(self.client.get(self.url_base).context['data_dict'])
 
     def tearDown(self):
         self.user.delete()
 
     def test_filter(self):
+        url = f'{self.url_base}?assigned_section=ADM'
+        one_filter_response = self.client.get(url)
         expected_reports = Report.objects.filter(assigned_section='ADM')
-        actual_reports = self.one_filter_response.context['data_dict']
+        actual_reports = one_filter_response.context['data_dict']
 
         self.assertTrue(len(actual_reports) == len(list(expected_reports)))
 
     def test_combined_filter(self):
+        url_1 = f'{self.url_base}?assigned_section=ADM&status=new'
+        two_filter_response = self.client.get(url_1)
+        url_2 = f'{self.url_base}?assigned_section=ADM&status=closed'
+        two_filter_no_match = self.client.get(url_2)
+
         # assumes all new reports are assigned to ADM and labeled new
         all_reports_actual = Report.objects.filter(assigned_section='ADM', status='new')
-        all_reports_expected = self.two_filter_response.context['data_dict']
+        all_reports_expected = two_filter_response.context['data_dict']
         # assumes no reports should be assigned to ADM and marked closed
         no_reports_actual = Report.objects.filter(assigned_section='ADM', status='closed')
-        no_reports_expected = self.two_filter_no_match.context['data_dict']
+        no_reports_expected = two_filter_no_match.context['data_dict']
 
         self.assertTrue(len(all_reports_actual) == len(all_reports_expected))
         self.assertTrue(len(no_reports_actual) == len(no_reports_expected))
+
+    def test_date_filter(self):
+        yesterday = date.today() - timedelta(days=1)
+        tomorrow = date.today() + timedelta(days=1)
+
+        url_start_yesterday = f"{self.url_base}?create_date_start={yesterday.strftime('%Y%m%d')}"
+        start_yesterday_response = self.client.get(url_start_yesterday).context['data_dict']
+
+        url_start_tomorrow = f"{self.url_base}?create_date_start={tomorrow.strftime('%Y%m%d')}"
+        start_tomorrow_response = self.client.get(url_start_tomorrow).context['data_dict']
+
+        url_end_yesterday = f"{self.url_base}?create_date_end={yesterday.strftime('%Y%m%d')}"
+        end_yesterday_response = self.client.get(url_end_yesterday).context['data_dict']
+
+        url_end_tomorrow = f"{self.url_base}?create_date_end={tomorrow.strftime('%Y%m%d')}"
+        end_tomorrow_response = self.client.get(url_end_tomorrow).context['data_dict']
+
+        # sanity check
+        self.assertTrue(self.len_all_results > 0)
+
+        self.assertEqual(len(start_tomorrow_response), 0)
+        self.assertEqual(len(end_yesterday_response), 0)
+        self.assertEqual(len(start_yesterday_response), self.len_all_results)
+        self.assertEqual(len(end_tomorrow_response), self.len_all_results)
+
+    def test_text_filter(self):
+        url_phrase = f'{self.url_base}?violation_summary=Four%20score%20and%20seven'
+        phrase_response = self.client.get(url_phrase).context['data_dict']
+
+        url_phrase_case_insensitive = f'{self.url_base}?violation_summary=four%20score%20and%20seven'
+        case_insensitive_phrase_response = self.client.get(url_phrase_case_insensitive).context['data_dict']
+
+        url_disjointed_phrase = f'{self.url_base}?violation_summary=For%20seven'
+        disjointed_phrase_response = self.client.get(url_disjointed_phrase).context['data_dict']
+
+        url_not_in_phrase = f'{self.url_base}?violation_summary=haberdashery'
+        url_not_in_phrase_response = self.client.get(url_not_in_phrase).context['data_dict']
+
+        self.assertEqual(len(phrase_response), self.len_all_results)
+        self.assertEqual(len(case_insensitive_phrase_response), self.len_all_results)
+        self.assertEqual(len(disjointed_phrase_response), self.len_all_results)
+        self.assertEqual(len(url_not_in_phrase_response), 0)
 
 
 class Validation_Form_Tests(TestCase):

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -22,7 +22,7 @@ SORT_DESC_CHAR = '-'
 
 @login_required
 def IndexView(request):
-    report_filter_kwargs, query_filters = report_filter(request)
+    report_query, query_filters = report_filter(request)
 
     # Sort data based on request from params, default to `created_date` of complaint
     sort = request.GET.getlist('sort', ['-create_date'])
@@ -34,7 +34,7 @@ def IndexView(request):
     if all(elem.replace("-", '') in report_fields for elem in sort) is False:
         raise Http404(f'Invalid sort request: {sort}')
 
-    requested_reports = Report.objects.filter(**report_filter_kwargs).order_by(*sort)
+    requested_reports = report_query.order_by(*sort)
     paginator = Paginator(requested_reports, per_page)
     requested_reports, page_format = pagination(paginator, page, per_page)
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -22,7 +22,7 @@ SORT_DESC_CHAR = '-'
 
 @login_required
 def IndexView(request):
-    report_query, query_filters = report_filter(request)
+    report_filter_kwargs, query_filters = report_filter(request)
 
     # Sort data based on request from params, default to `created_date` of complaint
     sort = request.GET.getlist('sort', ['-create_date'])
@@ -34,7 +34,7 @@ def IndexView(request):
     if all(elem.replace("-", '') in report_fields for elem in sort) is False:
         raise Http404(f'Invalid sort request: {sort}')
 
-    requested_reports = report_query.order_by(*sort)
+    requested_reports = Report.objects.filter(**report_filter_kwargs).order_by(*sort)
     paginator = Paginator(requested_reports, per_page)
     requested_reports, page_format = pagination(paginator, page, per_page)
 


### PR DESCRIPTION

## What does this change?
Adds the filters we will need:
- Uses the postgres `to_tsvector` search for some pretty good out of the box text search
- Adds create date range search, (can change date format in the URL if needed later)
- Adds tests

### Author
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
