### PR TITLE
Add login exempt urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ Please update the [Accounts Spreadsheet](https://docs.google.com/spreadsheets/d/
 
 As we build out the product, we expect to add more granular user roles and permissions.
 
+For production, we use DOJ's Single Sign on for authentication. For the ADFS authentication, you need to make sure that public urls are listed in settings.py in the `AUTH_ADFS` section.
+
+For the dev and staging site, you will want to make sure the `@login_required` decorator are on all views that need authentication.
+
+Setting up single sign on is documented in [docs/maintenance_or_infrequent_tasks](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/maintenance_or_infrequent_tasks.md#single-sign-on).
+
 ### Create and update admin accounts
 
 Need to ssh to create superuser (would like to do this automatically in another PR):

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -158,6 +158,8 @@ if environment == 'PRODUCTION':
     AUTHENTICATION_BACKENDS = (
         'django_auth_adfs.backend.AdfsAuthCodeBackend',
     )
+    MIDDLEWARE.append('django_auth_adfs.middleware.LoginRequiredMiddleware')
+
     AUTH_CLIENT_ID = vcap['user-provided'][0]['credentials']['AUTH_CLIENT_ID']
     AUTH_SERVER = vcap['user-provided'][0]['credentials']['AUTH_SERVER']
     AUTH_USERNAME_CLAIM = vcap['user-provided'][0]['credentials']['AUTH_USERNAME_CLAIM']

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -194,6 +194,10 @@ if environment == 'PRODUCTION':
                           "email": "emailaddress"},
         "USERNAME_CLAIM": AUTH_USERNAME_CLAIM,
         "GROUP_CLAIM": AUTH_GROUP_CLAIM,
+        'LOGIN_EXEMPT_URLS': [
+            '/',
+            'report/',
+        ],
     }
 
     # Configure django to redirect users to the right URL for login


### PR DESCRIPTION
Now that we have middleware going, we need to add public urls to the 'LOGIN_EXEMPT_URLS'

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
