### PR TITLE
Add error class to text inputs

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -107,6 +107,7 @@ TEMPLATES = [
         'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
+            'builtins': ['cts_forms.templatetags.with_input_error'],
             'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -199,6 +199,7 @@ class Details(ModelForm):
         self.fields['violation_summary'].widget.attrs['aria-describedby'] = 'details-help-text'
         self.fields['violation_summary'].help_text = _("Please include any details you have about time, location, or people involved with the event, names of witnesses or any materials that would support your description")
         self.fields['violation_summary'].error_messages = {'required': VIOLATION_SUMMARY_ERROR}
+        self.fields['violation_summary'].required = True
 
 
 class LocationForm(ModelForm):
@@ -254,7 +255,7 @@ class LocationForm(ModelForm):
         }
         self.fields['location_city_town'].required = True
         self.fields['location_state'] = ChoiceField(
-            choices=STATES_AND_TERRITORIES,
+            choices=(('', _(' ')),) + STATES_AND_TERRITORIES,
             widget=Select(attrs={
                 'aria-describedby': 'location-help-text',
                 'class': 'usa-select'
@@ -264,7 +265,7 @@ class LocationForm(ModelForm):
                 'required': errors['location_state']
             },
             label='State',
-            help_text="Where did this happen?"
+            help_text="Where did this happen?",
         )
         self.fields['location_state'].widget.attrs['list'] = 'states'
 
@@ -537,11 +538,13 @@ class When(ModelForm):
         self.fields['last_incident_month'].error_messages = {
             'required': _('Please enter a month.'),
         }
+        self.fields['last_incident_month'].required = True
         self.fields['last_incident_day'].label = _('Day')
         self.fields['last_incident_year'].label = _('Year')
         self.fields['last_incident_year'].error_messages = {
             'required': _('Please enter a year.'),
         }
+        self.fields['last_incident_year'].required = True
 
     def clean(self):
         """Validating more than one field at a time can't be done in the model validation"""

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -245,12 +245,14 @@ class LocationForm(ModelForm):
         self.fields['location_name'].error_messages = {
             'required': errors['location_name']
         }
+        self.fields['location_name'].required = True
         self.fields['location_address_line_1'].label = 'Street address 1 (Optional)'
         self.fields['location_address_line_2'].label = 'Street address 2 (Optional)'
         self.fields['location_city_town'].label = 'City/town'
         self.fields['location_city_town'].error_messages = {
             'required': errors['location_city_town']
         }
+        self.fields['location_city_town'].required = True
         self.fields['location_state'] = ChoiceField(
             choices=STATES_AND_TERRITORIES,
             widget=Select(attrs={

--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -54,6 +54,7 @@
     <script src="{% static 'js/url_params_polyfill.js' %}"></script>
     <script src="{% static 'js/uswds.min.js' %}"></script>
     <script src="{% static 'js/focus_alert.js' %}"></script>
+    <script src="{% static 'js/clear_error_class.js' %}"></script>
     {% block page_js %}{% endblock %}
   </body>
 </html>

--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load with_input_error %}
 <!DOCTYPE html>
 <html lang="en">
  <head>

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
-{% load with_input_error %}
 {% block head %}
   {{ wizard.form.media }}
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
+{% load with_input_error %}
 {% block head %}
   {{ wizard.form.media }}
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_commercial_public_location.html
+++ b/crt_portal/cts_forms/templates/forms/report_commercial_public_location.html
@@ -31,7 +31,7 @@
 </fieldset>
 {% block page_js %}
 <script src="{% static 'js/other_show_hide.js' %}"></script>
-<script>
+<script nonce="{{request.csp_nonce}}">
   window.CRT.otherTextInputToggle('#id_5-commercial_or_public_place .usa-radio')
 </script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_date.html
+++ b/crt_portal/cts_forms/templates/forms/report_date.html
@@ -18,7 +18,7 @@
             <label class="usa-label" for="{{ month.id_for_label }}">
               {{ month.label }}
             </label>
-            {{ month }}
+            {{ month|withInputError }}
           </div>
           <div class="mobile-lg:grid-col-3">
             <label class="usa-label" for="{{ day.id_for_label}}">
@@ -33,7 +33,7 @@
             <label class="usa-label" for="{{ year.id_for_label }}">
               {{ year.label }}
             </label>
-            {{ year }}
+            {{ year|withInputError }}
           </div>
         </div>
       </section>

--- a/crt_portal/cts_forms/templates/forms/report_details.html
+++ b/crt_portal/cts_forms/templates/forms/report_details.html
@@ -15,7 +15,7 @@
 
 	</div>
 	<div class="margin-bottom-4">
-	  {{ field }}
+	  {{ field|withInputError }}
 	  {% if field.errors %}
 	    {% include "forms/snippets/error_alert.html" with errors=field.errors %}
 	  {% endif %}

--- a/crt_portal/cts_forms/templates/forms/report_location.html
+++ b/crt_portal/cts_forms/templates/forms/report_location.html
@@ -16,13 +16,13 @@
         <label for="{{city.id_for_label}}">
           {{ city.label }}
         </label>
-        {{ city }}
+        {{city|withInputError}}
       </div>
       <div class="mobile-lg:grid-col-4">
         <label for="{{state.id_for_label}}">
           {{state.label}}
         </label>
-        {{ state }}
+        {{state|withInputError}}
       </div>
     </div>
     {% if city.errors %}

--- a/crt_portal/cts_forms/templates/forms/report_police_location.html
+++ b/crt_portal/cts_forms/templates/forms/report_police_location.html
@@ -22,7 +22,7 @@
     {% endif %}
   {% endwith %}
 
-  <script>
+  <script nonce="{{request.csp_nonce}}">
     var toggleWrapperEl = document.querySelector('[data-toggle="toggle"]');
     var toggleControls = Array.prototype.slice.call(
       toggleWrapperEl.querySelectorAll('[name="4-inside_correctional_facility"]')

--- a/crt_portal/cts_forms/templates/forms/snippets/input.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/input.html
@@ -10,7 +10,7 @@
     <em>{{ field.help_text }}</em>
   </p>
   {% endif %}
-  {{ field }}
+  {{ field|withInputError }}
   {% if field.errors %}
     {% include "forms/snippets/error_alert.html" with errors=field.errors %}
   {% endif %}

--- a/crt_portal/cts_forms/templatetags/with_input_error.py
+++ b/crt_portal/cts_forms/templatetags/with_input_error.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+@register.filter(name='withInputError')
+def with_input_error(field, arg = 'usa-input--error'):
+    if bool(field.errors):
+      css_classes = field.field.widget.attrs.get('class', None)
+      return field.as_widget(attrs={'class': f"{arg} {css_classes}" })
+    
+    return field

--- a/crt_portal/cts_forms/templatetags/with_input_error.py
+++ b/crt_portal/cts_forms/templatetags/with_input_error.py
@@ -2,10 +2,11 @@ from django import template
 
 register = template.Library()
 
+
 @register.filter(name='withInputError')
-def with_input_error(field, arg = 'usa-input--error'):
+def with_input_error(field, arg='usa-input--error'):
     if bool(field.errors):
-      css_classes = field.field.widget.attrs.get('class', None)
-      return field.as_widget(attrs={'class': f"{arg} {css_classes}" })
-    
+        css_classes = field.field.widget.attrs.get('class', None)
+        return field.as_widget(attrs={'class': f"{arg} {css_classes}"})
+
     return field

--- a/crt_portal/static/js/clear_error_class.js
+++ b/crt_portal/static/js/clear_error_class.js
@@ -1,0 +1,18 @@
+(function() {
+  var USA_INPUT_ERROR = 'usa-input--error';
+  var inputs = document.querySelectorAll('input[type="text"], textarea, select');
+  var inputList = Array.prototype.slice.call(inputs);
+
+  function isRequired(node) {
+    return node.required;
+  }
+
+  function removeError(event) {
+    var node = event.target;
+
+    node.classList.remove(USA_INPUT_ERROR);
+  }
+  inputList.filter(isRequired).forEach(function(node) {
+    node.addEventListener('change', removeError);
+  });
+})();

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -195,6 +195,10 @@ form#report-form {
   }
 }
 
+.usa-input--error {
+  border: .25rem solid #d63e04;
+}
+
 .complaint-multi-select {
   min-width: 140px;
 }


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/163)

## What does this change?
* Adds an error class to any required `input[type="text"]`, `textarea` or `select` field.
* Adds JS to clear the error border when content is changed.

## Screenshots (for front-end PR):
**HANDY GIF**:
![error-ex](https://user-images.githubusercontent.com/1421848/74789001-41aaa400-5268-11ea-9ffe-a2ecbd060949.gif)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
