### PR TITLE
Adds login required middleware

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -158,6 +158,8 @@ if environment == 'PRODUCTION':
     AUTHENTICATION_BACKENDS = (
         'django_auth_adfs.backend.AdfsAuthCodeBackend',
     )
+    MIDDLEWARE.append('django_auth_adfs.middleware.LoginRequiredMiddleware')
+
     AUTH_CLIENT_ID = vcap['user-provided'][0]['credentials']['AUTH_CLIENT_ID']
     AUTH_SERVER = vcap['user-provided'][0]['credentials']['AUTH_SERVER']
     AUTH_USERNAME_CLAIM = vcap['user-provided'][0]['credentials']['AUTH_USERNAME_CLAIM']


### PR DESCRIPTION
[redirect error for admin sso.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/289)

## What does this change?
Add middleware so that the admin/login and accounts/login go to single sign on

## Checklist:
This is deployed, now you can go to https://crt-portal-django-prod.app.cloud.gov/admin and it redirects to single sign on instead of the Django login page!
### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
