### PR TITLE
Adding routing for DRS with tests

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -157,30 +157,47 @@ class Report(models.Model):
 
         if len(hatecrimes_options) > 0:
             return 'CRM'
-        elif self.primary_complaint == 'voting' and self.__is_not_disabled(protected_classes):
-            return 'VOT'
+
+        elif self.primary_complaint == 'voting':
+            if self.__is_not_disabled(protected_classes):
+                return 'VOT'
+            else:
+                return 'DRS'
+
         elif self.primary_complaint == 'workplace':
             if self.__has_immigration_protected_classes(protected_classes):
                 return 'IER'
-            elif self.__is_not_disabled(protected_classes):
+            else:
                 return 'ELS'
+
         elif self.primary_complaint == 'commercial_or_public':
             if self.commercial_or_public_place == 'healthcare' and self.__is_not_disabled(protected_classes):
                 return 'SPL'
+            elif self.commercial_or_public_place == 'healthcare' and not self.__is_not_disabled(protected_classes):
+                return 'DRS'
             else:
                 return 'HCE'
+
         elif self.primary_complaint == 'housing':
-            if self.__is_not_disabled(protected_classes):
-                return 'HCE'
+            return 'HCE'
+
         elif self.primary_complaint == 'education':
             if self.public_or_private_school == 'public':
                 return 'EOS'
             elif self.__is_not_disabled(protected_classes):
                 return 'EOS'
+            elif self.public_or_private_school == 'private'and not self.__is_not_disabled(protected_classes):
+                return 'DRS'
+
         elif self.primary_complaint == 'police':
             if self.__is_not_disabled(protected_classes) and self.inside_correctional_facility == 'inside':
                 return 'SPL'
-            if self.__is_not_disabled(protected_classes) and self.inside_correctional_facility == 'outside':
+            elif self.__is_not_disabled(protected_classes) and self.inside_correctional_facility == 'outside':
                 return 'CRM'
+            else:
+                return 'DRS'
+
+        elif self.primary_complaint == 'something_else' and not self.__is_not_disabled(protected_classes):
+            return 'DRS'
 
         return 'ADM'

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -171,10 +171,10 @@ class Report(models.Model):
                 return 'ELS'
 
         elif self.primary_complaint == 'commercial_or_public':
-            if self.commercial_or_public_place == 'healthcare' and self.__is_not_disabled(protected_classes):
-                return 'SPL'
-            elif self.commercial_or_public_place == 'healthcare' and not self.__is_not_disabled(protected_classes):
+            if not self.__is_not_disabled(protected_classes):
                 return 'DRS'
+            elif self.commercial_or_public_place == 'healthcare':
+                return 'SPL'
             else:
                 return 'HCE'
 

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -182,7 +182,7 @@ class Report(models.Model):
             return 'HCE'
 
         elif self.primary_complaint == 'education':
-            if self.public_or_private_school == 'public':
+            if self.public_or_private_school == 'public' or self.public_or_private_school == 'not_sure':
                 return 'EOS'
             elif self.__is_not_disabled(protected_classes):
                 return 'EOS'

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -304,7 +304,6 @@ class SectionAssignmentTests(TestCase):
         immigration = ProtectedClass.objects.get_or_create(protected_class='Immigration/citizenship status (choosing this will not share your status)')
         language = ProtectedClass.objects.get_or_create(protected_class='Language')
         origin = ProtectedClass.objects.get_or_create(protected_class='National origin (including ancestry and ethnicity)')
-        disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
 
         SAMPLE_REPORT['primary_complaint'] = 'workplace'
         test_report = Report.objects.create(**SAMPLE_REPORT)

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -238,7 +238,7 @@ class Complaint_Show_View_Valid(TestCase):
 
 
 class SectionAssignmentTests(TestCase):
-    def test_crm_humantrafficking_routing(self):
+    def test_CRM_routing(self):
         # All human trafficking goes to CRM.
         data = copy.deepcopy(SAMPLE_REPORT)
         data['primary_complaint'] = 'voting'
@@ -248,7 +248,6 @@ class SectionAssignmentTests(TestCase):
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'CRM')
 
-    def test_crm_hatecrime(self):
         # All hate crime goes to CRM.
         data = copy.deepcopy(SAMPLE_REPORT)
         data['primary_complaint'] = 'voting'
@@ -261,14 +260,12 @@ class SectionAssignmentTests(TestCase):
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'CRM')
 
-    def test_police_outside(self):
         data = copy.deepcopy(SAMPLE_REPORT)
         data['primary_complaint'] = 'police'
         data['inside_correctional_facility'] = 'outside'
         test_report = Report.objects.create(**data)
         self.assertTrue(test_report.assign_section() == 'CRM')
 
-    def test_no_hatecrime_trafficking(self):
         data = copy.deepcopy(SAMPLE_REPORT)
         data['primary_complaint'] = 'voting'
         test_report = Report.objects.create(**data)
@@ -277,7 +274,7 @@ class SectionAssignmentTests(TestCase):
         test_report.save()
         self.assertTrue(test_report.assign_section() != 'CRM')
 
-    def test_voting_primary_complaint(self):
+    def test_VOT_routing(self):
         # Unless a protected class of disability is selected, reports
         # with a primary complaint of voting should be assigned to voting.
         data = copy.deepcopy(SAMPLE_REPORT)
@@ -286,18 +283,7 @@ class SectionAssignmentTests(TestCase):
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'VOT')
 
-    def test_voting_disability_exception(self):
-        # Reports with a primary complaint of voting and protected class of disability
-        # should not be assigned to voting.
-        data = copy.deepcopy(SAMPLE_REPORT)
-        data['primary_complaint'] = 'voting'
-        test_report = Report.objects.create(**data)
-        disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
-        test_report.protected_class.add(disability[0])
-        test_report.save()
-        self.assertTrue(test_report.assign_section() == 'DRS')
-
-    def test_workplace_primary_complaint_exception(self):
+    def test_ELS_routing(self):
         # Workplace discrimination complaints are routed to ELS by default
         data = copy.deepcopy(SAMPLE_REPORT)
         data['primary_complaint'] = 'workplace'
@@ -305,7 +291,14 @@ class SectionAssignmentTests(TestCase):
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'ELS')
 
-    def test_workplace_primary_complaint_routing(self):
+        data = copy.deepcopy(SAMPLE_REPORT)
+        SAMPLE_REPORT['primary_complaint'] = 'workplace'
+        disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
+        test_report.protected_class.add(disability[0])
+        test_report.save()
+        self.assertTrue(test_report.assign_section() == 'ELS')
+
+    def test_IER_routing(self):
         # If the report contains any of the first three Protected Classes here,
         # route to IER
         immigration = ProtectedClass.objects.get_or_create(protected_class='Immigration/citizenship status (choosing this will not share your status)')
@@ -330,12 +323,7 @@ class SectionAssignmentTests(TestCase):
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'IER')
 
-        test_report.protected_class.remove(origin[0])
-        test_report.protected_class.add(disability[0])
-        test_report.save()
-        self.assertTrue(test_report.assign_section() == 'ELS')
-
-    def test_housing_routing(self):
+    def test_HCE_routing(self):
         data = copy.deepcopy(SAMPLE_REPORT)
         data['primary_complaint'] = 'commercial_or_public'
         test_report = Report.objects.create(**data)
@@ -346,17 +334,12 @@ class SectionAssignmentTests(TestCase):
         test_report = Report.objects.create(**data)
         self.assertTrue(test_report.assign_section() == 'HCE')
 
-    def test_housing_excepetions(self):
-        disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
-
         data = copy.deepcopy(SAMPLE_REPORT)
-        data['primary_complaint'] = 'commercial_or_public'
-        data['commercial_or_public_place'] = 'healthcare'
-        test_report = Report.objects.create(**data)
-        test_report.protected_class.add(disability[0])
-        self.assertTrue(test_report.assign_section() == 'DRS')
+        test_report.commercial_or_public_place = 'other'
+        test_report.save()
+        self.assertTrue(test_report.assign_section() == 'HCE')
 
-    def test_education_routing(self):
+    def test_EOS_routing(self):
         disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
 
         data = copy.deepcopy(SAMPLE_REPORT)
@@ -375,8 +358,6 @@ class SectionAssignmentTests(TestCase):
         self.assertTrue(test_report.assign_section() == 'EOS')
 
     def test_SPL_routing(self):
-        disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
-
         # Test if law enforcement and inside a prison
         data = copy.deepcopy(SAMPLE_REPORT)
         data['primary_complaint'] = 'police'
@@ -384,50 +365,55 @@ class SectionAssignmentTests(TestCase):
         test_report = Report.objects.create(**data)
         self.assertTrue(test_report.assign_section() == 'SPL')
 
-        test_report.protected_class.add(disability[0])
-        test_report.save()
-        self.assertTrue(test_report.assign_section() == 'DRS')
-
-        test_report.inside_correctional_facility = 'outside'
-        test_report.save()
-        self.assertTrue(test_report.assign_section() == 'DRS')
-
-        test_report.protected_class.remove(disability[0])
         test_report.primary_complaint = 'commercial_or_public'
         test_report.commercial_or_public_place = 'healthcare'
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'SPL')
 
-        test_report.protected_class.add(disability[0])
-        test_report.save()
-        self.assertTrue(test_report.assign_section() == 'DRS')
-
-        test_report.protected_class.remove(disability[0])
-        test_report.commercial_or_public_place = 'other'
-        test_report.save()
-        self.assertTrue(test_report.assign_section() == 'HCE')
-
-    def DRS_routing(self):
+    def test_DRS_routing(self):
         disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
 
         school_data = copy.deepcopy(SAMPLE_REPORT)
         school_data['primary_complaint'] = 'education'
         school_data['public_or_private_school'] = 'private'
         test_report = Report.objects.create(**school_data)
-        test_report.add.protected_class.add(disability[0])
+        test_report.protected_class.add(disability[0])
         self.assertTrue(test_report.assign_section() == 'DRS')
 
         data = copy.deepcopy(SAMPLE_REPORT)
         data['primary_complaint'] = 'something_else'
         test_report = Report.objects.create(**data)
-        test_report.add.protected_class.add(disability[0])
+        test_report.protected_class.add(disability[0])
         self.assertTrue(test_report.assign_section() == 'DRS')
 
+        # housing exemption
         data = copy.deepcopy(SAMPLE_REPORT)
         data['primary_complaint'] = 'commercial_or_public'
         data['commercial_or_public_place'] = 'healthcare'
         test_report = Report.objects.create(**data)
         test_report.protected_class.add(disability[0])
+        self.assertTrue(test_report.assign_section() == 'DRS')
+
+        # Reports with a primary complaint of voting and protected class of disability
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'voting'
+        test_report = Report.objects.create(**data)
+        test_report.protected_class.add(disability[0])
+        test_report.save()
+        self.assertTrue(test_report.assign_section() == 'DRS')
+
+        # special exemptions
+        data = copy.deepcopy(SAMPLE_REPORT)
+        data['primary_complaint'] = 'police'
+        data['inside_correctional_facility'] = 'inside'
+        test_report = Report.objects.create(**data)
+
+        test_report.protected_class.add(disability[0])
+        test_report.save()
+        self.assertTrue(test_report.assign_section() == 'DRS')
+
+        test_report.inside_correctional_facility = 'outside'
+        test_report.save()
         self.assertTrue(test_report.assign_section() == 'DRS')
 
 

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -356,14 +356,6 @@ class SectionAssignmentTests(TestCase):
         test_report.protected_class.add(disability[0])
         self.assertTrue(test_report.assign_section() == 'DRS')
 
-        # will confirm this change in the ticket, then can take this out
-
-        # test_report2 = Report.objects.create(**data)
-        # disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
-        # test_report2.protected_class.add(disability[0])
-        # test_report2.save()
-        # self.assertTrue(test_report.assign_section() == 'DRS')
-
     def test_education_routing(self):
         disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
 

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -415,13 +415,13 @@ class SectionAssignmentTests(TestCase):
         test_report.save()
         self.assertTrue(test_report.assign_section() == 'HCE')
 
-    def DRS_routing():
+    def DRS_routing(self):
         disability = ProtectedClass.objects.get_or_create(protected_class='Disability (including temporary or recovery)')
 
         school_data = copy.deepcopy(SAMPLE_REPORT)
         school_data['primary_complaint'] = 'education'
         school_data['public_or_private_school'] = 'private'
-        test_report = Report.objects.create(**data)
+        test_report = Report.objects.create(**school_data)
         test_report.add.protected_class.add(disability[0])
         self.assertTrue(test_report.assign_section() == 'DRS')
 


### PR DESCRIPTION
[routing for DRS](https://github.com/18F/crt-portal/issues/72#issuecomment-580923571)

Routing for DRS as indicated in the ticket.

Reorganized tests so they are grouped by final destination, it is a bit easier to think about now that we have all the sections going.

Latest results added here:
https://docs.google.com/spreadsheets/d/1Ba0617v1wqwf89vYkCQmpNGmi3yI-bfPgXSF8JPqkeQ/edit#gid=1942838706

## What does this change?
Adds routing for DRS

## Checklist:
- [ ] make sure ACs are met

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
