### PR TITLE
Updates progress bar to better follow a11y guidelines

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -24,21 +24,26 @@
 
 {% block content %}
   {# Progress text for screen reader. #}
-  <span class="usa-sr-only">
-    Current step: {{ current_step_name }}. Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}.
-  </span>
   <div class="page-header-background">
     <div class="grid-container">
       <div class="grid-row grid-gap">
         <div class="tablet:grid-col-7 tablet:grid-offset-2">
-          <div class="padding-bottom-4 padding-top-3">
-            <ol class="steps" aria-hidden="true">
+          <div class="padding-bottom-4 padding-top-3" aria-label="progress">
+            <span class="usa-sr-only">
+              Current step: {{ current_step_name }}. Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}.
+            </span>
+            <ol class="steps">
               {% for step in ordered_step_names %}
-                <li {% if step == current_step_name %}class="current"{% endif %}>
-                  <div class="step">{{ step }}</div>
+                <li class="step {% if step == current_step_name %}current{%else%}{%endif%}" {% if step == current_step_name %}aria-current="true"{%else%}aria-current="false"{% endif %}>
+                  {{ step }}
+                  {% if step != current_step_name %}
+                    <span class="usa-sr-only">
+                      {% if forloop.counter > wizard.steps.step1 %}not completed{% else %}completed{% endif %}
+                    </span>
+                  {% endif %}
                 </li>
               {% endfor %}
-            </ol>
+              </ol>
             <div class="connecting-line"></div>
           </div>
         </div>

--- a/crt_portal/static/sass/custom/progress.scss
+++ b/crt_portal/static/sass/custom/progress.scss
@@ -31,7 +31,8 @@ $outline-light-gray: #D8D8D8;
 ol.steps {
   display: flex;
   justify-content: space-between;
-  list-style: none; text-align: center;
+  list-style: none;
+  text-align: center;
   counter-reset: milestones; // init counter
 
   // design
@@ -85,14 +86,17 @@ ol.steps {
 
   // current milestone
   li.current {
+    &:focus {
+      outline: 1px;
+    }
     .step {
       font-weight: bold;
     }
   }
 
   // unfinished milestone
-  li.current ~ li {
-    .step::before {
+  li.current   {
+    ~ li.step::before {
       color: black;
       background-color: white;
       box-shadow: inset 0 0 0 $circle-border-width $outline-light-gray;


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/280)

## What does this change?

This PR restructures the progress bar to better follow [this awesome set of guidelines](https://design.gccollab.ca/component/progress-indicators/) @Jacklynn dug up from the government of  🇨🇦 !

The progress bar menu should now be fully navigable by screen readers. Following is a list of the changes made!

* Removed the extra `div` element, and moved the `step` class to the `li` element. This allows the screen reader to correctly read out the number of `li` elements

* Adds `aria-current` to the current step so the user can be apprised of it as they move through the list

* Adds 'completed' or 'not completed' text to the steps so the user can be apprised of what they have and haven't finished

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
