### PR TITLE
Display a dropdown with each section in the complaint show view

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -6,7 +6,7 @@ from django.forms import ModelForm, CheckboxInput, ChoiceField, TypedChoiceField
 from django.utils.translation import gettext_lazy as _
 
 from .question_group import QuestionGroup
-from .widgets import UsaRadioSelect, UsaCheckboxSelectMultiple, CrtRadioArea, CrtDropdown, CrtMultiSelect
+from .widgets import UsaRadioSelect, UsaCheckboxSelectMultiple, CrtRadioArea, CrtDropdown, CrtMultiSelect, ComplaintSelect
 from .models import Report, ProtectedClass, HateCrimesandTrafficking
 from .model_variables import (
     ELECTION_CHOICES,
@@ -614,3 +614,18 @@ class Filters(ModelForm):
 
         self.fields['location_state'].label = _('State')
         self.fields['location_state'].widget.attrs['list'] = 'states'
+
+
+class ComplaintActions(ModelForm):
+    class Meta:
+        model = Report
+        fields = ['assigned_section']
+
+    def __init__(self, *args, **kwargs):
+        ModelForm.__init__(self, *args, **kwargs)
+
+        self.fields['assigned_section'] = ChoiceField(
+            widget=ComplaintSelect,
+            choices=SECTION_CHOICES,
+            required=False
+        )

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -1,0 +1,12 @@
+<div class="complaint-card complaint-card--rounded">
+  <form
+    id="complaint-view-actions"
+    class="usa-form"
+    novalidate
+  >
+    <fieldset class="usa-fieldset usa-prose">
+      <legend class="usa-sr-only">Complaint detail view actions</legend>
+      {{ actions.assigned_section }}
+    </fieldset>
+  </form>
+</div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -44,7 +44,10 @@
     <div class="complaint-body">
       <div class="grid-container">
         <div class="grid-row grid-gap-md">
-          <div class="tablet:grid-col-8 grid-offset-2">
+          <div class="tablet:grid-col-4">
+            {% include 'forms/complaint_view/show/actions.html' %}
+          </div>
+          <div class="tablet:grid-col-8">
             {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}
             {% include 'forms/complaint_view/show/complaint_details.html' with data=data primaty_complaint=primary_complaint %}
             {% include 'forms/complaint_view/show/full_summary.html' with summary=data.violation_summary %}

--- a/crt_portal/cts_forms/templates/forms/widgets/complaint_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/complaint_select.html
@@ -1,0 +1,10 @@
+<label for="{{widget.attrs.id}}" class="text-uppercase text-bold">
+  Section
+</label>
+<select id="{{widget.attrs.id}}" name="{{widget.name}}" class="usa-select text-bold">
+  {% for group_name, group_choices, group_index in widget.optgroups %}
+    {% for option in group_choices %}
+      {% include option.template_name with option=option %}
+    {% endfor %}
+  {% endfor %}
+</select>

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -15,7 +15,7 @@ from .models import Report, ProtectedClass, HateCrimesandTrafficking
 from .model_variables import PROTECTED_CLASS_CODES, PRIMARY_COMPLAINT_CHOICES, HATE_CRIMES_TRAFFICKING_MODEL_CHOICES
 from .page_through import pagination
 from .filters import report_filter
-from .forms import Filters
+from .forms import Filters, ComplaintActions
 
 SORT_DESC_CHAR = '-'
 
@@ -125,6 +125,9 @@ def ShowView(request, id):
     )
 
     output = {
+        'actions': ComplaintActions(initial={
+            'assigned_section': report.assigned_section
+        }),
         'crimes': crimes,
         'data': report,
         'p_class_list': p_class_list,

--- a/crt_portal/cts_forms/widgets.py
+++ b/crt_portal/cts_forms/widgets.py
@@ -18,6 +18,12 @@ class CrtDropdown(ChoiceWidget):
     template_name = '../templates/forms/widgets/crt_dropdown.html'
 
 
+class ComplaintSelect(ChoiceWidget):
+    input_type = 'select'
+    template_name = '../templates/forms/widgets/complaint_select.html'
+    option_template_name = '../templates/forms/widgets/multi_select_option.html'
+
+
 class CrtMultiSelect(SelectMultiple):
     template_name = '../templates/forms/widgets/multi_select.html'
     option_template_name = '../templates/forms/widgets/multi_select_option.html'


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/249)

## What does this change?

Adds `assigned section` dropdown.

* Current section routing will be selected.
* Dropdown won't allow user to make changes at this point in time

## Screenshots (for front-end PR):
![Screen Shot 2020-01-27 at 12 56 59 PM](https://user-images.githubusercontent.com/1421848/73213484-22a37100-4105-11ea-89f2-c13dd99a3a88.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
