### PR TITLE
edited css for details tell us what happened html

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_details.html
+++ b/crt_portal/cts_forms/templates/forms/report_details.html
@@ -1,7 +1,26 @@
 {% extends "forms/report_base.html" %}
 {% block form_questions %}
   {% for field in wizard.form.visible_fields %}
-    {% include "forms/snippets/input.html" with field=field ally_id="details-help-text" %}
+
+    <div class="margin-bottom-2">
+	  <label
+	    for="{{ field.id_for_label }}"
+	    class="{{label_class}} margin-bottom-0"
+	  >
+	    <span class="em-text display-block margin-bottom-1">{{ field.label }}</span>
+		{% if field.help_text %}
+		  <em>{{ field.help_text }}</em>
+		{% endif %}
+	  </label>
+
+	</div>
+	<div class="margin-bottom-4">
+	  {{ field }}
+	  {% if field.errors %}
+	    {% include "forms/snippets/error_alert.html" with errors=field.errors %}
+	  {% endif %}
+	</div>
+
     {% include "forms/word_counter.html" with word_limit=500 %}
   {% endfor %}
 {% endblock %}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/268)

## What does this change?
- moved help text into the label to make a11y read properly.
- changed label formatting. made it blue/bold and edited the margins surrounding.

## Screenshots (for front-end PR):
![Screen Shot 2020-01-28 at 2 56 33 PM](https://user-images.githubusercontent.com/49283049/73300210-a1b8a800-41de-11ea-8a80-f2e840a4af85.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
