### PR TITLE
Various and sundry a11y improvements!

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -585,15 +585,20 @@ class Filters(ModelForm):
         ]
         widgets = {
             'contact_first_name': TextInput(attrs={
-                'class': 'usa-input'
+                'class': 'usa-input',
+                'name': 'contact_first_name'
             }),
             'contact_last_name': TextInput(attrs={
-                'class': 'usa-input'
+                'class': 'usa-input',
+                'name': 'contact_last_name'
             }),
             'location_city_town': TextInput(attrs={
-                'class': 'usa-input'
+                'class': 'usa-input',
+                'name': 'location_city_town'
             }),
-            'location_state': CrtDropdown
+            'location_state': CrtDropdown(attrs={
+                'name': 'location_state'
+            })
         }
 
     def __init__(self, *args, **kwargs):
@@ -602,22 +607,25 @@ class Filters(ModelForm):
         self.fields['assigned_section'] = MultipleChoiceField(
             choices=SECTION_CHOICES,
             widget=CrtMultiSelect(attrs={
-                'classes': 'text-uppercase'
+                'classes': 'text-uppercase',
+                'name': 'assigned_section'
             }),
             required=False
         )
         self.fields['location_state'] = ChoiceField(
             choices=STATES_AND_TERRITORIES,
-            widget=CrtDropdown,
+            widget=CrtDropdown(attrs={
+                'name': 'location_state'
+            }),
             required=False,
         )
 
         self.fields['assigned_section'].label = _('View sections')
         self.fields['contact_first_name'].label = _('Contact first name')
         self.fields['contact_last_name'].label = _('Contact last name')
-        self.fields['location_city_town'].label = _('City')
+        self.fields['location_city_town'].label = _('Incident location city')
 
-        self.fields['location_state'].label = _('State')
+        self.fields['location_state'].label = _('Incident location state')
         self.fields['location_state'].widget.attrs['list'] = 'states'
 
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
@@ -9,31 +9,31 @@
   >
     <div class="grid-row">
       <div id="view-section-filter" class="margin-right-2">
-        <label for="{{form.assigned_section.attrs.id}}" class="usa-label margin-bottom-1">
+        <label for="id_{{form.fields.assigned_section.widget.attrs.name}}" class="usa-label margin-bottom-1">
           <b>{{form.assigned_section.label }}</b>
         </label>
         {{ form.assigned_section }}
       </div>
       <div id="contact-first-name-filter" class="margin-right-2">
-        <label for="{{form.contact_first_name.attrs.id}}" class="usa-label margin-bottom-1">
+        <label for="id_{{form.fields.contact_first_name.widget.attrs.name}}" class="usa-label margin-bottom-1">
           <b>{{form.contact_first_name.label }}</b>
         </label>
         {{ form.contact_first_name }}
       </div>
       <div id="contact-last-name-filter" class="margin-right-2">
-        <label for="{{form.contact_last_name.attrs.id}}" class="usa-label margin-bottom-1">
+        <label for="id_{{form.fields.contact_last_name.widget.attrs.name}}" class="usa-label margin-bottom-1">
           <b>{{form.contact_last_name.label }}</b>
         </label>
         {{ form.contact_last_name }}
       </div>
-      <div>
-        <label for="{{form.location_city_town.attrs.id}}" class="usa-label margin-bottom-1">
+      <div class="margin-right-2">
+        <label for="id_{{form.fields.location_city_town.widget.attrs.name}}" class="usa-label margin-bottom-1">
           <b>{{form.location_city_town.label}}</b>
         </label>
         {{ form.location_city_town }}
       </div>
       <div id="location-state-filter" class="margin-right-2">
-        <label for="{{form.location_state.attrs.id}}" class="usa-label margin-bottom-1">
+        <label for="id_{{form.fields.location_state.widget.attrs.name}}" class="usa-label margin-bottom-1">
           <b>{{form.location_state.label }}</b>
         </label>
         {{ form.location_state }}

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -48,11 +48,11 @@
 
   <div class="grid-container">
     <div class="grid-row grid-gap">
-      <div class="tablet:grid-col-8 tablet:grid-offset-2">
+      <div class="tablet:grid-col-8 tablet:grid-offset-2"">
         {% if page_errors %}
-          <div id="page-errors" class="page-errors margin-top-4 margin-bottom-2">
+          <section id="page-errors" class="display-none page-errors margin-top-4 margin-bottom-2" role="alert" aria-live="assertive">
             {{ num_page_errors }} error{{ num_page_errors|pluralize }}: {{ page_errors_desc }}
-          </div>
+          </section>
         {% endif %}
         <div class="margin-bottom-4 {% if not page_errors %}margin-top-5{% endif %}">
           <h2 class="margin-0">{{ current_step_title }}</h2>
@@ -117,8 +117,7 @@
     root.CRT.translations = {
       wordRemainingText: "{{ word_count_text.wordRemainingText }}",
       wordsRemainingText: "{{ word_count_text.wordsRemainingText }}",
-      wordLimitReachedText: "{{ word_count_text.wordLimitReachedText }}",
-      finishSummaryText: "{{ word_count_text.finishSummaryText }}"
+      wordLimitReachedText: "{{ word_count_text.wordLimitReachedText }}"
     };
   })(window)
 </script>

--- a/crt_portal/cts_forms/templates/forms/report_date.html
+++ b/crt_portal/cts_forms/templates/forms/report_date.html
@@ -2,14 +2,18 @@
 
 {% block form_questions %}
   <fieldset class="usa-fieldset">
-    <legend class="em-text ">When did this happen?</legend>
+    <legend class="em-text ">
+      When did this happen?
+    </legend>
 
-    <p class="margin-top-0 margin-bottom-1">
-      <em>If this happened over a period of time or is still happening, please provide the most recent date.</em>
+    <p class="margin-top-0 margin-bottom-1" id="incident-date-help-text">
+      <em>
+        If this happened over a period of time or is still happening, please provide the most recent date. Please use the format MM/DD/YY.
+      </em>
     </p>
     {% with month=wizard.form.last_incident_month day=wizard.form.last_incident_day year=wizard.form.last_incident_year %}
-      <div class="usa-memorable-date">
-        <div class="grid-row grid-gap">
+      <section class="usa-memorable-date">
+        <div class="grid-row grid-gap" aria-labelledby="incident-date-help-text">
           <div class="mobile-lg:grid-col-3">
             <label class="usa-label" for="{{ month.id_for_label }}">
               {{ month.label }}
@@ -32,7 +36,7 @@
             {{ year }}
           </div>
         </div>
-    </div>
+      </section>
     {% if month.errors %}
       {% include "forms/snippets/error_alert.html" with errors=month.errors %}
     {% endif %}

--- a/crt_portal/cts_forms/templates/forms/report_grouped_questions.html
+++ b/crt_portal/cts_forms/templates/forms/report_grouped_questions.html
@@ -3,21 +3,17 @@
   {% include 'forms/grouped_questions.html' %}
 
 {% with field=wizard.form.servicemember %}
-  <div id='servicemember' class="margin-bottom-5">
+  <fieldset class="usa-fieldset">
     <legend class="em-text big margin-bottom-0">
       {{field.label}}
     </legend>
-    <div>
-      <label for="{{ field.id_for_label }}">
-        <em>{{ field.help_text }}</em>
-      </label>
-    {{ field }}
-    {% if field.errors %}
-      {% include "forms/snippets/error_alert.html" with errors=field.errors %}
-    {% endif %}
+    <em id="service-member-help-text">{{ field.help_text }}</em>
+    <div aria-labelledby="service-member-help-text">
+      {{ field }}
+      {% if field.errors %}
+        {% include "forms/snippets/error_alert.html" with errors=field.errors %}
+      {% endif %}
     </div>
-  </div>
+  </fieldset>
 {% endwith %}
-</fieldset>
-
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/word_counter.html
+++ b/crt_portal/cts_forms/templates/forms/word_counter.html
@@ -1,8 +1,8 @@
 <noscript>
   <em>{{ word_limit }} word limit.</em>
 </noscript>
-<div id="word_count_area" aria-live="polite" hidden>
-  <em id="word_limit_message" class="margin-bottom-0" role="tooltip"></em>
+<div id="word_count_area" hidden>
+  <em id="word_limit_message" class="margin-bottom-0" role="tooltip"  aria-live="polite"></em>
   <div id="word_limit_alert"
        role="alert"
        class="usa-alert usa-alert--warning usa-alert--slim"

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -298,7 +298,6 @@ class CRTReportWizard(SessionWizardView):
                 'wordRemainingText': _('word remaining'),
                 'wordsRemainingText': _(' words remaining'),
                 'wordLimitReachedText': _(' word limit reached'),
-                'finishSummaryText': _('Please finish your summary -- '),
             },
             'form_name': form_name
         })

--- a/crt_portal/static/js/focus_alert.js
+++ b/crt_portal/static/js/focus_alert.js
@@ -1,11 +1,21 @@
-function triggerAlert() {
-  var alertEl = document.querySelectorAll('.usa-alert__text');
-
-  if (alertEl.length) {
-    Array.prototype.slice.call(alertEl).forEach(function(el) {
-      el.setAttribute('role', 'alert');
-    });
+function prepareErrors() {
+  var pageErrors = document.getElementById('page-errors');
+  if (!pageErrors) {
+    return;
   }
+
+  // Page level errors begin hidden, and are revealed once the DOM has loaded
+  // This makes screen readers think a new element has been inserted into the page.
+  pageErrors.classList.remove('display-none');
+}
+
+function triggerAlert() {
+  /**
+   * Wrapping this call in a set timeout of zero schedules it's execution
+   * at the beginning of the next JS frame's call stack. I'm not exactly sure
+   * why, but this allows the screen reader to see the 'error' messages.
+   */
+  setTimeout(prepareErrors, 0);
 }
 
 window.addEventListener('DOMContentLoaded', triggerAlert);

--- a/crt_portal/static/js/word_count.js
+++ b/crt_portal/static/js/word_count.js
@@ -51,12 +51,11 @@
     wordLimitAlert.removeAttribute('hidden');
 
     var messageText = String(max) + translations.wordLimitReachedText;
+    wordLimitScreenReaderText.innerText = messageText;
+  }
 
-    if (wordLimitScreenReaderText.innerText === messageText) {
-      wordLimitScreenReaderText.innerText = translations.finishSummaryText + messageText;
-    } else {
-      wordLimitScreenReaderText.innerText = messageText;
-    }
+  function isA11yAssertive(el) {
+    return el.getAttribute('aria-live') === 'assertive';
   }
 
   function updateWordCount(e, max, textAreaElem) {
@@ -87,10 +86,10 @@
       onBelowLimit(wordCount, max, textAreaElem);
     }
 
-    if (wordCount >= (max * 4) / 5) {
-      wordCountArea.setAttribute('aria-live', 'assertive');
-    } else {
-      wordCountArea.setAttribute('aria-live', 'polite');
+    if (wordCount >= (max * 4) / 5 && !isA11yAssertive(wordLimitMessage)) {
+      wordLimitMessage.setAttribute('aria-live', 'assertive');
+    } else if (isA11yAssertive(wordLimitMessage)) {
+      wordLimitMessage.setAttribute('aria-live', 'polite');
     }
   }
 


### PR DESCRIPTION
1). [Indicate the date format](https://github.com/18F/crt-portal/issues/282)
2). [Service members question not reading the labels](https://github.com/18F/crt-portal/issues/281)
3). [Details page isn't announcing 'words remaining' when typed](https://github.com/18F/crt-portal/issues/286)
4). [Screen reader error message on Details page doesn't match sighted experience](https://github.com/18F/crt-portal/issues/285)
5). [If there are multiple errors, all errors should get read by a screen reader](https://github.com/18F/crt-portal/issues/283)

## What does this change?
This PR rolls up a few smaller accessibility improvements! For more information, see the list above.
The numbered changes below correspond to the issue above 😄 

1). Wrap the `incident date` fields in a `section` element, and add the `aria-labelledby` attribute. This allows for the `em` help text to be read when the user first tabs into a date field. Subsequent date fields will not repeat the information; hopefully this provides enough context to the user without being overwhelming. This PR also adds a formatting hint to the `incident date` group.

2). Clean up the HTML by adding a missing opening `fieldset` tag, removing an extraneous div, and removing an unnecessary `margin` class. Also removes extra `label` element that was causing help text to be read out of order. As above, applied `aria-labelledby` to the parent div of the form elements, so help text is only read when the user first enters the field group

3). Word count announcement updates as user begins typing each word. The only change from the previous behavior is that we no longer reset the `aria-live` attribute to `polite` every time we _don't_ set `aria-live` to `assertive`; I think this repeated update may have been stopping the announcement.

4). Remove screen reader specific text from word limit JS

5). Screen readers will now read multiple error messages when the user enters the page.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
