### PR TITLE
Set role of presentation for primary reason list

### DIFF
--- a/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
@@ -24,9 +24,9 @@
               <div class="examples-title margin-top-2">
                 Examples:
               </div>
-              <ul class="margin-top-1">
+              <ul class="margin-top-1" role="presentation">
                 {% for example in examples %}
-                  <li class="primary-issue-example-li">
+                  <li class="primary-issue-example-li" role="listitem">
                     {{ example }}<span class="usa-sr-only">.</span>
                   </li>
                 {% endfor %}


### PR DESCRIPTION
Follow-up PR to get the `primary reason` example lists to read properly with VoiceOver

## What does this change?
* Safari + VoiceOver app doesn't recognize the primary reason's list of examples without
  `role="presentation"` being explicitly defined on the `ul`

