### PR TITLE
fixing label for summary

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -10,7 +10,7 @@
       {% render_sortable_heading 'Contact Name' sort_state filter_state %}
       {% render_sortable_heading 'Contact Details' sort_state filter_state %}
       {% render_sortable_heading 'Incident Location' sort_state filter_state %}
-      {% render_sortable_heading 'Violation Summary' sort_state filter_state %}
+      {% render_sortable_heading 'Summary' sort_state filter_state %}
       {% render_sortable_heading 'Class' sort_state filter_state %}
     </tr>
   </thead>
@@ -73,7 +73,7 @@
         </td>
       </tr>
     {% endfor %}
-    </tbody>  
+    </tbody>
   {% endif %}
 </table>
 


### PR DESCRIPTION
[https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/237]("Violation summary" to "summary"#237)

Title should be "Summary" in the CRT table