### PR TITLE
Adds employer info to relevant details

### DIFF
--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -211,6 +211,14 @@ EMPLOYER_SIZE_CHOICES = (
     ('not_sure', _('I\'m not sure')),
 )
 
+EMPLOYER_FRIENDLY_TEXT = {
+    'public_employer': _('Public'),
+    'private_employer': _('Private'),
+    'not_sure': _('Not sure'),
+    '14_or_less': _('Less than 15'),
+    '15_or_more': _('15 or more'),
+}
+
 PUBLIC_OR_PRIVATE_SCHOOL_CHOICES = (
     ('public', _('Public school or educational program')),
     ('private', _('Private school or educational program')),

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -1,5 +1,6 @@
 {% load commercial_public_space_view %}
 {% load correctional_facility_view %}
+{% load employer_info_view %}
 
 <div class="complaint-card complaint-card--rounded">
   <h3 class="complaint-card-heading text-uppercase">Complaint details</h3>
@@ -40,6 +41,8 @@
             {% render_correctional_facility_view data.inside_correctional_facility data.correctional_facility_type %}
           {% elif data.public_or_private_school %}
             School type: {% if data.public_or_private_school == 'not_sure' %} Not sure {% else %} {{ data.public_or_private_school|title }} {% endif %}
+          {% elif data.public_or_private_employer %}
+            {% render_employer_info_view data.public_or_private_employer data.employer_size %}
           {% else %}
             —
           {% endif %}

--- a/crt_portal/cts_forms/templates/forms/snippets/employer_info_view.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/employer_info_view.html
@@ -1,0 +1,3 @@
+Employer type: {{employer_type}}
+<br />
+Employee size: {{employee_size}}

--- a/crt_portal/cts_forms/templatetags/correctional_facility_view.py
+++ b/crt_portal/cts_forms/templatetags/correctional_facility_view.py
@@ -7,7 +7,6 @@ register = template.Library()
 
 @register.inclusion_tag('forms/snippets/correctional_facility_view.html')
 def render_correctional_facility_view(facility, facility_type):
-    print(facility_type)
     if facility == 'outside':
         location_type = CORRECTIONAL_FACILITY_FRIENDLY_TEXT.get(facility, '—')
     else:

--- a/crt_portal/cts_forms/templatetags/employer_info_view.py
+++ b/crt_portal/cts_forms/templatetags/employer_info_view.py
@@ -1,0 +1,13 @@
+from django import template
+from ..model_variables import EMPLOYER_FRIENDLY_TEXT
+
+
+register = template.Library()
+
+
+@register.inclusion_tag('forms/snippets/employer_info_view.html')
+def render_employer_info_view(employer_type, employee_size):
+    return {
+        'employer_type': EMPLOYER_FRIENDLY_TEXT.get(employer_type, '-'),
+        'employee_size': EMPLOYER_FRIENDLY_TEXT.get(employee_size, '-')
+    }


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/300)

## What does this change?

Adds the missing relevant details for the employment info primary complaint reason. This information will now correctly display on the complaint details page.

## Screenshots (for front-end PR):
![Screen Shot 2020-02-14 at 11 27 11 AM](https://user-images.githubusercontent.com/1421848/74561779-2107e480-4f1e-11ea-8a8e-80122e85781e.png)
![Screen Shot 2020-02-14 at 11 26 12 AM](https://user-images.githubusercontent.com/1421848/74561783-22391180-4f1e-11ea-828a-a5be04d5f3f7.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
