### PR TITLE
Adds extra CRM routing

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -180,5 +180,7 @@ class Report(models.Model):
         elif self.primary_complaint == 'police':
             if self.__is_not_disabled(protected_classes) and self.inside_correctional_facility == 'inside':
                 return 'SPL'
+            if self.__is_not_disabled(protected_classes) and self.inside_correctional_facility == 'outside':
+                return 'CRM'
 
         return 'ADM'

--- a/crt_portal/cts_forms/test_all_section_assignments.py
+++ b/crt_portal/cts_forms/test_all_section_assignments.py
@@ -1,14 +1,15 @@
 """This is not a test yet, it is looping through meaningful permeations of the data and showing the output of the assign section function."""
 import csv
+import copy
 
 from django.test import TestCase
 
 from .models import Report, ProtectedClass, HateCrimesandTrafficking
-from .model_variables import PRIMARY_COMPLAINT_CHOICES, PROTECTED_CLASS_CHOICES, COMMERCIAL_OR_PUBLIC_PLACE_CHOICES
+from .model_variables import PRIMARY_COMPLAINT_CHOICES, PROTECTED_CLASS_CHOICES, COMMERCIAL_OR_PUBLIC_PLACE_CHOICES, CORRECTIONAL_FACILITY_LOCATION_CHOICES, PUBLIC_OR_PRIVATE_SCHOOL_CHOICES
 from .test_data import SAMPLE_REPORT
 
 
-fieldnames = ['section_assignment_actual', 'primary_complaint', 'protected_class', 'hate_crimes_trafficking', 'place']
+fieldnames = ['section_assignment_actual', 'primary_complaint', 'protected_class', 'hate_crimes_trafficking', 'place', 'facility', 'school']
 
 
 class Ultimate_Section_Assignment_Test(TestCase):
@@ -22,24 +23,32 @@ class Ultimate_Section_Assignment_Test(TestCase):
                 'protected_class': 'Protected class',
                 'hate_crimes_trafficking': 'Hate crimes or trafficking',
                 'place': 'Place',
+                'facility': 'Facility',
+                'school': 'School',
             })
             for protected_class in PROTECTED_CLASS_CHOICES:
                 class_object = ProtectedClass.objects.get_or_create(protected_class=protected_class)
                 for primary in PRIMARY_COMPLAINT_CHOICES:
-                    # right now we are not accounting for multiple protected class selections, since we only have routing tied to disability for the moment, we may want to add more permutations as the logic gets more complex.
-                    # create object with required fields
                     SAMPLE_REPORT['primary_complaint'] = primary[0]
-                    test_report = Report.objects.create(**SAMPLE_REPORT)
-                    test_report.protected_class.add(class_object[0])
-                    # without hate crimes
-                    section_no_hc = test_report.assign_section()
-                    writer.writerow({
-                        'section_assignment_actual': section_no_hc,
-                        'primary_complaint': primary[0],
-                        'protected_class': protected_class,
-                        'hate_crimes_trafficking': 'none',
-                        'place': 'n/a',
-                    })
+                    # right now we are not accounting for multiple protected class selections, since we only have routing tied to disability for the moment, we may want to add more permutations as the logic gets more complex.
+
+                    # this is a bisic example, if there is another required question for routing, we don't record this because it can't exist without the required question
+                    if primary[0] not in ['commercial_or_public', 'police', 'education']:
+                        # create object with required fields
+                        test_report = Report.objects.create(**SAMPLE_REPORT)
+                        test_report.protected_class.add(class_object[0])
+                        # without hate crimes
+                        section_no_hc = test_report.assign_section()
+                        writer.writerow({
+                            'section_assignment_actual': section_no_hc,
+                            'primary_complaint': primary[0],
+                            'protected_class': protected_class,
+                            'hate_crimes_trafficking': 'none',
+                            'place': 'n/a',
+                            'facility': 'n/a',
+                            'school': 'n/a',
+                        })
+
                     # hate crime and trafficking example
                     crime_object = HateCrimesandTrafficking.objects.all()
                     test_report.hatecrimes_trafficking.add(crime_object[0])
@@ -52,14 +61,16 @@ class Ultimate_Section_Assignment_Test(TestCase):
                         'protected_class': protected_class,
                         'hate_crimes_trafficking': "hate crimes and trafficking",
                         'place': 'n/a',
+                        'facility': 'n/a',
+                        'school': 'n/a',
                     })
 
                     if primary[0] == 'commercial_or_public':
                         for place in COMMERCIAL_OR_PUBLIC_PLACE_CHOICES:
                             # create object with required fields
-                            SAMPLE_REPORT['primary_complaint'] = primary[0]
-                            SAMPLE_REPORT['commercial_or_public_place'] = place[0]
-                            test_report = Report.objects.create(**SAMPLE_REPORT)
+                            data = copy.deepcopy(SAMPLE_REPORT)
+                            data['commercial_or_public_place'] = place[0]
+                            test_report = Report.objects.create(**data)
                             test_report.protected_class.add(class_object[0])
                             # without hate crimes
                             section_no_hc = test_report.assign_section()
@@ -69,4 +80,38 @@ class Ultimate_Section_Assignment_Test(TestCase):
                                 'protected_class': protected_class,
                                 'hate_crimes_trafficking': 'none',
                                 'place': place[0],
+                                'facility': 'n/a',
+                                'school': 'n/a',
+                            })
+                    if primary[0] == 'police':
+                        for facility in CORRECTIONAL_FACILITY_LOCATION_CHOICES:
+                            data = copy.deepcopy(SAMPLE_REPORT)
+                            data['inside_correctional_facility'] = facility[0]
+                            test_report = Report.objects.create(**data)
+                            test_report.protected_class.add(class_object[0])
+                            section_facility = test_report.assign_section()
+                            writer.writerow({
+                                'section_assignment_actual': section_facility,
+                                'primary_complaint': primary[0],
+                                'protected_class': protected_class,
+                                'hate_crimes_trafficking': 'none',
+                                'place': 'n/a',
+                                'facility': facility[0],
+                                'school': 'n/a',
+                            })
+                    if primary[0] == 'education':
+                        for school in PUBLIC_OR_PRIVATE_SCHOOL_CHOICES:
+                            data = copy.deepcopy(SAMPLE_REPORT)
+                            data['public_or_private_school'] = school[0]
+                            test_report = Report.objects.create(**data)
+                            test_report.protected_class.add(class_object[0])
+                            section_facility = test_report.assign_section()
+                            writer.writerow({
+                                'section_assignment_actual': section_facility,
+                                'primary_complaint': primary[0],
+                                'protected_class': protected_class,
+                                'hate_crimes_trafficking': 'none',
+                                'place': 'n/a',
+                                'facility': 'n/a',
+                                'school': school[0],
                             })

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -243,10 +243,15 @@ class SectionAssignmentTests(TestCase):
         data = copy.deepcopy(SAMPLE_REPORT)
         data['primary_complaint'] = 'voting'
         test_report = Report.objects.create(**data)
-        test_report = Report.objects.create(**SAMPLE_REPORT)
         human_trafficking = HateCrimesandTrafficking.objects.get_or_create(hatecrimes_trafficking_option='Coerced or forced to do work or perform a commercial sex act')
         test_report.hatecrimes_trafficking.add(human_trafficking[0])
         test_report.save()
+        self.assertTrue(test_report.assign_section() == 'CRM')
+
+        data2 = copy.deepcopy(SAMPLE_REPORT)
+        data2['primary_complaint'] = 'police'
+        data2['inside_correctional_facility'] = 'outside'
+        test_report2 = Report.objects.create(**data2)
         self.assertTrue(test_report.assign_section() == 'CRM')
 
     def test_crm_hatecrime(self):

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -248,12 +248,6 @@ class SectionAssignmentTests(TestCase):
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'CRM')
 
-        data2 = copy.deepcopy(SAMPLE_REPORT)
-        data2['primary_complaint'] = 'police'
-        data2['inside_correctional_facility'] = 'outside'
-        test_report2 = Report.objects.create(**data2)
-        self.assertTrue(test_report.assign_section() == 'CRM')
-
     def test_crm_hatecrime(self):
         # All hate crime goes to CRM.
         data = copy.deepcopy(SAMPLE_REPORT)
@@ -265,6 +259,13 @@ class SectionAssignmentTests(TestCase):
         human_trafficking = HateCrimesandTrafficking.objects.get_or_create(hatecrimes_trafficking_option='Physical harm or threats of violence based on race, color, national origin, religion, gender, sexual orientation, gender identity, or disability')
         test_report.hatecrimes_trafficking.add(human_trafficking[0])
         test_report.save()
+        self.assertTrue(test_report.assign_section() == 'CRM')
+
+    def test_police_outside(self):
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'police'
+        data['inside_correctional_facility'] = 'outside'
+        test_report = Report.objects.create(**data)
         self.assertTrue(test_report.assign_section() == 'CRM')
 
     def test_no_hatecrime_trafficking(self):
@@ -295,7 +296,6 @@ class SectionAssignmentTests(TestCase):
         test_report.protected_class.add(disability[0])
         test_report.save()
         self.assertFalse(test_report.assign_section() == 'VOT')
-        self.assertTrue(test_report.assign_section() == 'ADM')
 
     def test_workplace_primary_complaint_exception(self):
         # Workplace discrimination complaints are routed to ELS by default
@@ -333,7 +333,7 @@ class SectionAssignmentTests(TestCase):
         test_report.protected_class.remove(origin[0])
         test_report.protected_class.add(disability[0])
         test_report.save()
-        self.assertTrue(test_report.assign_section() == 'ADM')
+        self.assertTrue(test_report.assign_section() != 'IER')
 
     def test_housing_routing(self):
         data = copy.deepcopy(SAMPLE_REPORT)
@@ -379,7 +379,6 @@ class SectionAssignmentTests(TestCase):
         test_report.protected_class.add(disability[0])
         test_report.save()
         self.assertFalse(test_report.assign_section() == 'EOS')
-        self.assertTrue(test_report.assign_section() == 'ADM')
 
     def test_SPL_routing(self):
         disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
@@ -398,7 +397,7 @@ class SectionAssignmentTests(TestCase):
         test_report.protected_class.remove(disability[0])
         test_report.inside_correctional_facility = 'outside'
         test_report.save()
-        self.assertTrue(test_report.assign_section() == 'ADM')
+        self.assertTrue(test_report.assign_section() != 'SPL')
 
         test_report.primary_complaint = 'commercial_or_public'
         test_report.commercial_or_public_place = 'healthcare'


### PR DESCRIPTION
This was mentioned in [SPL routing](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/92) and I updated the CRM card. 

## What does this change?
routes to CRM in s outside a prison and not disability 
Tests with the school and correctional facility data

Updated the section assignment spreadsheet here:
https://docs.google.com/spreadsheets/d/1Ba0617v1wqwf89vYkCQmpNGmi3yI-bfPgXSF8JPqkeQ/edit#gid=1269745325

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
