### PR TITLE
Adds actstreams django package and example feed

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,6 +23,7 @@ testfixtures = "*"
 django-auth-adfs = "*"
 django-csp = "*"
 pip = "*"
+django-activity-stream = "*"
 
 [requires]
 python_version = "3.8.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "63e6fa1c9e2dbc890520c09af98aacac90d3eb286ff2f43c77851859a34df25f"
+            "sha256": "745cfcd45f69b5d91176d08da84875e2eeb5b3220d5c677e2a142c230b447c88"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -119,6 +119,13 @@
             ],
             "index": "pypi",
             "version": "==2.2.9"
+        },
+        "django-activity-stream": {
+            "hashes": [
+                "sha256:ef07f7242f25dbf6e198b377632a72fdd0c06ce3cd1097c394d9b7052c943b4e"
+            ],
+            "index": "pypi",
+            "version": "==0.8.0"
         },
         "django-appconf": {
             "hashes": [

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -86,7 +86,9 @@ INSTALLED_APPS = [
     'formtools',
     # 'django_auth_adfs' in production only
     'crequest',
+    'actstream',
 ]
+SITE_ID = 1
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/crt_portal/cts_forms/apps.py
+++ b/crt_portal/cts_forms/apps.py
@@ -6,3 +6,8 @@ class CtsFormsConfig(AppConfig):
 
     def ready(self):
         import cts_forms.signals  # noqa
+        
+        from actstream import registry
+        registry.register(self.get_model('Report'))
+
+

--- a/crt_portal/cts_forms/apps.py
+++ b/crt_portal/cts_forms/apps.py
@@ -6,8 +6,6 @@ class CtsFormsConfig(AppConfig):
 
     def ready(self):
         import cts_forms.signals  # noqa
-        
+
         from actstream import registry
         registry.register(self.get_model('Report'))
-
-

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -75,11 +75,13 @@
 
 {% if not data_dict %}
 <div class="complaint-card table-message">
-  <div class="grid-container padding-bottom-2">
-    <div class="align-center">
-      <img src="{% static 'img/filters.svg' %}" class="margin-top-1" />
-      <p class="margin-bottom-1 margin-top-1"><b>No records found</b></p>
-      <em>Try adjusting your filters to see more records</em>
+  <div class="complaint-card-content">
+    <div class="grid-container padding-bottom-2">
+      <div class="align-center">
+        <img src="{% static 'img/filters.svg' %}" class="margin-top-1" />
+        <p class="margin-bottom-1 margin-top-1"><b>No records found</b></p>
+        <em>Try adjusting your filters to see more records</em>
+      </div>
     </div>
   </div>
 </div>
@@ -87,13 +89,15 @@
 
 {% if not page_format.has_next and data_dict %}
 <div class="complaint-card table-message">
-  <div class="grid-container padding-bottom-2">
-    <div class="align-center">
-      <p class="margin-bottom-1">
-        <img src="{% static 'img/coffee.svg' %}" />
-        <b>End of results</b>
-      </p>
-      <em>Try adjusting your filters to see more records</em>
+  <div class="complaint-card-content">
+    <div class="grid-container padding-bottom-2">
+      <div class="align-center">
+        <p class="margin-bottom-1">
+          <img src="{% static 'img/coffee.svg' %}" />
+          <b>End of results</b>
+        </p>
+        <em>Try adjusting your filters to see more records</em>
+      </div>
     </div>
   </div>
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters.html
@@ -1,77 +1,79 @@
 {% load static %}
 
 <div class="complaint-card">
-  <form
-    id="filters-form"
-    method="GET"
-    action="/form/view"
-    novalidate
-  >
-    <div class="grid-row">
-      <div id="view-section-filter" class="margin-right-2">
-        <label for="id_{{form.fields.assigned_section.widget.attrs.name}}" class="usa-label margin-bottom-1">
-          <b>{{form.assigned_section.label }}</b>
-        </label>
-        {{ form.assigned_section }}
+  <div class="complaint-card-content">
+    <form
+      id="filters-form"
+      method="GET"
+      action="/form/view"
+      novalidate
+    >
+      <div class="grid-row">
+        <div id="view-section-filter" class="margin-right-2">
+          <label for="id_{{form.fields.assigned_section.widget.attrs.name}}" class="usa-label margin-bottom-1">
+            <b>{{form.assigned_section.label }}</b>
+          </label>
+          {{ form.assigned_section }}
+        </div>
+        <div id="contact-first-name-filter" class="margin-right-2">
+          <label for="id_{{form.fields.contact_first_name.widget.attrs.name}}" class="usa-label margin-bottom-1">
+            <b>{{form.contact_first_name.label }}</b>
+          </label>
+          {{ form.contact_first_name }}
+        </div>
+        <div id="contact-last-name-filter" class="margin-right-2">
+          <label for="id_{{form.fields.contact_last_name.widget.attrs.name}}" class="usa-label margin-bottom-1">
+            <b>{{form.contact_last_name.label }}</b>
+          </label>
+          {{ form.contact_last_name }}
+        </div>
+        <div class="margin-right-2">
+          <label for="id_{{form.fields.location_city_town.widget.attrs.name}}" class="usa-label margin-bottom-1">
+            <b>{{form.location_city_town.label}}</b>
+          </label>
+          {{ form.location_city_town }}
+        </div>
+        <div id="location-state-filter" class="margin-right-2">
+          <label for="id_{{form.fields.location_state.widget.attrs.name}}" class="usa-label margin-bottom-1">
+            <b>{{form.location_state.label }}</b>
+          </label>
+          {{ form.location_state }}
+        </div>
       </div>
-      <div id="contact-first-name-filter" class="margin-right-2">
-        <label for="id_{{form.fields.contact_first_name.widget.attrs.name}}" class="usa-label margin-bottom-1">
-          <b>{{form.contact_first_name.label }}</b>
-        </label>
-        {{ form.contact_first_name }}
-      </div>
-      <div id="contact-last-name-filter" class="margin-right-2">
-        <label for="id_{{form.fields.contact_last_name.widget.attrs.name}}" class="usa-label margin-bottom-1">
-          <b>{{form.contact_last_name.label }}</b>
-        </label>
-        {{ form.contact_last_name }}
-      </div>
-      <div class="margin-right-2">
-        <label for="id_{{form.fields.location_city_town.widget.attrs.name}}" class="usa-label margin-bottom-1">
-          <b>{{form.location_city_town.label}}</b>
-        </label>
-        {{ form.location_city_town }}
-      </div>
-      <div id="location-state-filter" class="margin-right-2">
-        <label for="id_{{form.fields.location_state.widget.attrs.name}}" class="usa-label margin-bottom-1">
-          <b>{{form.location_state.label }}</b>
-        </label>
-        {{ form.location_state }}
-      </div>
-    </div>
-    <div class="margin-top-2">
-      <button type="submit" class="usa-button usa-button--primary">
-        Filter results
-      </button>
-    </div>
-  </form>
-  <div id="active-filters" class="active-filters margin-top-2">
-    {% for key, value in filters.items %}
-      {% for item in value %}
-        <span class="usa-sr-only">{{key}}: {{item}}</span>
-        <button
-          class="filter-control usa-button usa-button--light margin-top-2"
-          aria-label="Remove filter {{ key}}: {{item}} from the list"
-          data-filter-name="{{key}}"
-          data-filter-value="{{item}}"
-        >
-          {% if key == 'assigned_section' %}
-            Routed
-          {% elif key == 'contact_first_name' %}
-            Contact first name
-          {% elif key == 'contact_last_name' %}
-            Contact last name
-          {% elif key == 'location_city_town' %}
-            City
-          {% elif key == 'location_state' %}
-            State
-          {% else %}
-            {{key}}
-          {% endif %}: {{item}}
-          <div class="divider"></div>
-          <img src="{% static "img/close-blue-50-alt.svg" %}" class="filter-action">
+      <div class="margin-top-2">
+        <button type="submit" class="usa-button usa-button--primary">
+          Filter results
         </button>
-        {% endfor %}
-    {% endfor %}
+      </div>
+    </form>
+    <div id="active-filters" class="active-filters margin-top-2">
+      {% for key, value in filters.items %}
+        {% for item in value %}
+          <span class="usa-sr-only">{{key}}: {{item}}</span>
+          <button
+            class="filter-control usa-button usa-button--light margin-top-2"
+            aria-label="Remove filter {{ key}}: {{item}} from the list"
+            data-filter-name="{{key}}"
+            data-filter-value="{{item}}"
+          >
+            {% if key == 'assigned_section' %}
+              Routed
+            {% elif key == 'contact_first_name' %}
+              Contact first name
+            {% elif key == 'contact_last_name' %}
+              Contact last name
+            {% elif key == 'location_city_town' %}
+              City
+            {% elif key == 'location_state' %}
+              State
+            {% else %}
+              {{key}}
+            {% endif %}: {{item}}
+            <div class="divider"></div>
+            <img src="{% static "img/close-blue-50-alt.svg" %}" class="filter-action">
+          </button>
+          {% endfor %}
+      {% endfor %}
+    </div>
   </div>
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -1,22 +1,24 @@
 <div class="complaint-card complaint-card--rounded">
-  <form
-    id="complaint-view-actions"
-    class="usa-form"
-    method="post"
-    action="/form/view/{{data.id}}/"
-    novalidate
-  >
-    {% csrf_token %}
-    <fieldset class="usa-fieldset usa-prose">
-      <legend class="usa-sr-only">Complaint detail view actions</legend>
-      <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
-      <div class="margin-bottom-2">
-        {{ actions.assigned_section }}
-      </div>
-      <div class="margin-bottom-2">
-        {{ actions.status }}
-      </div>
-      <button class="usa-button" type="submit">Apply changes</button>
-    </fieldset>
-  </form>
+  <div class="complaint-card-content">
+    <form
+      id="complaint-view-actions"
+      class="usa-form"
+      method="post"
+      action="/form/view/{{data.id}}/"
+      novalidate
+    >
+      {% csrf_token %}
+      <fieldset class="usa-fieldset usa-prose">
+        <legend class="usa-sr-only">Complaint detail view actions</legend>
+        <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
+        <div class="margin-bottom-2">
+          {{ actions.assigned_section }}
+        </div>
+        <div class="margin-bottom-2">
+          {{ actions.status }}
+        </div>
+        <button class="usa-button" type="submit">Apply changes</button>
+      </fieldset>
+    </form>
+  </div>
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
@@ -1,0 +1,24 @@
+<div class="complaint-card complaint-card--rounded">
+  <div class="activity-stream">
+    <div class="heading">
+      Activity
+    </div>
+    <div class="complaint-card-content">
+      <ul class="activity-stream-list usa-list usa-list--unstyled">
+        {% for activity in activity_stream %}
+          <li class="activity-stream-item">
+            <div class="display-flex flex-justify">
+              <b  >{{activity.actor.email}}</b>
+              <span class="date font-sans-sm flex-align-end">
+                {{ activity.timestamp|date:'n/d/y'}} {{ activity.timestamp|time}}
+              </span>
+            </div>
+            <p class="margin-top-0">
+              {{activity.verb}} {{activity.description}}
+            </p>
+          </li>    
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
@@ -8,7 +8,7 @@
         {% for activity in activity_stream %}
           <li class="activity-stream-item">
             <div class="display-flex flex-justify">
-              <b  >{{activity.actor.email}}</b>
+              <b  >{{activity.actor.username}}</b>
               <span class="date font-sans-sm flex-align-end">
                 {{ activity.timestamp|date:'n/d/y'}} {{ activity.timestamp|time}}
               </span>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -3,88 +3,90 @@
 {% load employer_info_view %}
 
 <div class="complaint-card complaint-card--rounded">
-  <h3 class="complaint-card-heading text-uppercase">Complaint details</h3>
-  <table class="usa-table usa-table--borderless complaint-card-table">
-    <tr>
-      <th>Primary issue</th>
-      <td>
-        <strong>{{primary_complaint.0}}</strong>
-      </td>
+  <div class="complaint-card-content">
+    <h3 class="complaint-card-heading text-uppercase">Complaint details</h3>
+    <table class="usa-table usa-table--borderless complaint-card-table">
       <tr>
-        <th>Hate crime</th>
+        <th>Primary issue</th>
         <td>
-          {% if crimes.physical_harm %}
-            Yes (checked)
-          {% else %}
-            No (unchecked)
-          {% endif %}
+          <strong>{{primary_complaint.0}}</strong>
         </td>
-      </tr>
-      <tr>
-        <th>Human Trafficking</th>
-        <td>
-          {% if crimes.trafficking %}
-            Yes (checked)
-          {% else %}
-            No (unchecked)
-          {% endif %}
-        </td>
-      </tr>
-      <tr>
-        <th>Relevant Details</th>
-        <td>
-          {% if data.election_details %}
-            Election type (federal/local): {{ data.election_details }}
-          {% elif data.commercial_or_public_place %}
-            {% render_commercial_public_space_view data.commercial_or_public_place data.other_commercial_or_public_place %}
-          {% elif data.inside_correctional_facility %}
-            {% render_correctional_facility_view data.inside_correctional_facility data.correctional_facility_type %}
-          {% elif data.public_or_private_school %}
-            School type: {% if data.public_or_private_school == 'not_sure' %} Not sure {% else %} {{ data.public_or_private_school|title }} {% endif %}
-          {% elif data.public_or_private_employer %}
-            {% render_employer_info_view data.public_or_private_employer data.employer_size %}
-          {% else %}
-            —
-          {% endif %}
-        </td>
-      </tr>
-      <tr>
-        <th>Location name</th>
-        <td>{{data.location_name|default:"-"}}</td>
-      </tr>
-      <tr>
-        <th>City, State</th>
-        <td>
-          {{data.location_city_town|default:"-"}},
-          {{data.location_state|default:"-"}}
-        </td>
-      </tr>
-      <tr>
-        <th>Reported reason</th>
-        <td>
-          {% for p_class in p_class_list %}
-            {% if not forloop.last %}
-              {{p_class}},
+        <tr>
+          <th>Hate crime</th>
+          <td>
+            {% if crimes.physical_harm %}
+              Yes (checked)
             {% else %}
-              {{p_class}}
+              No (unchecked)
             {% endif %}
-          {% endfor %}
-          {% if data.other_class %}
-            <br>
-            Other: {{data.other_class}}
-          {% endif %}
-        </td>
+          </td>
+        </tr>
+        <tr>
+          <th>Human Trafficking</th>
+          <td>
+            {% if crimes.trafficking %}
+              Yes (checked)
+            {% else %}
+              No (unchecked)
+            {% endif %}
+          </td>
+        </tr>
+        <tr>
+          <th>Relevant Details</th>
+          <td>
+            {% if data.election_details %}
+              Election type (federal/local): {{ data.election_details }}
+            {% elif data.commercial_or_public_place %}
+              {% render_commercial_public_space_view data.commercial_or_public_place data.other_commercial_or_public_place %}
+            {% elif data.inside_correctional_facility %}
+              {% render_correctional_facility_view data.inside_correctional_facility data.correctional_facility_type %}
+            {% elif data.public_or_private_school %}
+              School type: {% if data.public_or_private_school == 'not_sure' %} Not sure {% else %} {{ data.public_or_private_school|title }} {% endif %}
+            {% elif data.public_or_private_employer %}
+              {% render_employer_info_view data.public_or_private_employer data.employer_size %}
+            {% else %}
+              —
+            {% endif %}
+          </td>
+        </tr>
+        <tr>
+          <th>Location name</th>
+          <td>{{data.location_name|default:"-"}}</td>
+        </tr>
+        <tr>
+          <th>City, State</th>
+          <td>
+            {{data.location_city_town|default:"-"}},
+            {{data.location_state|default:"-"}}
+          </td>
+        </tr>
+        <tr>
+          <th>Reported reason</th>
+          <td>
+            {% for p_class in p_class_list %}
+              {% if not forloop.last %}
+                {{p_class}},
+              {% else %}
+                {{p_class}}
+              {% endif %}
+            {% endfor %}
+            {% if data.other_class %}
+              <br>
+              Other: {{data.other_class}}
+            {% endif %}
+          </td>
+        </tr>
+        <tr>
+          <th>Service Member</th>
+          <td>{{data.servicemember|title|default:"—"}}</td>
+        </tr>
+        <tr>
+          <th>Date of incident</th>
+          <td>
+            {{ data.last_incident_month}}/{% if data.last_incident_day %}{{data.last_incident_day}}{%else%}-/{%endif%}{{data.last_incident_year}}
+          </td>
+        </tr>
       </tr>
-      <tr>
-        <th>Service Member</th>
-        <td>{{data.servicemember|title|default:"—"}}</td>
-      </tr>
-      <tr>
-        <th>Date of incident</th>
-        <td>
-          {{ data.last_incident_month}}/{% if data.last_incident_day %}{{data.last_incident_day}}{%else%}-/{%endif%}{{data.last_incident_year}}
-        </td>
-      </tr>
-    </tr>
-  </table>
+    </table>
+  </div>
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/correspondent_info.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/correspondent_info.html
@@ -1,23 +1,25 @@
 <div class="complaint-card complaint-card--rounded">
-  <h3 class="complaint-card-heading text-uppercase">Correspondent information</h3>
-  <table class="usa-table usa-table--borderless complaint-card-table">
-    <tr>
-      <th>Name</th>
-      <td>
-        <strong>
-          {% with l_name=data.contact_last_name|default:"—" f_name=data.contact_first_name|default:"—" %}
-          {{ l_name }}, {{ f_name }}
-          {% endwith %}
-        </strong>
-      </td>
-    </tr>
-    <tr>
-      <th>Email</th>
-      <td>{{ data.contact_email|default:"—" }}</td>
-    </tr>
-    <tr>
-      <th>Telephone</th>
-      <td>{{ data.contact_phone|default:"—" }}</td>
-    </tr>
-  </table>
+  <div class="complaint-card-content">
+    <h3 class="complaint-card-heading text-uppercase">Correspondent information</h3>
+    <table class="usa-table usa-table--borderless complaint-card-table">
+      <tr>
+        <th>Name</th>
+        <td>
+          <strong>
+            {% with l_name=data.contact_last_name|default:"—" f_name=data.contact_first_name|default:"—" %}
+            {{ l_name }}, {{ f_name }}
+            {% endwith %}
+          </strong>
+        </td>
+      </tr>
+      <tr>
+        <th>Email</th>
+        <td>{{ data.contact_email|default:"—" }}</td>
+      </tr>
+      <tr>
+        <th>Telephone</th>
+        <td>{{ data.contact_phone|default:"—" }}</td>
+      </tr>
+    </table>
+  </div>
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/full_summary.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/full_summary.html
@@ -1,4 +1,6 @@
 <div class="complaint-card complaint-card--rounded">
-  <h3 class="complaint-card-heading text-uppercase">Full summary</h3>
-  <p>{{ summary|linebreaks }}</p>
+  <div class="complaint-card-content">
+    <h3 class="complaint-card-heading text-uppercase">Full summary</h3>
+    <p>{{ summary|linebreaks }}</p>
+  </div>
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -19,11 +19,11 @@
 {% block main_class %} class="page-header-background"{% endblock %}
 
 {% block content %}
-  <div class="grid-container">
+  <div class="grid-container-widescreen">
     <div class="complaint-header bg-primary text-white">
-      <div class="grid-container">
+      <div class="grid-container-widescreen">
       <div class="grid-row grid-gap">
-        <div class="tablet:grid-col-6 grid-offset-2">
+        <div class="tablet:grid-col-6">
           <h2 class="text-uppercase">
             Complaint
           </h2>
@@ -32,7 +32,7 @@
             <span class="text-white">{{ data.create_date|date:'g:s a F j, Y' }}</span>
           </p>
         </div>
-        <div class="tablet:grid-col-3 tablet:grid-offset-1 text-right">
+        <div class="tablet:grid-col-3 tablet:grid-offset-3 text-right">
           <a class="usa-button usa-button--light close-record" href="/form/view{{ return_url_args }}">
             <img src="{% static "img/close-blue-50-alt.svg" %}">
             Close record
@@ -42,10 +42,11 @@
     </div>
     </div>
     <div class="complaint-body">
-      <div class="grid-container">
+      <div class="grid-container-widescreen">
         <div class="grid-row grid-gap-md">
           <div class="tablet:grid-col-4">
             {% include 'forms/complaint_view/show/actions.html' %}
+            {% include 'forms/complaint_view/show/activity_stream.html' %}
           </div>
           <div class="tablet:grid-col-8">
             {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -158,6 +158,7 @@ class ShowView(View):
 
         updates = {}
 
+        # see custom message options https://django-activity-stream.readthedocs.io/en/latest/data.html
         for key, value in request.POST.items():
             if key != 'csrfmiddlewaretoken' and key != 'next':
                 updates[key] = value

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -25,10 +25,6 @@ $complaint-body-offset: calc(
 }
 
 .complaint-card {
-  @include u-margin-bottom(1);
-  @include u-padding-y(1.5);
-  @include u-padding-x(2.5);
-  
   background-color: $white;
   box-shadow: 0 1px 6px 2px rgba(0,0,0,.14);
 
@@ -49,6 +45,12 @@ $complaint-body-offset: calc(
     &--rounded {
       @include u-radius('md');
     }
+  }
+
+  .complaint-card-content  {
+    @include u-margin-bottom(1);
+    @include u-padding-y(1.5);
+    @include u-padding-x(3);
   }
 
   .complaint-card-table {
@@ -80,6 +82,40 @@ $complaint-body-offset: calc(
     tr:last-child {
       th, td {
         border: none;
+      }
+    }
+  }
+}
+
+.activity-stream {
+  
+  
+  .heading {
+    background: $blue-warm-vivid-70;
+    color: white;
+    font-size: 22px;
+    padding: 1rem;
+    padding-left: 1.5rem;
+    text-transform: uppercase;
+  }
+  .complaint-card-content {
+    max-height: 368px;
+    overflow-y: scroll;
+  }
+
+  .activity-stream-list {
+    padding-top: 1.25rem;
+
+    .activity-stream-item {
+      border-bottom: 1px solid $theme-color-base-lighter;
+      padding: .5rem 0 .5rem 0;
+
+      &:not(:first-child) {
+        margin-top: 1rem;
+      }
+
+      .date {
+        color: #aeaeab;
       }
     }
   }


### PR DESCRIPTION
Follow up of the spike ticket to add an activity log to the backend. DOES NOT include commenting feature, that will come in a follow-up PR!

## What does this change?

* Adds actions to report updates
* Adds example feed of actions taken in to the `complaint details` view

## Screenshots (for front-end PR):
![Screen Shot 2020-02-19 at 1 27 38 PM](https://user-images.githubusercontent.com/1421848/74878509-56487400-531c-11ea-982e-a1e874db150c.png)



## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
