### PR TITLE
Normalize heading & help text for Primary Issue page

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -145,7 +145,7 @@ class PrimaryReason(ModelForm):
             error_messages={
                 'required': PRIMARY_COMPLAINT_ERROR
             },
-            label=_('What is the primary reason for contacting the Civil Rights Division'),
+            label=_('What is your primary reason for contacting the Civil Rights Division?'),
             help_text=_('Please choose the option below that best fits your situation. The examples listed in each are only a sampling of related issues. You will have space to explain in detail later.'),
         )
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -145,7 +145,8 @@ class PrimaryReason(ModelForm):
             error_messages={
                 'required': PRIMARY_COMPLAINT_ERROR
             },
-            help_text=_('Please choose the option below that best fits your situation. The examples listed in each are only a sampling of related issues. You will have space to explain in detail later.')
+            label=_('What is the primary reason for contacting the Civil Rights Division'),
+            help_text=_('Please choose the option below that best fits your situation. The examples listed in each are only a sampling of related issues. You will have space to explain in detail later.'),
         )
 
         self.fields['hatecrimes_trafficking'] = ModelMultipleChoiceField(
@@ -156,6 +157,7 @@ class PrimaryReason(ModelForm):
             required=False,
             label=_('Please select if any that apply to your situation (optional)')
         )
+
         self.question_groups = [
             QuestionGroup(
                 self,

--- a/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
+++ b/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
@@ -2,9 +2,7 @@
 {% block form_questions %}
   {% with primary_complaint_field=wizard.form.primary_complaint %}
     <fieldset class="usa-fieldset margin-bottom-5 question_{{primary_complaint_field.name}}">      
-      <legend
-        class="em-text margin-bottom-2"
-      >
+      <legend class="em-text margin-bottom-2">
         {{ primary_complaint_field.label }}
       </legend>
 
@@ -14,11 +12,13 @@
         </div>
       {% endif %}
 
-      {{ primary_complaint_field }}
+      <div aria-labelledby="primary-complaint-help-text">
+        {{ primary_complaint_field }}
 
-      {% if primary_complaint_field.errors %}
-        {% include "forms/snippets/error_alert.html" with errors=primary_complaint_field.errors %}
-      {% endif %}
+        {% if primary_complaint_field.errors %}
+          {% include "forms/snippets/error_alert.html" with errors=primary_complaint_field.errors %}
+        {% endif %}
+      </div>
     </fieldset>
   {% endwith %}
   {% include "forms/grouped_questions.html" %}

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -270,7 +270,7 @@ class CRTReportWizard(SessionWizardView):
         # This title appears in large font above the question elements
         ordered_step_titles = [
             _('Contact'),
-            _('What is your primary reason for contacting the Civil Rights Division?'),
+            _('Primary issue'),
             _('Location details'),
             _('Location details'),
             _('Location details'),


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/247)

## What does this change?

This PR moves the existing heading to the `legend` tag in the form, and updates the page title to follow the conventions established on the other steps of the form.

## Screenshots (for front-end PR):
![Screen Shot 2020-02-10 at 9 31 52 AM](https://user-images.githubusercontent.com/1421848/74174352-a1f67180-4be8-11ea-9d3d-9e19986e08ba.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
