### PR TITLE
Show protected class

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -58,6 +58,7 @@
             {% endif %}
           {% endfor %}
           {% if data.other_class %}
+            <br>
             Other: {{data.other_class}}
           {% endif %}
         </td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -50,7 +50,13 @@
       <tr>
         <th>Protected class</th>
         <td>
-          {{data.p_class_list}}
+          {% for p_class in p_class_list %}
+            {% if not forloop.last %}
+              {{p_class}},
+            {% else %}
+              {{p_class}}
+            {% endif %}
+          {% endfor %}
           {% if data.other_class %}
             Other: {{data.other_class}}
           {% endif %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -47,6 +47,15 @@
           {{data.location_state|default:"-"}}
         </td>
       </tr>
+      <tr>
+        <th>Protected class</th>
+        <td>
+          {{data.p_class_list}}
+          {% if data.other_class %}
+            Other: {{data.other_class}}
+          {% endif %}
+        </td>
+      </tr>
     </tr>
   </table>
 </div>

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -20,7 +20,7 @@ from .forms import Filters
 SORT_DESC_CHAR = '-'
 
 
-def format_protected_class(p_class_objects):
+def format_protected_class(p_class_objects, other_class):
     p_class_list = []
     for p_class in p_class_objects:
         if p_class.protected_class is not None:
@@ -28,7 +28,7 @@ def format_protected_class(p_class_objects):
             if code != 'Other':
                 p_class_list.append(code)
             # If this code is other but there is no other_class description, we want it to say "Other". If there is an other_class that will take the place of "Other"
-            elif report.other_class is None:
+            elif other_class is None:
                 p_class_list.append(code)
 
     return p_class_list
@@ -76,7 +76,10 @@ def IndexView(request):
     data = []
 
     for report in requested_reports:
-        p_class_list = format_protected_class(report.protected_class.all().order_by('form_order'))
+        p_class_list = format_protected_class(
+            report.protected_class.all().order_by('form_order'),
+            report.other_class,
+        )
         if report.other_class:
             p_class_list.append(report.other_class)
         if len(p_class_list) > 3:
@@ -116,7 +119,10 @@ def ShowView(request, id):
             if crime.hatecrimes_trafficking_option == choice[1]:
                 crimes[choice[0]] = True
 
-    p_class_list = format_protected_class(report.protected_class.all().order_by('form_order'))
+    p_class_list = format_protected_class(
+        report.protected_class.all().order_by('form_order'),
+        report.other_class,
+    )
 
     output = {
         'crimes': crimes,


### PR DESCRIPTION
Closes 2 issues
[View details of the complaint on the Complaint details page #186](https://github.com/18F/crt-portal/issues/186)
and
[Show protected classes on the complaint details page #257](https://github.com/18F/crt-portal/issues/257)

## What does this change?
Adds protected class to the individual page view
## Screenshots (for front-end PR):
![Screen Shot 2020-01-14 at 11 59 33 AM](https://user-images.githubusercontent.com/4406333/72364976-663dba00-36c5-11ea-8b43-97e61f95b707.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
