### PR TITLE
Adds missing nonces to inline script tags

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -43,7 +43,7 @@
 </div>
 {% endblock %}
 {% block page_js %}
-<script>
+<script nonce="{{request.csp_nonce}}">
   (function(root) {
     root.CRT = root.CRT || {}
     root.CRT.pageArgs = "{{ page_args }}"

--- a/crt_portal/cts_forms/templates/forms/report_class.html
+++ b/crt_portal/cts_forms/templates/forms/report_class.html
@@ -25,5 +25,5 @@
 {% block page_js %}
 {{ block.super }}
 <script src="{% static 'js/other_show_hide.js' %}"></script>
-<script>window.CRT.otherTextInputToggle()</script>
+<script nonce="{{request.csp_nonce}}">window.CRT.otherTextInputToggle()</script>
 {% endblock %}


### PR DESCRIPTION
## What does this change?
Adds missing `nonce` attributes to remaining inline script tags

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
