### PR TITLE
Adds service member status to complaint show view

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -48,7 +48,7 @@
         </td>
       </tr>
       <tr>
-        <th>Protected class</th>
+        <th>Reported reason</th>
         <td>
           {% for p_class in p_class_list %}
             {% if not forloop.last %}
@@ -62,6 +62,10 @@
             Other: {{data.other_class}}
           {% endif %}
         </td>
+      </tr>
+      <tr>
+        <th>Service Member</th>
+        <td>{{data.servicemember|title|default:"—"}}</td>
       </tr>
     </tr>
   </table>


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/251)

## What does this change?

* I also added a default of '—', which we shouldn't ever see, but it will at least keep the formatting consistent in case of a malformed datum.

## Screenshots (for front-end PR):

![Screen Shot 2020-01-23 at 12 00 00 PM](https://user-images.githubusercontent.com/1421848/73019158-ea83f180-3dd7-11ea-8fe5-a208d1e03745.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
