### PR TITLE
Display school type when user indicates discrimination at school

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -38,6 +38,8 @@
             {% render_commercial_public_space_view data.commercial_or_public_place data.other_commercial_or_public_place %}
           {% elif data.inside_correctional_facility %}
             {% render_correctional_facility_view data.inside_correctional_facility data.correctional_facility_type %}
+          {% elif data.public_or_private_school %}
+            School type: {% if data.public_or_private_school == 'not_sure' %} Not sure {% else %} {{ data.public_or_private_school|title }} {% endif %}
           {% else %}
             —
           {% endif %}


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/273)

## What does this change?

* School type will now display under `Relevant Details` when the complainant has alleged discrimination at a school.

## Screenshots (for front-end PR):

![Screen Shot 2020-01-29 at 10 18 16 AM](https://user-images.githubusercontent.com/1421848/73384832-e72db180-4280-11ea-959a-b207bff3c897.png)
![Screen Shot 2020-01-29 at 10 17 12 AM](https://user-images.githubusercontent.com/1421848/73384838-e8f77500-4280-11ea-9590-e2baebd73a18.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
