### PR TITLE
Update complaint table with sortable incident date

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -11,7 +11,7 @@
       {% render_sortable_heading 'Contact Details' sort_state filter_state %}
       {% render_sortable_heading 'Incident Location' sort_state filter_state %}
       {% render_sortable_heading 'Summary' sort_state filter_state %}
-      {% render_sortable_heading 'Class' sort_state filter_state %}
+      {% render_sortable_heading 'Incident Date' sort_state filter_state %}
     </tr>
   </thead>
   {% if data_dict %}
@@ -60,15 +60,10 @@
             {% endwith %}
           </a>
         </td>
+
         <td>
           <a class="td-link display-block" href="{{datum.url}}">
-            {% for protected_class in datum.report_protected_classes %}
-                {% if not forloop.last %}
-                  {{ protected_class|truncatechars:50 }},<br>
-                {% else %}
-                  {{ protected_class|truncatechars:50 }}
-                {% endif %}
-            {% endfor %}
+            {{ datum.report.last_incident_month }}/{% if datum.report.last_incident_day %}{{datum.report.last_incident_day}}/{% endif %}{{ datum.report.last_incident_year }}
           </a>
         </td>
       </tr>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -63,7 +63,7 @@
 
         <td>
           <a class="td-link display-block" href="{{datum.url}}">
-            {{ datum.report.last_incident_month }}/{% if datum.report.last_incident_day %}{{datum.report.last_incident_day}}/{% endif %}{{ datum.report.last_incident_year }}
+            {{ datum.report.last_incident_month }}/{% if datum.report.last_incident_day %}{{datum.report.last_incident_day}}{%else%}-{% endif %}/{{ datum.report.last_incident_year }}
           </a>
         </td>
       </tr>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -76,6 +76,12 @@
         <th>Service Member</th>
         <td>{{data.servicemember|title|default:"—"}}</td>
       </tr>
+      <tr>
+        <th>Date of incident</th>
+        <td>
+          {{ data.last_incident_month}}/{% if data.last_incident_day %}{{data.last_incident_day}}{%else%}-/{%endif%}{{data.last_incident_year}}
+        </td>
+      </tr>
     </tr>
   </table>
 </div>

--- a/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
@@ -6,7 +6,7 @@
       id="{{id}}"
       href="{{sort_url}}{{filter_state}}"
       class="sort-link display-block {% if is_descending %}sort-up{% else %}sort-down{% endif %}"
-      aria-label="Sort complaints by property {{ heading }}"
+      aria-label="Sort complaints by property {{ heading }} {% if is_descending %}descending{% else %}ascending{% endif %}"
     >
       <span>{{ heading }}</span>
     </a>

--- a/crt_portal/cts_forms/templatetags/sortable_table_heading.py
+++ b/crt_portal/cts_forms/templatetags/sortable_table_heading.py
@@ -7,14 +7,16 @@ sort_lookup = {
     'routed': 'assigned_section',
     'submitted': 'create_date',
     'contact name': 'contact_last_name',
-    'incident location': 'location_city_town'
+    'incident location': 'location_city_town',
+    'incident date': 'last_incident_month',
 }
 sortable_props = [
     'status',
     'assigned_section',
     'create_date',
     'contact_last_name',
-    'location_city_town'
+    'location_city_town',
+    'last_incident_month',
 ]
 
 
@@ -24,6 +26,8 @@ def heading_2_model_prop(heading):
         return ['contact_last_name', 'contact_first_name']
     elif heading == 'incident location':
         return ['location_city_town', 'location_state']
+    elif heading == 'incident date':
+        return ['last_incident_day', 'last_incident_month', 'last_incident_year']
     else:
         return [sort_lookup[heading]]
 

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -14,7 +14,6 @@ from .models import ProtectedClass, Report, HateCrimesandTrafficking
 from .model_variables import (
     PROTECTED_CLASS_CHOICES,
     PROTECTED_CLASS_ERROR,
-    PROTECTED_CLASS_CODES,
     VIOLATION_SUMMARY_ERROR,
     WHERE_ERRORS,
     PRIMARY_COMPLAINT_CHOICES,
@@ -125,6 +124,9 @@ class Valid_CRT_view_Tests(TestCase):
         for choice in PROTECTED_CLASS_CHOICES:
             ProtectedClass.objects.get_or_create(protected_class=choice)
         test_report = Report.objects.create(**SAMPLE_REPORT)
+        test_report.last_incident_day = '1'
+        test_report.last_incident_month = '1'
+        test_report.last_incident_year = '2020'
         self.protected_example = ProtectedClass.objects.get(protected_class=PROTECTED_CLASS_CHOICES[0])
         test_report.protected_class.add(self.protected_example)
         test_report.save()
@@ -140,12 +142,8 @@ class Valid_CRT_view_Tests(TestCase):
     def tearDown(self):
         self.user.delete()
 
-    def test_other_class(self):
-        self.assertTrue('test other' in self.content)
-
-    def test_class(self):
-        # uses the short hand code for display
-        self.assertTrue(PROTECTED_CLASS_CODES.get(self.protected_example.protected_class) in self.content)
+    def test_incident_date(self):
+        self.assertTrue('1/1/2020' in self.content)
 
     def test_first_name(self):
         self.assertTrue(self.test_report.contact_first_name in self.content)

--- a/crt_portal/cts_forms/tests.py
+++ b/crt_portal/cts_forms/tests.py
@@ -143,6 +143,8 @@ class Valid_CRT_view_Tests(TestCase):
         self.user.delete()
 
     def test_incident_date(self):
+        print(self.content)
+        print(self.test_report.last_incident_day)
         self.assertTrue('1/1/2020' in self.content)
 
     def test_first_name(self):


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/236)

## What does this change?
Adds incident date as a sortable column!

* Removes protected class column
* Adds 'ascending' and 'descending' to screen reader labeling


## Screenshots (for front-end PR):
![Screen Shot 2020-02-03 at 11 22 32 AM](https://user-images.githubusercontent.com/1421848/73684798-bc28d080-4679-11ea-9d05-00b70603c644.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

I have an open question on the behavior of this feature! Currently when you sort, if `last_incident_day` is missing, those dates will appear after any records that have complete dates filled in i.e. those with M/D/YYYY.

I'm not 100% is this behavior is what the intake specialist would want, but would like to hear your thoughts!

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
