### PR TITLE
Adds prison location to relevant details

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -410,9 +410,10 @@ class PoliceLocation(LocationForm):
         inside_facility = self.cleaned_data.get('inside_correctional_facility')
         facility_type = self.cleaned_data.get('correctional_facility_type')
 
-        if inside_facility == 'inside' and facility_type is None:
-            msg = ValidationError(POLICE_LOCATION_ERRORS['facility_type'])
-            self.add_error('correctional_facility_type', msg)
+        if inside_facility == 'inside':
+            if facility_type is None:
+                msg = ValidationError(POLICE_LOCATION_ERRORS['facility_type'])
+                self.add_error('correctional_facility_type', msg)
         else:
             self.cleaned_data['correctional_facility_type'] = None
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -414,7 +414,8 @@ class PoliceLocation(LocationForm):
             if facility_type is None:
                 msg = ValidationError(POLICE_LOCATION_ERRORS['facility_type'])
                 self.add_error('correctional_facility_type', msg)
-        else:
+
+        if inside_facility == 'outside':
             self.cleaned_data['correctional_facility_type'] = None
 
         return self.cleaned_data

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -411,7 +411,7 @@ class PoliceLocation(LocationForm):
         facility_type = self.cleaned_data.get('correctional_facility_type')
 
         if inside_facility == 'inside':
-            if facility_type is None:
+            if bool(facility_type) is False:
                 msg = ValidationError(POLICE_LOCATION_ERRORS['facility_type'])
                 self.add_error('correctional_facility_type', msg)
 

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -191,6 +191,14 @@ CORRECTIONAL_FACILITY_LOCATION_TYPE_CHOICES = (
     ('not_sure', _('I\'m not sure'))
 )
 
+CORRECTIONAL_FACILITY_FRIENDLY_TEXT = {
+    'outside': _('Outside of prison'),
+    'state_local': 'Prison (State/local)',
+    'federal': _('Prison (Federal)'),
+    'private': _('Prison (Private)'),
+    'not_sure': _('Prison (I\'m not sure)'),
+}
+
 PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES = (
     ('public_employer', _('Public employer')),
     ('private_employer', _('Private employer')),

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -1,4 +1,5 @@
 {% load commercial_public_space_view %}
+{% load correctional_facility_view %}
 
 <div class="complaint-card complaint-card--rounded">
   <h3 class="complaint-card-heading text-uppercase">Complaint details</h3>
@@ -35,6 +36,8 @@
             Election type (federal/local): {{ data.election_details }}
           {% elif data.commercial_or_public_place %}
             {% render_commercial_public_space_view data.commercial_or_public_place data.other_commercial_or_public_place %}
+          {% elif data.inside_correctional_facility %}
+            {% render_correctional_facility_view data.inside_correctional_facility data.correctional_facility_type %}
           {% else %}
             —
           {% endif %}

--- a/crt_portal/cts_forms/templates/forms/snippets/correctional_facility_view.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/correctional_facility_view.html
@@ -1,0 +1,1 @@
+Location: {{ location_type }}

--- a/crt_portal/cts_forms/templatetags/correctional_facility_view.py
+++ b/crt_portal/cts_forms/templatetags/correctional_facility_view.py
@@ -1,0 +1,18 @@
+from django import template
+from ..model_variables import CORRECTIONAL_FACILITY_FRIENDLY_TEXT
+
+
+register = template.Library()
+
+
+@register.inclusion_tag('forms/snippets/correctional_facility_view.html')
+def render_correctional_facility_view(facility, facility_type):
+    print(facility_type)
+    if facility == 'outside':
+        location_type = CORRECTIONAL_FACILITY_FRIENDLY_TEXT.get(facility, '—')
+    else:
+        location_type = CORRECTIONAL_FACILITY_FRIENDLY_TEXT.get(facility_type, '—')
+
+    return {
+        'location_type': location_type
+    }

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -691,7 +691,6 @@ class Validation_Form_Tests(TestCase):
         form = PoliceLocation(data=location_data)
         self.assertTrue(form.is_valid())
 
-
         location_data.update({
             'inside_correctional_facility': 'inside',
             'correctional_facility_type': None

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -31,6 +31,7 @@ from .forms import (
     PrimaryReason,
     CommercialPublicLocation,
     EducationLocation,
+    PoliceLocation,
     When,
 )
 from .test_data import SAMPLE_REPORT
@@ -669,6 +670,40 @@ class Validation_Form_Tests(TestCase):
             'other_commercial_or_public_place': 'Home'
         })
         form = CommercialPublicLocation(data=location_data)
+        self.assertTrue(form.is_valid())
+
+    def test_correctional_facility(self):
+        location_data = {
+            'location_name': 'Street',
+            'location_city_town': 'Nome',
+            'location_state': 'AK',
+        }
+
+        location_data.update({
+            'inside_correctional_facility': ''
+        })
+        form = PoliceLocation(data=location_data)
+        self.assertFalse(form.is_valid())
+
+        location_data.update({
+            'inside_correctional_facility': 'outside'
+        })
+        form = PoliceLocation(data=location_data)
+        self.assertTrue(form.is_valid())
+
+
+        location_data.update({
+            'inside_correctional_facility': 'inside',
+            'correctional_facility_type': None
+        })
+        form = PoliceLocation(data=location_data)
+        self.assertFalse(form.is_valid())
+
+        location_data.update({
+            'inside_correctional_facility': 'inside',
+            'correctional_facility_type': 'state_local'
+        })
+        form = PoliceLocation(data=location_data)
         self.assertTrue(form.is_valid())
 
     def test_education_location(self):

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -76,5 +76,11 @@ $complaint-body-offset: calc(
       border-top: 0;
       padding-bottom: 0;
     }
+
+    tr:last-child {
+      th, td {
+        border: none;
+      }
+    }
   }
 }


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

* Displays when user's primary concern is mistreatment by law enforcement
* Fixes bug in logic where facility_type was always getting set to None

## Screenshots (for front-end PR):
<img width="577" alt="Screen Shot 2020-01-23 at 4 47 23 PM" src="https://user-images.githubusercontent.com/1421848/73036340-1e730d00-3e00-11ea-9b81-1edd38094b1a.png">

<img width="573" alt="Screen Shot 2020-01-23 at 4 48 26 PM" src="https://user-images.githubusercontent.com/1421848/73036372-39de1800-3e00-11ea-8cc0-b016b3eace16.png">







## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
