### PR TITLE
Route reports to IER

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -108,10 +108,25 @@ class Report(models.Model):
     def __str__(self):
         return f'{self.create_date} {self.violation_summary}'
 
+    def __has_immigration_protected_classes(self, pcs):
+        immigration_classes = [
+            'Immigration/citizenship status (choosing this will not share your status)',
+            'National origin (including ancestry and ethnicity)',
+            'Language'
+        ]
+        is_not_included = set(pcs).isdisjoint(set(immigration_classes))
+
+        if is_not_included:
+            return False
+
+        return True
+
     def assign_section(self):
         protected_classes = [n.protected_class for n in self.protected_class.all()]
 
         if self.primary_complaint == 'voting' and 'Disability (including temporary or recovery)' not in protected_classes:
             return 'VOT'
+        elif self.primary_complaint == 'workplace' and self.__has_immigration_protected_classes(protected_classes):
+            return 'IER'
 
         return 'ADM'


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/73)

## What does this change?

Adds assigned section routing to IER when the primary complaint involves the workplace, and at least one of the three protected classes outlined in the issue is indicated by the user.

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

