### PR TITLE
Adding Housing routing

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -162,5 +162,8 @@ class Report(models.Model):
         elif self.primary_complaint == 'commercial_or_public':
             if ('Disability (including temporary or recovery)' not in protected_classes) and (self.commercial_or_public_place != 'healthcare'):
                 return 'HCE'
+        elif self.primary_complaint == 'housing':
+            if 'Disability (including temporary or recovery)' not in protected_classes:
+                return 'HCE'
 
         return 'ADM'

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -159,5 +159,8 @@ class Report(models.Model):
                 return 'IER'
             elif 'Disability (including temporary or recovery)' not in protected_classes:
                 return 'ELS'
+        elif self.primary_complaint == 'commercial_or_public':
+            if ('Disability (including temporary or recovery)' not in protected_classes) and (self.commercial_or_public_place != 'healthcare'):
+                return 'HCE'
 
         return 'ADM'

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -336,6 +336,13 @@ class SectionAssignmentTests(TestCase):
         print(test_report.assign_section())
         self.assertTrue(test_report.assign_section() == 'HCE')
 
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'housing'
+        test_report = Report.objects.create(**data)
+        print(SAMPLE_REPORT)
+        print(test_report.assign_section())
+        self.assertTrue(test_report.assign_section() == 'HCE')
+
     def test_housing_excepetions(self):
         data = copy.deepcopy(SAMPLE_REPORT)
         data['primary_complaint'] = 'commercial_or_public'

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -320,6 +320,23 @@ class SectionAssignmentTests(TestCase):
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'ADM')
 
+    def test_housing_routing(self):
+        SAMPLE_REPORT['primary_complaint'] = 'commercial_or_public'
+        test_report = Report.objects.create(**SAMPLE_REPORT)
+        self.assertTrue(test_report.assign_section() == 'HCE')
+
+    def test_housing_excepetions(self):
+        SAMPLE_REPORT['primary_complaint'] = 'commercial_or_public'
+        SAMPLE_REPORT['commercial_or_public_place'] = 'healthcare'
+        test_report = Report.objects.create(**SAMPLE_REPORT)
+        self.assertFalse(test_report.assign_section() == 'HCE')
+
+        test_report2 = Report.objects.create(**SAMPLE_REPORT)
+        disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
+        test_report2.protected_class.add(disability[0])
+        test_report2.save()
+        self.assertFalse(test_report.assign_section() == 'HCE')
+
 
 class Valid_CRT_Pagnation_Tests(TestCase):
     def setUp(self):

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -238,7 +238,9 @@ class Complaint_Show_View_Valid(TestCase):
 class SectionAssignmentTests(TestCase):
     def test_crm_humantrafficking_routing(self):
         # All human trafficking goes to CRM.
-        SAMPLE_REPORT['primary_complaint'] = 'voting'
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'voting'
+        test_report = Report.objects.create(**data)
         test_report = Report.objects.create(**SAMPLE_REPORT)
         human_trafficking = HateCrimesandTrafficking.objects.get_or_create(hatecrimes_trafficking_option='Coerced or forced to do work or perform a commercial sex act')
         test_report.hatecrimes_trafficking.add(human_trafficking[0])
@@ -247,7 +249,9 @@ class SectionAssignmentTests(TestCase):
 
     def test_crm_hatecrime(self):
         # All hate crime goes to CRM.
-        SAMPLE_REPORT['primary_complaint'] = 'voting'
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'voting'
+        test_report = Report.objects.create(**data)
         test_report = Report.objects.create(**SAMPLE_REPORT)
         disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
         test_report.protected_class.add(disability[0])
@@ -257,8 +261,9 @@ class SectionAssignmentTests(TestCase):
         self.assertTrue(test_report.assign_section() == 'CRM')
 
     def test_no_hatecrime_trafficking(self):
-        SAMPLE_REPORT['primary_complaint'] = 'voting'
-        test_report = Report.objects.create(**SAMPLE_REPORT)
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'voting'
+        test_report = Report.objects.create(**data)
         disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
         test_report.protected_class.add(disability[0])
         test_report.save()
@@ -267,16 +272,18 @@ class SectionAssignmentTests(TestCase):
     def test_voting_primary_complaint(self):
         # Unless a protected class of disability is selected, reports
         # with a primary complaint of voting should be assigned to voting.
-        SAMPLE_REPORT['primary_complaint'] = 'voting'
-        test_report = Report.objects.create(**SAMPLE_REPORT)
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'voting'
+        test_report = Report.objects.create(**data)
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'VOT')
 
     def test_voting_disability_exception(self):
         # Reports with a primary complaint of voting and protected class of disability
         # should not be assigned to voting.
-        SAMPLE_REPORT['primary_complaint'] = 'voting'
-        test_report = Report.objects.create(**SAMPLE_REPORT)
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'voting'
+        test_report = Report.objects.create(**data)
         disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
         test_report.protected_class.add(disability[0])
         test_report.save()
@@ -285,8 +292,9 @@ class SectionAssignmentTests(TestCase):
 
     def test_workplace_primary_complaint_exception(self):
         # Workplace discrimination complaints are routed to ELS by default
-        SAMPLE_REPORT['primary_complaint'] = 'workplace'
-        test_report = Report.objects.create(**SAMPLE_REPORT)
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'workplace'
+        test_report = Report.objects.create(**data)
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'ELS')
 
@@ -321,14 +329,18 @@ class SectionAssignmentTests(TestCase):
         self.assertTrue(test_report.assign_section() == 'ADM')
 
     def test_housing_routing(self):
-        SAMPLE_REPORT['primary_complaint'] = 'commercial_or_public'
-        test_report = Report.objects.create(**SAMPLE_REPORT)
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'commercial_or_public'
+        test_report = Report.objects.create(**data)
+        print(SAMPLE_REPORT)
+        print(test_report.assign_section())
         self.assertTrue(test_report.assign_section() == 'HCE')
 
     def test_housing_excepetions(self):
-        SAMPLE_REPORT['primary_complaint'] = 'commercial_or_public'
-        SAMPLE_REPORT['commercial_or_public_place'] = 'healthcare'
-        test_report = Report.objects.create(**SAMPLE_REPORT)
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'commercial_or_public'
+        data['commercial_or_public_place'] = 'healthcare'
+        test_report = Report.objects.create(**data)
         self.assertFalse(test_report.assign_section() == 'HCE')
 
         test_report2 = Report.objects.create(**SAMPLE_REPORT)


### PR DESCRIPTION
[HCE routing#76](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/76)

## What does this change?
Adds the routing for housing  with test case and updated output script
## Screenshots (for front-end PR):
Updated section output from script here: https://docs.google.com/spreadsheets/d/1Ba0617v1wqwf89vYkCQmpNGmi3yI-bfPgXSF8JPqkeQ/edit#gid=662580086
## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
