### PR TITLE
We are using all https, so making this token secure should be fine.

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -234,6 +234,7 @@ if environment in ['PRODUCTION', 'STAGE', 'DEVELOP']:
     MIDDLEWARE.append('csp.middleware.CSPMiddleware')
     # headers required for security
     SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
     # If this is set to True, client-side JavaScript will not be able to access the language cookie.
     SESSION_COOKIE_HTTPONLY = True
     # see settings options https://django-csp.readthedocs.io/en/latest/configuration.html#configuration-chapter


### PR DESCRIPTION
Makes csrf token https only. Should clear one more scan result.