### PR TITLE
Added date validation tests

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -452,6 +452,16 @@ class When(ModelForm):
                     _('Date can not be in the future'),
                     params={'value': test_date.strftime('%x')},
                 )
+            if year < 100:
+                raise ValidationError(
+                    _('Please enter four digits for the year'),
+                    params={'value': test_date.strftime('%x')},
+                )
+            if test_date < datetime(1964, 7, 2):
+                raise ValidationError(
+                    _('Date too long ago'),
+                    params={'value': test_date.strftime('%x')},
+                )
         except ValueError:
             # a bit of a catch-all for all the ways people could make bad dates
             raise ValidationError(

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -457,7 +457,7 @@ class When(ModelForm):
                     _('Please enter four digits for the year'),
                     params={'value': test_date.strftime('%x')},
                 )
-            if test_date < datetime(1964, 7, 2):
+            if test_date < datetime(1899, 12, 31):
                 raise ValidationError(
                     _('Date too long ago'),
                     params={'value': test_date.strftime('%x')},

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -21,7 +21,7 @@ from .model_variables import (
     PRIMARY_COMPLAINT_ERROR,
     HATE_CRIMES_TRAFFICKING_CHOICES,
 )
-from .forms import Who, Details, Contact, ProtectedClassForm, LocationForm, PrimaryReason
+from .forms import Who, Details, Contact, ProtectedClassForm, LocationForm, PrimaryReason, When
 from .test_data import SAMPLE_REPORT
 
 
@@ -45,8 +45,6 @@ class Valid_Form_Tests(TestCase):
     def test_Details_valid(self):
         form = Details(data={
             'violation_summary': 'Hello! I have a problem. ႠႡႢ',
-            'when': 'last_6_months',
-            'how_many': 'no',
         })
         self.assertTrue(form.is_valid())
 
@@ -98,6 +96,14 @@ class Valid_Form_Tests(TestCase):
             'hatecrimes_trafficking': HateCrimesandTrafficking.objects.all(),
             'primary_complaint': PRIMARY_COMPLAINT_CHOICES[0][0],
         })
+        self.assertTrue(form.is_valid())
+
+    def test_When_vaild(self):
+        form = When(data={
+            'last_incident_year': 2019,
+            'last_incident_month': 5,
+            'last_incident_day': 5,
+            })
         self.assertTrue(form.is_valid())
 
 
@@ -543,6 +549,43 @@ class Validation_Form_Tests(TestCase):
         # ensure Hatecrime is not in error list
         self.assertFalse('hatecrimes_trafficking<ul class="errorlist"><li>' in str(form.errors))
         self.assertTrue(f'<ul class="errorlist"><li>{PRIMARY_COMPLAINT_ERROR}' in str(form.errors))
+
+    def test_required_year(self):
+        form = When(data={
+            'last_incident_month': 5,
+            'last_incident_day': 5,
+            })
+        self.assertTrue(f'<ul class="errorlist"><li>Please enter a year' in str(form.errors))
+
+    def test_required_month(self):
+        form = When(data={
+            'last_incident_year': 2019,
+            'last_incident_day': 5,
+            })
+        self.assertTrue(f'<ul class="errorlist"><li>Please enter a month' in str(form.errors))
+
+    def test_NOT_required_day(self):
+        form = When(data={
+            'last_incident_year': 2019,
+            'last_incident_month': 5,
+            })
+        self.assertTrue(form.is_valid())
+
+    def test_future_incident_date(self):
+        form = When(data={
+            'last_incident_year': 2200,
+            'last_incident_month': 5,
+            'last_incident_day': 5,
+            })
+        self.assertFalse(form.is_valid())
+
+    def test_past_incident_date(self):
+        form = When(data={
+            'last_incident_year': 20,
+            'last_incident_month': 5,
+            'last_incident_day': 5,
+            })
+        self.assertFalse(form.is_valid())
 
 
 class ContactValidationTests(TestCase):

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -103,7 +103,7 @@ class Valid_Form_Tests(TestCase):
             'last_incident_year': 2019,
             'last_incident_month': 5,
             'last_incident_day': 5,
-            })
+        })
         self.assertTrue(form.is_valid())
 
 
@@ -554,21 +554,21 @@ class Validation_Form_Tests(TestCase):
         form = When(data={
             'last_incident_month': 5,
             'last_incident_day': 5,
-            })
+        })
         self.assertTrue(f'<ul class="errorlist"><li>Please enter a year' in str(form.errors))
 
     def test_required_month(self):
         form = When(data={
             'last_incident_year': 2019,
             'last_incident_day': 5,
-            })
+        })
         self.assertTrue(f'<ul class="errorlist"><li>Please enter a month' in str(form.errors))
 
     def test_NOT_required_day(self):
         form = When(data={
             'last_incident_year': 2019,
             'last_incident_month': 5,
-            })
+        })
         self.assertTrue(form.is_valid())
 
     def test_future_incident_date(self):
@@ -576,7 +576,7 @@ class Validation_Form_Tests(TestCase):
             'last_incident_year': 2200,
             'last_incident_month': 5,
             'last_incident_day': 5,
-            })
+        })
         self.assertFalse(form.is_valid())
 
     def test_past_incident_date(self):
@@ -584,7 +584,7 @@ class Validation_Form_Tests(TestCase):
             'last_incident_year': 20,
             'last_incident_month': 5,
             'last_incident_day': 5,
-            })
+        })
         self.assertFalse(form.is_valid())
 
 


### PR DESCRIPTION
[Tell DOJ CRT when the discrimination took place#70](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/70)

## What does this change?
- Adds more date validation must be greater than 1900
- Adds date validation tests
### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
