### PR TITLE
Removes usa-banner and footer from intake screens

### DIFF
--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -20,6 +20,7 @@
   </head>
   <body>
     <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+    {% block usa_banner %}
     <div class="usa-banner">
       <div class="usa-accordion">
         <header class="usa-banner__header">
@@ -61,6 +62,7 @@
         </div>
       </div>
     </div>
+    {% endblock %}
 
     {% block page_header %}{% endblock %}
 
@@ -68,6 +70,7 @@
       {% block content %} {% endblock %}
     </main>
 
+    {% block usa_footer %}
     <footer class="usa-footer usa-footer--slim" role="contentinfo">
       <div class="usa-footer__secondary-section">
         <div class="grid-container">
@@ -87,6 +90,7 @@
         </div>
       </div>
     </footer>
+    {% endblock %}
   </body>
   <script src="{% static 'js/uswds.min.js' %}"></script>
   <script src="{% static 'js/focus_alert.js' %}"></script>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -1,4 +1,4 @@
-{% extends "forms/base.html" %}
+{% extends "forms/complaint_view/intake_base.html" %}
 {% load static %}
 
 {% block page_header %}
@@ -42,7 +42,6 @@
   </div>
 </div>
 {% endblock %}
-
 {% block page_js %}
 <script>
   (function(root) {

--- a/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
@@ -1,0 +1,3 @@
+{% extends "forms/base.html" %}
+{% block usa_banner %}{% endblock %}
+{% block usa_footer %}{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -1,4 +1,4 @@
-{% extends "forms/base.html" %}
+{% extends "forms/complaint_view/intake_base.html" %}
 {% load static %}
 
 {% block page_header %}


### PR DESCRIPTION
No issue, just a quick change @Jacklynn will appreciate!

## What does this change?

This PR removes the `usa-banner` and footer elements from the intake screens. 
Logged in users already know they are on a government website, and removing these elements gives the page a more 'web app' feel

## Screenshots (for front-end PR):

<img width="1240" alt="Screen Shot 2019-12-17 at 4 14 57 PM" src="https://user-images.githubusercontent.com/1421848/71045083-7e331580-20e8-11ea-8edc-838d03fa1996.png">

