### PR TITLE
Removing autocomplete off warning form local and testing environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ For more technical documentation see the [docs](https://github.com/usdoj-crt/crt
 
 ### Adjust form autocomplete per-instance
 
-To prevent form autocomplete on an application instance, add `FORM_AUTOCOMPLETE_OFF=True` as an environment variable (locally, add to `.env`).
+To prevent form autocomplete on an application instance, add `FORM_AUTOCOMPLETE_OFF=True` as an environment variable. We are using that in staging to help mask personal data during usability testing.
 
 To restore default behavior of allowing form autocomplete, remove the `FORM_AUTOCOMPLETE_OFF` flag.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - ENV=LOCAL
       - SECRET_KEY=${SECRET_KEY}
-      - FORM_AUTOCOMPLETE_OFF=${FORM_AUTOCOMPLETE_OFF}
+      - FORM_AUTOCOMPLETE_OFF=False
     build: .
     command: /code/run.sh
     volumes:


### PR DESCRIPTION
Autocomplte off is expected behavior for every environment except staging. 

[Link to ZenHub issue.](link-goes-here)

## What does this change?

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
