### PR TITLE
Updates other toggle js to work with radio buttons

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_class.html
+++ b/crt_portal/cts_forms/templates/forms/report_class.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% block form_questions %}
 
+<div data-toggle>
 {% include 'forms/grouped_questions.html' %}
 {% with field=wizard.form.other_class %}
   <div class='other-class-option' class="padding-left-4">
@@ -16,7 +17,7 @@
     </div>
   </div>
 {% endwith %}
-</fieldset>
+</div>
 
 <div class="margin-bottom-5"></div>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_commercial_public_location.html
+++ b/crt_portal/cts_forms/templates/forms/report_commercial_public_location.html
@@ -5,7 +5,7 @@
   <legend class="em-text">
     {% trans "Please choose the location that best describes your situation" %}
   </legend>
-  <div>
+  <div data-toggle>
     {{ form.commercial_or_public_place }}
     {% with field=form.other_commercial_or_public_place %}    
     <div class='other-class-option padding-top-1'>

--- a/crt_portal/static/js/other_show_hide.js
+++ b/crt_portal/static/js/other_show_hide.js
@@ -1,29 +1,44 @@
-(function(root) {
+(function(root, dom) {
   root.CRT = root.CRT || {};
+
+  function doToggle(predicate, target) {
+    if (predicate) {
+      target.removeAttribute('hidden');
+    } else {
+      target.setAttribute('hidden', '');
+    }
+  }
+
   root.CRT.otherTextInputToggle = function toggleTextInput(selector, index) {
+    var parentEl = dom.querySelector('[data-toggle]');
     var selector = selector || '.usa-checkbox';
-    var dom = root.document;
-    var options = dom.querySelectorAll(selector);
+    var options = parentEl.querySelectorAll(selector);
     var index = index || options.length - 1;
 
-    // Wapper element for the 'other' option checkbox
+    // Wapper element for the 'other' option form control
     var otherOptionEl = options[index];
-    // The actual checkbox the user will interact with
-    var otherOptionCheckbox = otherOptionEl.querySelector('[class$="__input"]');
+    // The actual checkbox or radio button the user will interact with
+    var otherOptionFormEl = otherOptionEl.querySelector('[class$="__input"]');
     // Wrapper element for the short text description revealed when the 'other' option is selected
-    var otherOptionTextEl = dom.querySelector('.other-class-option');
+    var otherOptionTextEl = parentEl.querySelector('.other-class-option');
 
-    function toggleOtherOptionTextInput() {
-      if (otherOptionCheckbox.checked) {
-        otherOptionTextEl.removeAttribute('hidden');
-      } else {
-        otherOptionTextEl.setAttribute('hidden', '');
+    function toggleOtherOptionTextInput(event) {
+      var target = event.target;
+
+      if (target.nodeName !== 'INPUT') {
+        return;
+      }
+
+      if (target.type === 'checkbox') {
+        doToggle(otherOptionFormEl.checked, otherOptionTextEl);
+      } else if (target.type === 'radio') {
+        doToggle(target === otherOptionFormEl, otherOptionTextEl);
       }
     }
 
-    otherOptionCheckbox.addEventListener('click', toggleOtherOptionTextInput);
+    parentEl.addEventListener('click', toggleOtherOptionTextInput);
     otherOptionTextEl.setAttribute('hidden', '');
   };
 
   return root;
-})(window);
+})(window, document);


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/274)

## What does this change?

The adds additional functionality to the `other_show_hide` js to handle radio button behavior! See the handy GIF below 👇 

## Screenshots (for front-end PR):

![othertoggle](https://user-images.githubusercontent.com/1421848/72942610-bdc4d100-3d28-11ea-9a67-9e5c758260f0.gif)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
