### PR TITLE
Fix table overflow issue that hid pagination

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -33,7 +33,7 @@
     <div class="grid-col-3">
       {% include "forms/complaint_view/index/filters.html" with filters=filters form=form %}
     </div> 
-    <div class="grid-col-9">
+    <div class="grid-col-9 height-full">
       {% include "forms/complaint_view/index/complaints_table.html" with page_format=page_format data_dict=data_dict sort_state=sort_state filter_state=filter_state %}
     </div>
   </div>

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -105,8 +105,13 @@
 
     var preparedFilters = filters.length ? '&' + filters.join('&') : '';
     var preparedParams = params.length ? params.join('&') : '';
+    var finalQuery = '';
 
-    window.location = form.action + '?' + preparedParams + preparedFilters;
+    if (preparedFilters || preparedParams) {
+      finalQuery = '?' + preparedParams + preparedFilters;
+    }
+
+    window.location = form.action + finalQuery;
   }
 
   function addMultiSelectBehavior(props) {
@@ -122,6 +127,7 @@
     function onFilterTagClick(node) {
       var sections = filterData.assigned_section;
       var filterName = node.getAttribute('data-filter-value');
+
       sections.splice(sections.indexOf(filterName), 1);
       filterData.assigned_section = sections;
 


### PR DESCRIPTION
## What does this change?

* Fixes issue I introduced 😬 where the pagination controls at the bottom of the complaint table view were being covered by the table.

*ALSO fixes a bug where query params were malformed when clearing all filters

## Screenshots (for front-end PR):

![Screen Shot 2019-12-17 at 9 28 41 AM](https://user-images.githubusercontent.com/1421848/71019653-963a7300-20af-11ea-933d-299789942171.png)
