### PR TITLE
Use abbreviations for section routing filter

### DIFF
--- a/crt_portal/cts_forms/templates/forms/widgets/multi_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/multi_select.html
@@ -1,4 +1,4 @@
-<select multiple name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+<select class="complaint-multi-select" multiple name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
   {% for group_name, group_choices, group_index in widget.optgroups %}
     {% if group_name %}
       <optgroup label="{{ group_name }}">

--- a/crt_portal/cts_forms/templates/forms/widgets/multi_select_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/multi_select_option.html
@@ -1,3 +1,3 @@
 <option value="{{option.value}}" {% if option.selected is not False %}selected{% endif %}>
-  {{option.label}}
+  {{option.value}}
 </option>

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -170,3 +170,6 @@ form#report-form {
   }
 }
 
+.complaint-multi-select {
+  min-width: 140px;
+}


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/234)

## What does this change?

Now the `view sections` multi-select filter control display the routing section abbreviation, rather than the full name. The intake folks are power users and don't need the entire word displayed in order to select the correct filter.


## Screenshots (for front-end PR):
<img width="1383" alt="Screen Shot 2019-12-23 at 12 35 43 PM" src="https://user-images.githubusercontent.com/1421848/71379653-eff3df00-2580-11ea-9069-099c182998e8.png">



## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
