### PR TITLE
Small refactor of complaint viewer filter JS code

### DIFF
--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -1,23 +1,4 @@
 (function(root, dom) {
-  var SEARCH_PARAMS_WHITELIST = ['sort', 'page', 'per_page'];
-  var filterData = {
-    assigned_section: [],
-    primary_complaint: '',
-    status: '',
-    location_state: '',
-    primary_complaint: '',
-    contact_first_name: '',
-    contact_last_name: '',
-    contact_email: '',
-    other_class: '',
-    violation_summary: '',
-    location_name: '',
-    location_address_line_1: '',
-    location_address_line_2: '',
-    create_date_start: '',
-    create_date_end: '',
-  };
-
   /**
    * Convert an array-like object to an array.
    *
@@ -28,6 +9,20 @@
    */
   function toArray(arrayLike) {
     return Array.prototype.slice.call(arrayLike);
+  }
+
+  function getMutiselectValues(select) {
+    var options = toArray((select && select.options) || []);
+
+    function isSelected(option) {
+      return option.selected;
+    }
+
+    function unwrapValue(x) {
+      return x.value;
+    }
+
+    return options.filter(isSelected).map(unwrapValue);
   }
 
   /**
@@ -61,35 +56,6 @@
   }
 
   /**
-   * Mutate the current filter state with updated filter values
-   * @param {Object} state The current filter state
-   * @param {Object} updates The properties of the filter state to be updated
-   */
-  function mutateFilterDataWithUpdates(state, updates) {
-    for (var key in updates) {
-      if (state.hasOwnProperty(key)) {
-        state[key] = updates[key];
-      }
-    }
-  }
-
-  function getMutiselectValues(select) {
-    var options = toArray((select && select.options) || []);
-
-    function isSelected(option) {
-      return option.selected;
-    }
-
-    function unwrapValue(x) {
-      return x.value;
-    }
-
-    return options
-      .filter(isSelected)
-      .map(unwrapValue);
-  }
-
-  /**
    * Given an object of query parameters, convert them back into a string
    * @param {Object} paramsObj An object containing initial
    * @returns {Array} A list of URI-encoded query param strings
@@ -104,14 +70,14 @@
         return memo;
       }
 
-      var valueAsList = paramValue instanceof Array ? paramValue : [ paramValue ];
+      var valueAsList = paramValue instanceof Array ? paramValue : [paramValue];
       var paramsString = valueAsList
         .reduce(function(accum, value) {
           accum.push(makeQueryParam(key, value));
 
-        return accum;
-      }, [])
-      .join('&');
+          return accum;
+        }, [])
+        .join('&');
 
       memo.push(paramsString);
 
@@ -129,93 +95,69 @@
     return key + '=' + encodeURIComponent(value);
   }
 
+  /**
+   * Concat all previous params together
+   * @param {Array} params An array of URI-encoded query param strings
+   * @returns {String} The supplies param strings joined and delimited by an ampersand
+   */
   function finalizeQueryParams(params) {
     return params.length ? params.join('&') : '';
   }
 
-  function doSearch(form) {
-    var paramsObj = getQueryParams(root.location.search, SEARCH_PARAMS_WHITELIST);
-    var preparedFilters = finalizeQueryParams(makeQueryParams(filterData));
-    var preparedParams = finalizeQueryParams(makeQueryParams(paramsObj));
-    var finalQuery = '';
+  /**
+   * filterDataModel and the mutation function below control the `model` behavior
+   * of the filters JS
+   */
 
-    if (preparedFilters || preparedParams) {
-      finalQuery = '?' + preparedParams + preparedFilters;
-    }
+  var filterDataModel = {
+    assigned_section: [],
+    primary_complaint: '',
+    status: '',
+    location_state: '',
+    primary_complaint: '',
+    contact_first_name: '',
+    contact_last_name: '',
+    contact_email: '',
+    other_class: '',
+    violation_summary: '',
+    location_name: '',
+    location_address_line_1: '',
+    location_address_line_2: '',
+    create_date_start: '',
+    create_date_end: '',
+    sort: '',
+    page: '',
+    per_page: ''
+  };
 
-    window.location = form.action + finalQuery;
-  }
-
-  function addMultiSelectBehavior(props) {
-    props.el.addEventListener('change', function(event) {
-      filterData.assigned_section = getMutiselectValues(event.target);
-    });
-  }
-
-  function addTextInputBehavior(props) {
-    if (!props.el || !props.name) {
-      throw new Error(
-        'Component must be supplied with a valid DOM node and a `name` key corresponding to a key in the filterData object'
-      );
-    }
-
-    props.el.addEventListener('change', function(event) {
-      filterData[props.name] = event.target.value;
-    });
-  }
-
-  function filterController() {
-    var form = dom.getElementById('filters-form');
-    var activeFilters = dom.getElementById('active-filters');
-
-    function onFilterTagClick(node) {
-      var sections = filterData.assigned_section;
-      var filterName = node.getAttribute('data-filter-name');
-
-      if (filterName === 'assigned_section') {
-        sections.splice(sections.indexOf(filterName), 1);
-        filterData.assigned_section = sections;
-      } else {
-        filterData[filterName] = '';
+  /**
+   * Mutate the current filter state with updated filter values
+   * @param {Object} state The current filter state
+   * @param {Object} updates The properties of the filter state to be updated
+   */
+  function mutateFilterDataWithUpdates(state, updates) {
+    for (var key in updates) {
+      if (state.hasOwnProperty(key)) {
+        state[key] = updates[key];
       }
-
-      doSearch(form);
     }
-
-    var filterUpdates = getQueryParams(root.location.search, Object.keys(filterData));
-    mutateFilterDataWithUpdates(filterData, filterUpdates);
-
-    addFormSubmitBehavior({
-      el: form
-    });
-    addMultiSelectBehavior({
-      el: form.querySelector('select[name="assigned_section"')
-    });
-    addTextInputBehavior({
-      el: form.querySelector('input[name="contact_first_name"'),
-      name: 'contact_first_name'
-    });
-    addTextInputBehavior({
-      el: form.querySelector('input[name="contact_last_name"'),
-      name: 'contact_last_name'
-    });
-    addFilterTagBehavior({
-      el: activeFilters,
-      onClick: onFilterTagClick
-    });
   }
 
-  function addFormSubmitBehavior(props) {
-    var form = props.el;
+  /**
+   * The following functions represent the 'views' for this  application —
+   * these are the components that wire up event handling behavior to
+   * specific DOM nodes.
+   *
+   * Each view takes a `props` object, which, at a minimum, accepts an `el` property, which is
+   * an instance of the DOM node we want to add interactive behavior to.
+   */
 
-    form.addEventListener('submit', function handleSubmit(event) {
-      event.preventDefault();
-
-      doSearch(form);
-    });
-  }
-
-  function addFilterTagBehavior(props) {
+  /**
+   * View to control filter tag behavior
+   * @param {Object} props
+   * @param {HTMLElement} props.el The DOM node this view manages
+   */
+  function filterTagView(props) {
     var filters = props.el;
     var onClickHandler = props.onClick;
 
@@ -228,5 +170,121 @@
     });
   }
 
-  window.addEventListener('DOMContentLoaded', filterController);
+  /**
+   * View to control form element
+   * @param {Object} props
+   * @param {HTMLElement} props.el The DOM node this view manages
+   */
+  function formView(props) {
+    var form = props.el;
+
+    form.addEventListener('submit', function handleSubmit(event) {
+      event.preventDefault();
+
+      formView.doSearch(form);
+    });
+  }
+
+  /**
+   * Create a query param string from our filter data model, and update the URL
+   * in the browser to perform a new search with the applied filters
+   */
+  formView.doSearch = function doSearch(form) {
+    var preparedFilters = finalizeQueryParams(makeQueryParams(filterDataModel));
+    var finalQuery = '';
+
+    if (preparedFilters) {
+      finalQuery = '?' + preparedFilters;
+    }
+
+    window.location = form.action + finalQuery;
+  };
+
+  /**
+   * View to control multiselect elemeent behavior
+   * @param {Object} props
+   * @param {HTMLElement} props.el The DOM node this view manages
+   */
+  function multiSelectView(props) {
+    props.el.addEventListener('change', function(event) {
+      filterDataModel.assigned_section = getMutiselectValues(event.target);
+    });
+  }
+
+  /**
+   * View to control text input element behavior
+   * @param {Object} props
+   * @param {HTMLElement} props.el The DOM node this view manages
+   * @param {String} props.name The key in the filter data model that corresponds to the data to update
+   */
+  function textInputView(props) {
+    if (!props.el || !props.name) {
+      throw new Error(
+        'Component must be supplied with a valid DOM node and a `name` key corresponding to a key in the filterDataModel object'
+      );
+    }
+
+    props.el.addEventListener('change', function(event) {
+      filterDataModel[props.name] = event.target.value;
+    });
+  }
+
+  function filterController() {
+    var formEl = dom.getElementById('filters-form');
+    var multiSelectEl = formEl.querySelector('select[name="assigned_section"');
+    var firstNameEl = formEl.querySelector('input[name="contact_first_name"');
+    var lastNameEl = formEl.querySelector('input[name="contact_last_name"');
+    var activeFiltersEl = dom.getElementById('active-filters');
+
+    /**
+     * Update the filter data model when the user clears (clicks on) a filter tag,
+     * and perform a new search with the updated filters applied.
+     * @param {HTMLElement} node An HTML element
+     */
+    function onFilterTagClick(node) {
+      var filterName = node.getAttribute('data-filter-name');
+
+      if (filterName === 'assigned_section') {
+        var sections = filterDataModel.assigned_section;
+        var filterData = node.getAttribute('data-filter-value');
+
+        sections.splice(sections.indexOf(filterData), 1);
+        filterDataModel.assigned_section = sections;
+      } else {
+        filterDataModel[filterName] = '';
+      }
+
+      formView.doSearch(formEl);
+    }
+
+    formView({
+      el: formEl
+    });
+    multiSelectView({
+      el: multiSelectEl
+    });
+    textInputView({
+      el: firstNameEl,
+      name: 'contact_first_name'
+    });
+    textInputView({
+      el: lastNameEl,
+      name: 'contact_last_name'
+    });
+    filterTagView({
+      el: activeFiltersEl,
+      onClick: onFilterTagClick
+    });
+  }
+
+  // Bootstrap the filter code's data persistence and
+  // instantiate the controller that manages the UI components / views
+  function init() {
+    var filterUpdates = getQueryParams(root.location.search, Object.keys(filterDataModel));
+    mutateFilterDataWithUpdates(filterDataModel, filterUpdates);
+
+    filterController();
+  }
+
+  window.addEventListener('DOMContentLoaded', init);
 })(window, document);


### PR DESCRIPTION
## What does this change?

Removes duplication and cleans up some of the code around building a new query string of filters based on existing filter query parameters in the URL and user interaction with filtering form controls on the `/form/view` intake page.
