### PR TITLE
Filter by complainant contact name

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -11,8 +11,8 @@ filter_options = {
     'status': '__in',
     'location_state': '__in',
     'primary_complaint': '__in',
-    'contact_first_name': '__search',
-    'contact_last_name': '__search',
+    'contact_first_name': '__contains',
+    'contact_last_name': '__contains',
     'contact_email': '__search',
     'other_class': '__search',
     'violation_summary': '__search',
@@ -30,6 +30,7 @@ def report_filter(request):
     filters = {}
     for field in filter_options.keys():
         filter_list = request.GET.getlist(field)
+
         if len(filter_list) > 0:
             filters[field] = request.GET.getlist(field)
             if filter_options[field] == '__in':
@@ -38,6 +39,8 @@ def report_filter(request):
             elif filter_options[field] == '__search':
                 # takes one phrase
                 kwargs[f'{field}__search'] = request.GET.getlist(field)[0]
+            elif filter_options[field] == '__contains':
+                kwargs[f'{field}__icontains'] = request.GET.getlist(field)[0]
             elif field.startswith('create_date'):
                 # filters by a start date or an end date expects ddmmyyyy
                 year = int(request.GET.getlist(field)[0][:4])

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -367,7 +367,15 @@ class Who(ModelForm):
 class Filters(ModelForm):
     class Meta:
         model = Report
-        fields = ['assigned_section']
+        fields = ['assigned_section', 'contact_first_name', 'contact_last_name']
+        widgets = {
+            'contact_first_name': TextInput(attrs={
+                'class': 'usa-input'
+            }),
+            'contact_last_name': TextInput(attrs={
+                'class': 'usa-input'
+            }),
+        }
 
     def __init__(self, *args, **kwargs):
         ModelForm.__init__(self, *args, **kwargs)
@@ -377,3 +385,5 @@ class Filters(ModelForm):
             widget=CrtMultiSelect,
             required=False
         )
+        self.fields['contact_first_name'].label = _('Contact first name')
+        self.fields['contact_last_name'].label = _('Contact last name')

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
@@ -3,28 +3,34 @@
 <div class="complaint-card">
   <form
     id="filters-form"
-    class="usa-form"
     method="GET"
     action="/form/view"
     novalidate
   >
-    <div id="view-section-filter">
-      <label for="{{form.assigned_section.attrs.id}}" class="usa-label margin-bottom-1">
-        <b>{{form.assigned_section.label }}</b>
-      </label>
-      {{ form.assigned_section }}
-    </div>
-    <div>
-      <h3>Filters</h3>
-      <div id="contact-name-filter">
-        <label for="{{form.contact_name.attrs.id}}" class="usa-label margin-bottom-1">
-          <b>{{form.contact_name.label }}</b>
+    <div class="grid-row">
+      <div id="view-section-filter" class="margin-right-2">
+        <label for="{{form.assigned_section.attrs.id}}" class="usa-label margin-bottom-1">
+          <b>{{form.assigned_section.label }}</b>
         </label>
-        {{ form.contact_name }}
+        {{ form.assigned_section }}
+      </div>
+      <div id="contact-first-name-filter" class="margin-right-2">
+        <label for="{{form.contact_first_name.attrs.id}}" class="usa-label margin-bottom-1">
+          <b>{{form.contact_first_name.label }}</b>
+        </label>
+        {{ form.contact_first_name }}
+      </div>
+      <div id="contact-last-name-filter" class="margin-right-2">
+        <label for="{{form.contact_last_name.attrs.id}}" class="usa-label margin-bottom-1">
+          <b>{{form.contact_last_name.label }}</b>
+        </label>
+        {{ form.contact_last_name }}
       </div>
     </div>
     <div class="margin-top-2">
-      <button type="submit" class="usa-button usa-button--primary">Filter results</button>
+      <button type="submit" class="usa-button usa-button--primary">
+        Filter results
+      </button>
     </div>
   </form>
   <div id="active-filters" class="active-filters margin-top-2">
@@ -37,7 +43,15 @@
           data-filter-name="{{key}}"
           data-filter-value="{{item}}"
         >
-          {% if key == 'assigned_section' %} Routed {% else %} {{key}} {% endif %}: {{item}}  
+          {% if key == 'assigned_section' %}
+            Routed
+          {% elif key == 'contact_first_name' %}
+            Contact first name
+          {% elif key == 'contact_last_name' %}
+            Contact last name
+          {% else %}
+            {{key}}
+          {% endif %}: {{item}}
           <div class="divider"></div>
           <img src="{% static "img/close-blue-50-alt.svg" %}" class="filter-action">
         </button>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
@@ -8,10 +8,21 @@
     action="/form/view"
     novalidate
   >
-    <label for="{{form.assigned_section.attrs.id}}" class="usa-label margin-bottom-1">
-      <b>View sections</b>
-    </label>
-    {{ form.assigned_section }}
+    <div id="view-section-filter">
+      <label for="{{form.assigned_section.attrs.id}}" class="usa-label margin-bottom-1">
+        <b>{{form.assigned_section.label }}</b>
+      </label>
+      {{ form.assigned_section }}
+    </div>
+    <div>
+      <h3>Filters</h3>
+      <div id="contact-name-filter">
+        <label for="{{form.contact_name.attrs.id}}" class="usa-label margin-bottom-1">
+          <b>{{form.contact_name.label }}</b>
+        </label>
+        {{ form.contact_name }}
+      </div>
+    </div>
     <div class="margin-top-2">
       <button type="submit" class="usa-button usa-button--primary">Filter results</button>
     </div>


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/210)

## What does this change?

This PR adds the ability to filter complaints received by the complainant's first name, last name, or both. Note that the name filters, like each of the other individual filters, are also ANDs. That is, a search with `contact_last_name='smith'` and `contact_first_name='debbie'` will search for users with the name 'debbie smith' not `first_name=debbie OR last_name=smith`.

The name filters behave the same as the existing filters, that is, they produce tags with their values which can be clicked to remove that filter and requery the data.

## Screenshots (for front-end PR):

![Screen Shot 2020-01-03 at 2 12 48 PM](https://user-images.githubusercontent.com/1421848/71752232-2bb95f00-2e33-11ea-8d3f-e02be286b7ee.png)

![Screen Shot 2020-01-03 at 2 13 19 PM](https://user-images.githubusercontent.com/1421848/71752241-2f4ce600-2e33-11ea-9e9d-3e0d298f2c75.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

We decided to make this two fields as combining both fields into a single input on the front-end was not trivial. Further user testing is needed to see if two fields are better than one!
