### PR TITLE
Route education complaints to EOS

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -167,5 +167,10 @@ class Report(models.Model):
         elif self.primary_complaint == 'housing':
             if 'Disability (including temporary or recovery)' not in protected_classes:
                 return 'HCE'
+        elif self.primary_complaint == 'education':
+            if self.public_or_private_school == 'public':
+                return 'EOS'
+            elif 'Disability (including temporary or recovery)' not in protected_classes:
+                return 'EOS'
 
         return 'ADM'

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -357,6 +357,24 @@ class SectionAssignmentTests(TestCase):
         test_report2.save()
         self.assertFalse(test_report.assign_section() == 'HCE')
 
+    def test_education_routing(self):
+        disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
+
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'education'
+        data['public_or_private_school'] = 'public'
+        test_report = Report.objects.create(**data)
+        self.assertTrue(test_report.assign_section() == 'EOS')
+
+        test_report.public_or_private_school = 'private'
+        test_report.save()
+        self.assertTrue(test_report.assign_section() == 'EOS')
+
+        test_report.protected_class.add(disability[0])
+        test_report.save()
+        self.assertFalse(test_report.assign_section() == 'EOS')
+        self.assertTrue(test_report.assign_section() == 'ADM')
+
 
 class Valid_CRT_Pagnation_Tests(TestCase):
     def setUp(self):


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/75)

## What does this change?

* Education complaints will now route to EOS, when applicable
* Does not route to DRS yet, that functionality is out of scope for this work

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
