### PR TITLE
Adds ability to filter complaint forms table by city 

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -17,6 +17,7 @@ filter_options = {
     'other_class': '__search',
     'violation_summary': '__search',
     'location_name': '__search',
+    'location_city_town': '__contains',
     'location_address_line_1': '__search',
     'location_address_line_2': '__search',
     'create_date_start': '__gte',

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -371,7 +371,7 @@ class Who(ModelForm):
 class Filters(ModelForm):
     class Meta:
         model = Report
-        fields = ['assigned_section', 'contact_first_name', 'contact_last_name']
+        fields = ['assigned_section', 'contact_first_name', 'contact_last_name', 'location_city_town']
         widgets = {
             'contact_first_name': TextInput(attrs={
                 'class': 'usa-input'
@@ -379,6 +379,9 @@ class Filters(ModelForm):
             'contact_last_name': TextInput(attrs={
                 'class': 'usa-input'
             }),
+            'location_city_town': TextInput(attrs={
+                'class': 'usa-input'
+            })
         }
 
     def __init__(self, *args, **kwargs):
@@ -389,5 +392,7 @@ class Filters(ModelForm):
             widget=CrtMultiSelect,
             required=False
         )
+        self.fields['assigned_section'].label = _('View sections')
         self.fields['contact_first_name'].label = _('Contact first name')
         self.fields['contact_last_name'].label = _('Contact last name')
+        self.fields['location_city_town'].label = _('City')

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
@@ -26,6 +26,12 @@
         </label>
         {{ form.contact_last_name }}
       </div>
+      <div>
+        <label for="{{form.location_city_town.attrs.id}}" class="usa-label margin-bottom-1">
+          <b>{{form.location_city_town.label}}</b>
+        </label>
+        {{ form.location_city_town }}
+      </div>
     </div>
     <div class="margin-top-2">
       <button type="submit" class="usa-button usa-button--primary">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
@@ -55,6 +55,8 @@
             Contact first name
           {% elif key == 'contact_last_name' %}
             Contact last name
+          {% elif key == 'location_city_town' %}
+            City
           {% else %}
             {{key}}
           {% endif %}: {{item}}

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -366,6 +366,14 @@ class CRT_FILTER_Tests(TestCase):
             test_report.assigned_section = test_report.assign_section()
             test_report.save()
 
+        SAMPLE_REPORT['primary_complaint'] = PRIMARY_COMPLAINT_CHOICES[0][0]
+        test_report = Report.objects.create(**SAMPLE_REPORT)
+        test_report.contact_first_name = 'Mary'
+        test_report.contact_last_name = 'Bar'
+        test_report.location_city_town = 'Cleveland'
+        test_report.assigned_section = test_report.assign_section()
+        test_report.save()
+
         self.client = Client()
         # we are not running the tests against the production database, so this shouldn't be producing real users anyway.
         self.test_pass = secrets.token_hex(32)
@@ -442,6 +450,33 @@ class CRT_FILTER_Tests(TestCase):
         self.assertEqual(len(case_insensitive_phrase_response), self.len_all_results)
         self.assertEqual(len(disjointed_phrase_response), self.len_all_results)
         self.assertEqual(len(url_not_in_phrase_response), 0)
+
+    def test_first_name_filter(self):
+        first_name_filter = 'contact_first_name=lin'
+        response = self.client.get(f'{self.url_base}?{first_name_filter}')
+        reports = response.context['data_dict']
+
+        report_len = len(reports)
+
+        self.assertEquals(report_len, self.len_all_results - 1)
+
+    def test_last_name_filter(self):
+        last_name_filter = 'contact_last_name=bar'
+        response = self.client.get(f'{self.url_base}?{last_name_filter}')
+        reports = response.context['data_dict']
+
+        report_len = len(reports)
+
+        self.assertEquals(report_len, 1)
+
+    def test_city_name_filter(self):
+        city_name_filter = 'location_city_town=land'
+        response = self.client.get(f'{self.url_base}?{city_name_filter}')
+        reports = response.context['data_dict']
+
+        report_len = len(reports)
+
+        self.assertEquals(report_len, 1)
 
 
 class Validation_Form_Tests(TestCase):

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -65,12 +65,12 @@
 
     return keys.reduce(function(memo, key) {
       var paramValue = params[key];
+      var valueAsList = paramValue instanceof Array ? paramValue : [paramValue];
 
-      if (!paramValue) {
+      if (!paramValue.length) {
         return memo;
       }
 
-      var valueAsList = paramValue instanceof Array ? paramValue : [paramValue];
       var paramsString = valueAsList
         .reduce(function(accum, value) {
           accum.push(makeQueryParam(key, value));
@@ -123,6 +123,7 @@
     location_name: '',
     location_address_line_1: '',
     location_address_line_2: '',
+    location_city_town: '',
     create_date_start: '',
     create_date_end: '',
     sort: '',

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -234,6 +234,7 @@
     var multiSelectEl = formEl.querySelector('select[name="assigned_section"');
     var firstNameEl = formEl.querySelector('input[name="contact_first_name"');
     var lastNameEl = formEl.querySelector('input[name="contact_last_name"');
+    var cityEl = formEl.querySelector('input[name="location_city_town"]');
     var activeFiltersEl = dom.getElementById('active-filters');
 
     /**
@@ -270,6 +271,10 @@
     textInputView({
       el: lastNameEl,
       name: 'contact_last_name'
+    });
+    textInputView({
+      el: cityEl,
+      name: 'location_city_town'
     });
     filterTagView({
       el: activeFiltersEl,


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/191)

## What does this change?

* This PR adds the ability to filter complaints by city!

## Screenshots (for front-end PR):
<img width="1394" alt="Screen Shot 2020-01-06 at 3 32 10 PM" src="https://user-images.githubusercontent.com/1421848/71856713-b7342980-3099-11ea-8ee8-81531e9ec382.png">
<img width="1409" alt="Screen Shot 2020-01-06 at 3 32 21 PM" src="https://user-images.githubusercontent.com/1421848/71856724-b9968380-3099-11ea-8393-43ca34cdfeb8.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
