### PR TITLE
Adds filtering support for incident location state

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -371,7 +371,13 @@ class Who(ModelForm):
 class Filters(ModelForm):
     class Meta:
         model = Report
-        fields = ['assigned_section', 'contact_first_name', 'contact_last_name', 'location_city_town']
+        fields = [
+            'assigned_section',
+            'contact_first_name',
+            'contact_last_name',
+            'location_city_town',
+            'location_state'
+        ]
         widgets = {
             'contact_first_name': TextInput(attrs={
                 'class': 'usa-input'
@@ -381,7 +387,8 @@ class Filters(ModelForm):
             }),
             'location_city_town': TextInput(attrs={
                 'class': 'usa-input'
-            })
+            }),
+            'location_state': CrtDropdown
         }
 
     def __init__(self, *args, **kwargs):
@@ -392,7 +399,16 @@ class Filters(ModelForm):
             widget=CrtMultiSelect,
             required=False
         )
+        self.fields['location_state'] = ChoiceField(
+            choices=STATES_AND_TERRITORIES,
+            widget=CrtDropdown,
+            required=False,
+        )
+
         self.fields['assigned_section'].label = _('View sections')
         self.fields['contact_first_name'].label = _('Contact first name')
         self.fields['contact_last_name'].label = _('Contact last name')
         self.fields['location_city_town'].label = _('City')
+
+        self.fields['location_state'].label = _('State')
+        self.fields['location_state'].widget.attrs['list'] = 'states'

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
@@ -32,6 +32,12 @@
         </label>
         {{ form.location_city_town }}
       </div>
+      <div id="location-state-filter" class="margin-right-2">
+        <label for="{{form.location_state.attrs.id}}" class="usa-label margin-bottom-1">
+          <b>{{form.location_state.label }}</b>
+        </label>
+        {{ form.location_state }}
+      </div>
     </div>
     <div class="margin-top-2">
       <button type="submit" class="usa-button usa-button--primary">
@@ -57,6 +63,8 @@
             Contact last name
           {% elif key == 'location_city_town' %}
             City
+          {% elif key == 'location_state' %}
+            State
           {% else %}
             {{key}}
           {% endif %}: {{item}}

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -371,6 +371,7 @@ class CRT_FILTER_Tests(TestCase):
         test_report.contact_first_name = 'Mary'
         test_report.contact_last_name = 'Bar'
         test_report.location_city_town = 'Cleveland'
+        test_report.location_state = 'OH'
         test_report.assigned_section = test_report.assign_section()
         test_report.save()
 
@@ -472,6 +473,15 @@ class CRT_FILTER_Tests(TestCase):
     def test_city_name_filter(self):
         city_name_filter = 'location_city_town=land'
         response = self.client.get(f'{self.url_base}?{city_name_filter}')
+        reports = response.context['data_dict']
+
+        report_len = len(reports)
+
+        self.assertEquals(report_len, 1)
+
+    def test_state_filter(self):
+        state_filter = 'location_state=OH'
+        response = self.client.get(f'{self.url_base}?{state_filter}')
         reports = response.context['data_dict']
 
         report_len = len(reports)

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -11,20 +11,6 @@
     return Array.prototype.slice.call(arrayLike);
   }
 
-  function getMutiselectValues(select) {
-    var options = toArray((select && select.options) || []);
-
-    function isSelected(option) {
-      return option.selected;
-    }
-
-    function unwrapValue(x) {
-      return x.value;
-    }
-
-    return options.filter(isSelected).map(unwrapValue);
-  }
-
   /**
    * Converts a query string into an object, where the key is the
    * name of the query and the value is an array of all values associated
@@ -201,6 +187,19 @@
     window.location = form.action + finalQuery;
   };
 
+  function getMutiselectValues(select) {
+    var options = toArray((select && select.options) || []);
+
+    function isSelected(option) {
+      return option.selected;
+    }
+
+    function unwrapValue(x) {
+      return x.value;
+    }
+
+    return options.filter(isSelected).map(unwrapValue);
+  }
   /**
    * View to control multiselect elemeent behavior
    * @param {Object} props
@@ -236,6 +235,7 @@
     var firstNameEl = formEl.querySelector('input[name="contact_first_name"');
     var lastNameEl = formEl.querySelector('input[name="contact_last_name"');
     var cityEl = formEl.querySelector('input[name="location_city_town"]');
+    var locationStateEl = formEl.querySelector('input[name="location_state"]');
     var activeFiltersEl = dom.getElementById('active-filters');
 
     /**
@@ -276,6 +276,10 @@
     textInputView({
       el: cityEl,
       name: 'location_city_town'
+    });
+    textInputView({
+      el: locationStateEl,
+      name: 'location_state'
     });
     filterTagView({
       el: activeFiltersEl,


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/240)

## What does this change?

This PR adds the ability to filter the complainant table view by incident location state, in concert with the existing filters

## Screenshots (for front-end PR):

![Screen Shot 2020-01-07 at 7 57 19 AM](https://user-images.githubusercontent.com/1421848/71908712-5fda9b80-3123-11ea-9d94-18636b5c0ece.png)
![Screen Shot 2020-01-07 at 7 57 44 AM](https://user-images.githubusercontent.com/1421848/71908726-6406b900-3123-11ea-8ddb-5c818562fa7a.png)



## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
