### PR TITLE
A11y fixes for the CRT view backend

### DIFF
--- a/crt_portal/cts_forms/templates/forms/snippets/pagination.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/pagination.html
@@ -1,17 +1,18 @@
 {% load static %}
-<div class="usa-pagination-wrapper">
-  <nav class="usa-pagination view-all-pagination" role="navigation" aria-label="Pagination">
+<section class="usa-pagination-wrapper">
+  <nav class="usa-pagination view-all-pagination" role="navigation" aria-label="pagination">
+    <span class="usa-sr-only">Pagination: Current page, page {{ page_format.page }}.</span>
     <ol class="pagination">
-
       {# Left nav arrow #}
       {% if page_format.has_previous %}
         <li class="nav-arrow">
-          <a href="{{ page_args }}&page={{ page_format.previous_page_number }}" aria-label="Go back 1 page.">
+          <span id="page-back" class="usa-sr-only">Go back 1 page.</span>
+          <a href="{{ page_args }}&page={{ page_format.previous_page_number }}" aria-labelledby="page-back">
             {% include "forms/snippets/nav_arrow.html" %}
           </a>
         </li>
       {% else %}
-        <li class="nav-arrow disabled-nav" aria-hidden="true">
+        <li class="nav-arrow disabled-nav">
           <div>
             {% include "forms/snippets/nav_arrow.html" %}
           </div>
@@ -29,7 +30,11 @@
 
       {% for linkpage in page_format.page_numbers %}
         {% ifequal linkpage page_format.page %}
-           <li class="current-page disabled-nav" aria-label="Current page, page {{ page_format.page }}." aria-current="true"><div>{{ page_format.page }}</div></li>
+           <li class="current-page disabled-nav" aria-current="true">
+             <div>
+               {{ page_format.page }}
+            </div>
+          </li>
         {% else %}
            <li><a href="{{ page_args }}&page={{ linkpage }}" role="button" aria-label="Go to page {{ linkpage }}.">{{ linkpage }}</a></li>
         {% endifequal %}
@@ -47,12 +52,13 @@
       {# Right nav arrow #}
       {% if page_format.has_next %}
         <li class="nav-arrow">
-          <a href="{{ page_args }}&page={{ page_format.next_page_number }}" aria-hidden="true">
+          <span id="page-forward" class="usa-sr-only">Go forward 1 page.</span>
+          <a href="{{ page_args }}&page={{ page_format.next_page_number }}" aria-labelledby="page-forward">
             {% include "forms/snippets/nav_arrow.html" with point_right=True %}
           </a>
         </li>
       {% else %}
-        <li class="nav-arrow disabled-nav" aria-label="Go forward 1 page.">
+        <li class="nav-arrow disabled-nav" aria-hidden="true">
           <div>
             {% include "forms/snippets/nav_arrow.html" with point_right=True %}
           </div>
@@ -60,4 +66,4 @@
       {% endif %}
     </ol>
   </nav>
-</div>
+</section>

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -1,10 +1,11 @@
 @mixin clickable-table-cell {
   color: $gray-warm-80;
   height: 100%;
-  outline: 0;
   padding: .5rem 1rem;
+  position: relative;
   text-decoration: none;
   width: 100%;
+  z-index: 1;
 }
 
 @mixin sortable-cell-icon {


### PR DESCRIPTION
1). [Focus order not showing on table rows to open single record ](https://github.com/18F/crt-portal/issues/279)
2). [CRT pagination arrows missing label](https://github.com/18F/crt-portal/issues/284)
3). [Filters on CRT view missing labels](https://github.com/18F/crt-portal/issues/288)

## What does this change?


1). Adds tab focus to crt index view table cells. Unfortunately, this needs to be added on a per-cell basis, since each cell needs to include a clickable `a` tag. Wrapping a `tr` in an anchor is not an option due to HTML table layout rules.

2). Adds a11y labels to pagination buttons

3). Adds labels to filter fields; also, updates location labels to be explicit about the fact that they are labeling the incident location

## Screenshots (for front-end PR):

1).  <img width="456" alt="Screen Shot 2020-02-07 at 12 21 14 PM" src="https://user-images.githubusercontent.com/1421848/74063004-623f4800-49a4-11ea-85e4-87bbcc135b7d.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
