### PR TITLE
Bugfixes / updates

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -298,7 +298,12 @@ class WorkplaceLocation(LocationForm):
 
         self.fields['public_or_private_employer'] = TypedChoiceField(
             choices=PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES,
-            widget=UsaRadioSelect,
+            widget=UsaRadioSelect(attrs={
+                'help_text': {
+                    'public_employer': _('Funded by the government like a post office, fire department, courthouse, DMV, or public school. This could be at the local, state, or federal level'),
+                    'private_employer': _('Businesses or non-profits not funded by the government such as retail stores, banks, or restaurants')
+                }
+            }),
             required=True,
             error_messages={
                 'required': _('Please select what type of employer this is.')

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -160,8 +160,8 @@ PLACE_CHOICES = (
 )
 
 PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES = (
-    ('public_employer', _('Public employer -- Funded by the government like a post office, fire department, courthouse, DMV, or public school. This could be at the local, state, or federal level.')),
-    ('private_employer', _('Private employer -- Businesses or non-profits not funded by the government such as retail stores, banks, or restaurants.')),
+    ('public_employer', _('Public employer')),
+    ('private_employer', _('Private employer')),
     ('not_sure', _('I\'m not sure')),
 )
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -32,7 +32,7 @@
           {% if data.election_details %}
             Election type (federal/local): {{ data.election_details }}
           {% else %}
-            '—'
+            —
           {% endif %}
         </td>
       </tr>

--- a/crt_portal/cts_forms/templates/forms/widgets/usa_radio_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/usa_radio_option.html
@@ -1,11 +1,22 @@
+{% load get_dict_item %}
 <div class="usa-radio">
   <input type="radio"
          name="{{ widget.name }}"
          {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
          class="usa-radio__input"
          {% include "django/forms/widgets/attrs.html" %} />
-  <label class="usa-radio__label"
-         {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
-    {{ widget.label }}
+  <label class="usa-radio__label crt-radio__label_helper margin-bottom-2"
+         {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}
+  >
+    <div class="label-text margin-top-2">
+      <p class="margin-top-0 margin-bottom-0 margin-left-4">{{ widget.label }}</p>
+      {% if widget.attrs.help_text %}
+        {% with help_text=widget.attrs.help_text|get_dict_item:widget.value %}
+        {% if help_text %}
+          <em>{{ help_text }}</em>
+        {% endif %}
+        {% endwith %}
+      {% endif %}
+    </div>
   </label>
 </div>

--- a/crt_portal/cts_forms/templatetags/get_dict_item.py
+++ b/crt_portal/cts_forms/templatetags/get_dict_item.py
@@ -1,0 +1,9 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.filter(name='get_dict_item')
+def get_dict_item(value, arg):
+    return value.get(arg, None)

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -69,7 +69,7 @@ $complaint-body-offset: calc(
       width: 60%;
       white-space: normal;
       word-wrap: break-word;
-      word-break: break-all;
+      word-break: break-word;
     }
 
     th, td {

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -96,6 +96,16 @@ form#report-form {
     opacity: 0;
   }
 
+  .crt-radio__label_helper {
+    line-height: 1.5rem;
+
+    .label-text {
+      position: relative;
+      bottom: 40px;
+      margin-bottom: -30px;
+    }
+  }
+
   .crt-radio__label_area {
     @extend .usa-radio__label;
     text-indent: 0;


### PR DESCRIPTION
Fixes / updates to two issues!
* https://github.com/18F/crt-portal/issues/195
* https://github.com/18F/crt-portal/issues/186

## What does this change?

* On the complaint view show page:
  * Break long primary issues on a word rather than the middle of the word
  * Remove '' from the default emdash in the 'Relevant details' section

* On the workplace discrimination location page:
  * Properly adds the emphasized help text to radio labels


## Screenshots (for front-end PR):

<img width="741" alt="Screen Shot 2020-01-02 at 3 22 22 PM" src="https://user-images.githubusercontent.com/1421848/71699295-a9b63100-2d73-11ea-8585-2a5b346b6360.png">
<img width="646" alt="Screen Shot 2020-01-02 at 3 22 29 PM" src="https://user-images.githubusercontent.com/1421848/71699298-ac188b00-2d73-11ea-9967-c6b3b002c8a7.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
