### PR TITLE
Fix When form error message layout

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -430,12 +430,12 @@ class When(ModelForm):
 
         self.fields['last_incident_month'].label = _('Month')
         self.fields['last_incident_month'].error_messages = {
-            'required': _('Please enter a month'),
+            'required': _('Please enter a month.'),
         }
         self.fields['last_incident_day'].label = _('Day')
         self.fields['last_incident_year'].label = _('Year')
         self.fields['last_incident_year'].error_messages = {
-            'required': _('Please enter a year'),
+            'required': _('Please enter a year.'),
         }
 
     def clean(self):
@@ -449,23 +449,23 @@ class When(ModelForm):
             test_date = datetime(year, month, day)
             if test_date > datetime.now():
                 self.add_error('last_incident_year', ValidationError(
-                    _('Date can not be in the future'),
+                    _('Date can not be in the future.'),
                     params={'value': test_date.strftime('%x')},
                 ))
             if year < 100:
                 self.add_error('last_incident_year', ValidationError(
-                    _('Please enter four digits for the year'),
+                    _('Please enter four digits for the year.'),
                     params={'value': test_date.strftime('%x')},
                 ))
             if test_date < datetime(1899, 12, 31):
                 self.add_error('last_incident_year', ValidationError(
-                    _('Date too long ago'),
+                    _('Date too long ago.'),
                     params={'value': test_date.strftime('%x')},
                 ))
         except ValueError:
             # a bit of a catch-all for all the ways people could make bad dates
             self.add_error('last_incident_year', ValidationError(
-                _(f'Invalid date format {month}/{day}/{year}'),
+                _(f'Invalid date format {month}/{day}/{year}.'),
                 params={'value': f'{month}/{day}/{year}'},
             ))
         except KeyError:

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -448,26 +448,26 @@ class When(ModelForm):
             day = cleaned_data['last_incident_day'] or 1
             test_date = datetime(year, month, day)
             if test_date > datetime.now():
-                raise ValidationError(
+                self.add_error('last_incident_year', ValidationError(
                     _('Date can not be in the future'),
                     params={'value': test_date.strftime('%x')},
-                )
+                ))
             if year < 100:
-                raise ValidationError(
+                self.add_error('last_incident_year', ValidationError(
                     _('Please enter four digits for the year'),
                     params={'value': test_date.strftime('%x')},
-                )
+                ))
             if test_date < datetime(1899, 12, 31):
-                raise ValidationError(
+                self.add_error('last_incident_year', ValidationError(
                     _('Date too long ago'),
                     params={'value': test_date.strftime('%x')},
-                )
+                ))
         except ValueError:
             # a bit of a catch-all for all the ways people could make bad dates
-            raise ValidationError(
+            self.add_error('last_incident_year', ValidationError(
                 _(f'Invalid date format {month}/{day}/{year}'),
                 params={'value': f'{month}/{day}/{year}'},
-            )
+            ))
         except KeyError:
             # these will be caught by the built in error validation
             return cleaned_data

--- a/crt_portal/cts_forms/templates/forms/report_date.html
+++ b/crt_portal/cts_forms/templates/forms/report_date.html
@@ -32,17 +32,16 @@
             {{ year }}
           </div>
         </div>
-
-        {% if month.errors %}
-          {% include "forms/snippets/error_alert.html" with errors=month.errors %}
-        {% endif %}
-        {% if day.errors %}
-          {% include "forms/snippets/error_alert.html" with day=state.errors %}
-        {% endif %}
-        {% if year.errors %}
-          {% include "forms/snippets/error_alert.html" with year=state.errors %}
-        {% endif %}
     </div>
+    {% if month.errors %}
+      {% include "forms/snippets/error_alert.html" with errors=month.errors %}
+    {% endif %}
+    {% if day.errors %}
+      {% include "forms/snippets/error_alert.html" with errors=day.errors %}
+    {% endif %}
+    {% if year.errors %}
+      {% include "forms/snippets/error_alert.html" with errors=year.errors %}
+    {% endif %}
   </fieldset>
   {% endwith %}
 {% endblock %}

--- a/pa11y_scripts/.pa11y-ci-p4-date-errors.json
+++ b/pa11y_scripts/.pa11y-ci-p4-date-errors.json
@@ -1,0 +1,37 @@
+{
+  "urls": [
+    {
+      "url": "http://127.0.0.1:8000/report",
+      "actions": [
+          "wait for element #id_0-contact_phone to be visible",
+          "click element #submit-next",
+          "wait for element #id_1-primary_complaint to be visible",
+          "click element #id_1-primary_complaint_0",
+          "click element #submit-next",
+          "wait for element #id_3-public_or_private_employer_0 to be visible",
+          "click element #id_3-public_or_private_employer_0",
+          "click element #id_3-employer_size_0",
+          "set field #id_3-location_name to Store",
+          "set field #id_3-location_city_town to Town",
+          "set field #id_3-location_state_0 to AL",
+          "click element #submit-next",
+          "wait for element #id_6-protected_class_0 to be visible",
+          "click element #id_6-protected_class_0",
+          "click element #submit-next",
+          "wait for element #id_7-last_incident_month to be visible",
+          "click element #submit_next",
+          "wait for element #page-errors to be visible",
+          "set field #id_7-last_incident_month to 1",
+          "click element #submit_next",
+          "wait for element #page-errors to be visible",
+          "set field #id_7-last_incident_year to 2021",
+          "click element #submit_next",
+          "wait for element #page-errors to be visible",
+          "set field #id_7-last_incident_year to 2019",
+          "click element #submit_next",
+          "wait for element #id_8-violation_summary to be visible"
+      ],
+      "screenCapture": "pa11y-screenshots/page4-date-error.png"
+    }
+  ]
+}


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/271)

## What does this change?

 This PR changes the HTML structure a bit for the `report_date` form to fix error layout issues.

* Renames a misnamed variable being passed to `day` and `year` error messages
* Adds a pa11y sanity test to ensure error messages are displayed
*  Keys the generic errors to the `last_incident_year` so the form-level error messages appear beneath the form. This choice was arbitrary and could be any field! I'm also open to changing this to some kind of virtual error if `django` offers that behavior.

## Screenshots (for front-end PR):

**UPDATE**: Messages now feature periods!
<img width="581" alt="Screen Shot 2020-01-21 at 1 43 35 PM" src="https://user-images.githubusercontent.com/1421848/72845726-1b3b1e00-3c54-11ea-90b9-cf4b64005afa.png">



![Screen Shot 2020-01-21 at 12 24 57 PM](https://user-images.githubusercontent.com/1421848/72841211-c941ca80-3c4a-11ea-8636-66eecbe96725.png)

![Screen Shot 2020-01-21 at 12 25 13 PM](https://user-images.githubusercontent.com/1421848/72841224-cc3cbb00-3c4a-11ea-97c5-ec64a0aa0dce.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
