### PR TITLE
Adds status select field to complaint detail view

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -32,6 +32,7 @@ from .model_variables import (
     COMMERCIAL_OR_PUBLIC_PLACE_CHOICES,
     COMMERCIAL_OR_PUBLIC_PLACE_HELP_TEXT,
     PUBLIC_OR_PRIVATE_SCHOOL_CHOICES,
+    STATUS_CHOICES,
 )
 from .phone_regex import phone_validation_regex
 
@@ -621,7 +622,7 @@ class Filters(ModelForm):
 class ComplaintActions(ModelForm):
     class Meta:
         model = Report
-        fields = ['assigned_section']
+        fields = ['assigned_section', 'status']
 
     def __init__(self, *args, **kwargs):
         ModelForm.__init__(self, *args, **kwargs)
@@ -631,3 +632,22 @@ class ComplaintActions(ModelForm):
             choices=SECTION_CHOICES,
             required=False
         )
+
+        self.fields['status'] = ChoiceField(
+            widget=ComplaintSelect(label='Status'),
+            choices=self.__format_status_choices(),
+            required=False
+        )
+
+        self.fields['assigned_section'].widget.label = 'Section'
+        self.fields['status'].widget.label = 'Status'
+
+    def __format_status_choices(self):
+        formatted_status_choices = ()
+
+        for name, choice in STATUS_CHOICES:
+            print(name, choice)
+            formatted_choice = (name.capitalize(), choice)
+            formatted_status_choices = formatted_status_choices + (formatted_choice, )
+
+        return formatted_status_choices

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -601,7 +601,9 @@ class Filters(ModelForm):
 
         self.fields['assigned_section'] = MultipleChoiceField(
             choices=SECTION_CHOICES,
-            widget=CrtMultiSelect,
+            widget=CrtMultiSelect(attrs={
+                'classes': 'text-uppercase'
+            }),
             required=False
         )
         self.fields['location_state'] = ChoiceField(
@@ -628,26 +630,15 @@ class ComplaintActions(ModelForm):
         ModelForm.__init__(self, *args, **kwargs)
 
         self.fields['assigned_section'] = ChoiceField(
-            widget=ComplaintSelect,
+            widget=ComplaintSelect(label='Section', attrs={
+                'classes': 'text-uppercase'
+            }),
             choices=SECTION_CHOICES,
             required=False
         )
 
         self.fields['status'] = ChoiceField(
             widget=ComplaintSelect(label='Status'),
-            choices=self.__format_status_choices(),
+            choices=STATUS_CHOICES,
             required=False
         )
-
-        self.fields['assigned_section'].widget.label = 'Section'
-        self.fields['status'].widget.label = 'Status'
-
-    def __format_status_choices(self):
-        formatted_status_choices = ()
-
-        for name, choice in STATUS_CHOICES:
-            print(name, choice)
-            formatted_choice = (name.capitalize(), choice)
-            formatted_status_choices = formatted_status_choices + (formatted_choice, )
-
-        return formatted_status_choices

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -7,6 +7,7 @@
     <fieldset class="usa-fieldset usa-prose">
       <legend class="usa-sr-only">Complaint detail view actions</legend>
       {{ actions.assigned_section }}
+      {{ actions.status }}
     </fieldset>
   </form>
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -9,6 +9,7 @@
     {% csrf_token %}
     <fieldset class="usa-fieldset usa-prose">
       <legend class="usa-sr-only">Complaint detail view actions</legend>
+      <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
       <div class="margin-bottom-2">
         {{ actions.assigned_section }}
       </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -2,12 +2,20 @@
   <form
     id="complaint-view-actions"
     class="usa-form"
+    method="post"
+    action="/form/view/{{data.id}}/"
     novalidate
   >
+    {% csrf_token %}
     <fieldset class="usa-fieldset usa-prose">
       <legend class="usa-sr-only">Complaint detail view actions</legend>
-      {{ actions.assigned_section }}
-      {{ actions.status }}
+      <div class="margin-bottom-2">
+        {{ actions.assigned_section }}
+      </div>
+      <div class="margin-bottom-2">
+        {{ actions.status }}
+      </div>
+      <button class="usa-button" type="submit">Apply changes</button>
     </fieldset>
   </form>
 </div>

--- a/crt_portal/cts_forms/templates/forms/widgets/complaint_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/complaint_select.html
@@ -1,5 +1,6 @@
+
 <label for="{{widget.attrs.id}}" class="text-uppercase text-bold">
-  Section
+  {{ label }}
 </label>
 <select id="{{widget.attrs.id}}" name="{{widget.name}}" class="usa-select text-bold">
   {% for group_name, group_choices, group_index in widget.optgroups %}

--- a/crt_portal/cts_forms/templates/forms/widgets/complaint_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/complaint_select.html
@@ -1,8 +1,7 @@
-
 <label for="{{widget.attrs.id}}" class="text-uppercase text-bold">
   {{ label }}
 </label>
-<select id="{{widget.attrs.id}}" name="{{widget.name}}" class="usa-select text-bold">
+<select id="{{widget.attrs.id}}" name="{{widget.name}}" class="usa-select text-bold {{widget.attrs.classes}}">
   {% for group_name, group_choices, group_index in widget.optgroups %}
     {% for option in group_choices %}
       {% include option.template_name with option=option %}

--- a/crt_portal/cts_forms/templates/forms/widgets/multi_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/multi_select.html
@@ -1,4 +1,4 @@
-<select class="complaint-multi-select" multiple name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+<select class="complaint-multi-select {{widget.attrs.classes}}" multiple name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
   {% for group_name, group_choices, group_index in widget.optgroups %}
     {% if group_name %}
       <optgroup label="{{ group_name }}">

--- a/crt_portal/cts_forms/templates/forms/widgets/multi_select_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/multi_select_option.html
@@ -1,3 +1,3 @@
 <option value="{{option.value}}" {% if option.selected is not False %}selected{% endif %}>
-  {{option.value}}
+  {{option.value|title}}
 </option>

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -805,6 +805,39 @@ class ContactValidationTests(TestCase):
             self.assertTrue('contact_phone' in err.message_dict)
 
 
+class Complaint_Update_Tests(TestCase):
+    def setUp(self):
+        test_report = Report.objects.create(**SAMPLE_REPORT)
+        test_report.contact_first_name = 'Foobert'
+        test_report.contact_last_name = 'Bar'
+        test_report.location_city_town = 'Cleveland'
+        test_report.location_state = 'OH'
+        test_report.assigned_section = test_report.assign_section()
+        test_report.status = 'new'
+        test_report.save()
+
+        self.test_report = test_report
+        self.client = Client()
+        # we are not running the tests against the production database, so this shouldn't be producing real users anyway.
+        self.test_pass = secrets.token_hex(32)
+        self.user = User.objects.create_user('DELETE_USER', 'george@thebeatles.com', self.test_pass)
+        self.client.login(username='DELETE_USER', password=self.test_pass)
+
+    def tearDown(self):
+        self.user.delete()
+
+    def test_update_status_property(self):
+        self.assertTrue(self.test_report.status == 'new')
+        response = self.client.post(reverse('crt_forms:crt-forms-show', kwargs={'id': self.test_report.id}), {'status': 'open'})
+        print(response.context)
+        self.assertTrue(response.context['data'].status == 'open')
+
+    def test_update_assigned_section_property(self):
+        response = self.client.post(reverse('crt_forms:crt-forms-show', kwargs={'id': self.test_report.id}), {'assigned_section': 'VOT'})
+
+        self.assertTrue(response.context['data'].assigned_section == 'VOT')
+
+
 class LoginRequiredTests(TestCase):
     """Please add a test for each url that is tied to a view that requires authorization/authentication."""
 

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -4,7 +4,8 @@ from .views import IndexView, ShowView
 
 app_name = 'crt_forms'
 
+
 urlpatterns = [
-    path('view/<int:id>/', ShowView, name='crt-forms-show'),
+    path('view/<int:id>/', ShowView.as_view(), name='crt-forms-show'),
     path('view/', IndexView, name='crt-forms-index'),
 ]

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1,13 +1,15 @@
 import urllib.parse
 import os
 
-from django.shortcuts import render_to_response, get_object_or_404
+from django.shortcuts import render_to_response, render, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.utils.translation import gettext_lazy as _
+from django.utils.decorators import method_decorator
 from django.http import Http404
 from django.core import serializers
 from django.conf import settings
+from django.views.generic import View
 
 from formtools.wizard.views import SessionWizardView
 
@@ -105,42 +107,65 @@ def IndexView(request):
     return render_to_response('forms/complaint_view/index/index.html', final_data)
 
 
-@login_required
-def ShowView(request, id):
-    report = get_object_or_404(Report.objects, id=id)
-    primary_complaint = [choice[1] for choice in PRIMARY_COMPLAINT_CHOICES if choice[0] == report.primary_complaint]
-    crimes = {
-        'physical_harm': False,
-        'trafficking': False
-    }
+class ShowView(View):
+    def __serialize_data(self, request, report_id):
+        report = get_object_or_404(Report.objects, id=report_id)
+        primary_complaint = [choice[1] for choice in PRIMARY_COMPLAINT_CHOICES if choice[0] == report.primary_complaint]
+        crimes = {
+            'physical_harm': False,
+            'trafficking': False
+        }
 
-    for crime in report.hatecrimes_trafficking.all():
-        for choice in HATE_CRIMES_TRAFFICKING_MODEL_CHOICES:
-            if crime.hatecrimes_trafficking_option == choice[1]:
-                crimes[choice[0]] = True
+        for crime in report.hatecrimes_trafficking.all():
+            for choice in HATE_CRIMES_TRAFFICKING_MODEL_CHOICES:
+                if crime.hatecrimes_trafficking_option == choice[1]:
+                    crimes[choice[0]] = True
 
-    p_class_list = format_protected_class(
-        report.protected_class.all().order_by('form_order'),
-        report.other_class,
-    )
+        p_class_list = format_protected_class(
+            report.protected_class.all().order_by('form_order'),
+            report.other_class,
+        )
 
-    output = {
-        'actions': ComplaintActions(initial={
-            'assigned_section': report.assigned_section
-        }),
-        'crimes': crimes,
-        'data': report,
-        'p_class_list': p_class_list,
-        'primary_complaint': primary_complaint,
-        'return_url_args': request.GET.get('next', ''),
-    }
+        output = {
+            'actions': ComplaintActions(initial={
+                'assigned_section': report.assigned_section,
+                'status': report.status
+            }),
+            'crimes': crimes,
+            'data': report,
+            'p_class_list': p_class_list,
+            'primary_complaint': primary_complaint,
+            'return_url_args': request.GET.get('next', ''),
+        }
 
-    if settings.DEBUG:
-        output.update({
-            'debug_data': serializers.serialize('json', [report, ])
-        })
+        if settings.DEBUG:
+            output.update({
+                'debug_data': serializers.serialize('json', [report, ])
+            })
 
-    return render_to_response('forms/complaint_view/show/index.html', output)
+        return output
+
+    @method_decorator(login_required)
+    def dispatch(self, *args, **kwargs):
+        return super().dispatch(*args, **kwargs)
+
+    def get(self, request, id):
+        output = self.__serialize_data(request, id)
+
+        return render(request, 'forms/complaint_view/show/index.html', output)
+
+    def post(self, request, id):
+        record = Report.objects.filter(id=id)
+
+        updates = {}
+        for key, value in request.POST.items():
+            if key != 'csrfmiddlewaretoken':
+                updates[key] = value
+
+        record.update(**updates)
+
+        output = self.__serialize_data(request, id)
+        return render(request, 'forms/complaint_view/show/index.html', output)
 
 
 TEMPLATES = [

--- a/crt_portal/cts_forms/widgets.py
+++ b/crt_portal/cts_forms/widgets.py
@@ -23,6 +23,25 @@ class ComplaintSelect(ChoiceWidget):
     template_name = '../templates/forms/widgets/complaint_select.html'
     option_template_name = '../templates/forms/widgets/multi_select_option.html'
 
+    def __init__(self, *args, **kwargs):
+        label = kwargs.pop('label', None)
+
+        ChoiceWidget.__init__(self, *args, **kwargs)
+
+        self.label = label
+
+    def label_for_widget(self):
+        return self.label
+
+    def render(self, name, value, attrs=None, renderer=None):
+        extra_context = {
+            'label': self.label_for_widget()
+        }
+        context = self.get_context(name, value, attrs)
+        context.update(extra_context)
+
+        return self._render(self.template_name, context, renderer)
+
 
 class CrtMultiSelect(SelectMultiple):
     template_name = '../templates/forms/widgets/multi_select.html'


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/248)

## What does this change?

* Adds `select` element to complaint details view with available `status` values
* Extends ComplaintSelect widget to allow for custom labeling
* Styles will not match mocks yet

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
