### PR TITLE
View complain details

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -1,6 +1,5 @@
 <div class="complaint-card complaint-card--rounded">
-  {{data.primary_issue}}
-  <h3 class="complaint-card-heading text-uppercase">Correspondent information</h3>
+  <h3 class="complaint-card-heading text-uppercase">Complaint details</h3>
   <table class="usa-table usa-table--borderless complaint-card-table">
     <tr>
       <th>Primary issue</th>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -1,5 +1,53 @@
 <div class="complaint-card complaint-card--rounded">
+  {{data.primary_issue}}
   <h3 class="complaint-card-heading text-uppercase">Correspondent information</h3>
   <table class="usa-table usa-table--borderless complaint-card-table">
+    <tr>
+      <th>Primary issue</th>
+      <td>
+        <strong>{{primary_complaint.0}}</strong>
+      </td>
+      <tr>
+        <th>Hate crime</th>
+        <td>
+          {% if crimes.physical_harm %}
+            Yes (checked)
+          {% else %}
+            No (unchecked)
+          {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th>Human Trafficking</th>
+        <td>
+          {% if crimes.trafficking %}
+            Yes (checked)
+          {% else %}
+            No (unchecked)
+          {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th>Relevant Details</th>
+        <td>
+          {% if data.election_details %}
+            Election type (federal/local): {{ data.election_details }}
+          {% else %}
+            '—'
+          {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th>Location name</th>
+        <td>{{data.location_name|default:"-"}}</td>
+      </tr>
+      <tr>
+        <th>City, State</th>
+        <td>
+          {{data.location_city_town|default:"-"}},
+          {{data.location_state|default:"-"}}
+        </td>
+      </tr>
+    </tr>
   </table>
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -1,0 +1,5 @@
+<div class="complaint-card complaint-card--rounded">
+  <h3 class="complaint-card-heading text-uppercase">Correspondent information</h3>
+  <table class="usa-table usa-table--borderless complaint-card-table">
+  </table>
+</div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -19,7 +19,7 @@
 {% block main_class %} class="page-header-background"{% endblock %}
 
 {% block content %}
-  <div class="grid-container">
+  <div class="grid-container-widescreen">
     <div class="complaint-header bg-primary text-white">
       <div class="grid-container">
       <div class="grid-row grid-gap">
@@ -43,10 +43,10 @@
     </div>
     <div class="complaint-body">
       <div class="grid-container">
-        <div class="grid-row">
-          <div class="tablet:grid-col-6"></div>
-          <div class="tablet:grid-col-6">
+        <div class="grid-row grid-gap-md">
+          <div class="tablet:grid-col-8 grid-offset-2">
             {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}
+            {% include 'forms/complaint_view/show/complaint_details.html' %}
             {% include 'forms/complaint_view/show/full_summary.html' with summary=data.violation_summary %}
           </div>
         </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -19,11 +19,11 @@
 {% block main_class %} class="page-header-background"{% endblock %}
 
 {% block content %}
-  <div class="grid-container-widescreen">
+  <div class="grid-container">
     <div class="complaint-header bg-primary text-white">
       <div class="grid-container">
       <div class="grid-row grid-gap">
-        <div class="tablet:grid-col-8">
+        <div class="tablet:grid-col-6 grid-offset-2">
           <h2 class="text-uppercase">
             Complaint
           </h2>
@@ -46,7 +46,7 @@
         <div class="grid-row grid-gap-md">
           <div class="tablet:grid-col-8 grid-offset-2">
             {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}
-            {% include 'forms/complaint_view/show/complaint_details.html' %}
+            {% include 'forms/complaint_view/show/complaint_details.html' with data=data primaty_complaint=primary_complaint %}
             {% include 'forms/complaint_view/show/full_summary.html' with summary=data.violation_summary %}
           </div>
         </div>

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from formtools.wizard.views import SessionWizardView
 
 from .models import Report, ProtectedClass, HateCrimesandTrafficking
-from .model_variables import PROTECTED_CLASS_CODES
+from .model_variables import PROTECTED_CLASS_CODES, PRIMARY_COMPLAINT_CHOICES, HATE_CRIMES_TRAFFICKING_MODEL_CHOICES
 from .page_through import pagination
 from .filters import report_filter
 from .forms import Filters
@@ -99,8 +99,21 @@ def IndexView(request):
 @login_required
 def ShowView(request, id):
     report = get_object_or_404(Report.objects, id=id)
+    primary_complaint = [ choice[1] for choice in PRIMARY_COMPLAINT_CHOICES if choice[0] == report.primary_complaint ]
+    crimes = {
+        'physical_harm': False,
+        'trafficking': False
+    }
+
+    for crime in report.hatecrimes_trafficking.all():
+        for choice in HATE_CRIMES_TRAFFICKING_MODEL_CHOICES:
+            if crime.hatecrimes_trafficking_option == choice[1]:
+                crimes[choice[0]] = True
+
     output = {
+        'crimes': crimes,
         'data': report,
+        'primary_complaint': primary_complaint,
         'return_url_args': request.GET.get('next', ''),
     }
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -99,7 +99,7 @@ def IndexView(request):
 @login_required
 def ShowView(request, id):
     report = get_object_or_404(Report.objects, id=id)
-    primary_complaint = [ choice[1] for choice in PRIMARY_COMPLAINT_CHOICES if choice[0] == report.primary_complaint ]
+    primary_complaint = [choice[1] for choice in PRIMARY_COMPLAINT_CHOICES if choice[0] == report.primary_complaint]
     crimes = {
         'physical_harm': False,
         'trafficking': False


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/186)

## What does this change?

This PR adds the `Complaint Details` card to the 'Complaint Details' page (meta!).

## Screenshots (for front-end PR):
![Screen Shot 2019-12-23 at 9 34 47 AM](https://user-images.githubusercontent.com/1421848/71371844-70a5e180-2567-11ea-9a40-06ad815e34c6.png)


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
