### PR TITLE
Update header to match new designs

### DIFF
--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -23,7 +23,6 @@
     {% block usa_banner %}
     <div class="usa-banner">
       <div class="usa-accordion">
-
         <header class="usa-banner__header">
           <div class="usa-banner__inner">
             <div class="grid-col-auto">
@@ -67,31 +66,32 @@
     {% endblock %}
 
     {% block page_header %}{% endblock %}
+    <div class="wrapper">
+      <main id="main-content" {% block main_class %}{% endblock %}>
+        {% block content %} {% endblock %}
+      </main>
 
-    <main id="main-content" {% block main_class %}{% endblock %}>
-      {% block content %} {% endblock %}
-    </main>
-
-    {% block usa_footer %}
-    <footer class="usa-footer usa-footer--slim" role="contentinfo">
-      <div class="usa-footer__secondary-section">
-        <div class="grid-container">
-          <div class="usa-footer__logo grid-row grid-gap-2">
-            <div class="grid-col-auto">
-              <img src="{% static "img/doj-logo-footer.svg" %}"
-                  alt=""
-                  height="64" />
-            </div>
-            <div class="grid-col-auto">
-              <p class="usa-footer__logo-heading">
-                Civil Rights Division
-                <br/> U.S. Department of Justice
-              </p>
+      {% block usa_footer %}
+      <footer class="usa-footer usa-footer--slim" role="contentinfo">
+        <div class="usa-footer__secondary-section">
+          <div class="grid-container">
+            <div class="usa-footer__logo grid-row grid-gap-2">
+              <div class="grid-col-auto">
+                <img src="{% static "img/doj-logo-footer.svg" %}"
+                    alt=""
+                    height="64" />
+              </div>
+              <div class="grid-col-auto">
+                <p class="usa-footer__logo-heading">
+                  Civil Rights Division
+                  <br/> U.S. Department of Justice
+                </p>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </footer>
+      </footer>
+    </div>
     {% endblock %}
   </body>
   <script src="{% static 'js/url_params_polyfill.js' %}"></script>

--- a/crt_portal/cts_forms/templates/forms/portal/header.html
+++ b/crt_portal/cts_forms/templates/forms/portal/header.html
@@ -1,47 +1,45 @@
 {% load static %}
-<section class="crt-form-header">
-  <header class="page-header-background flex-child">
-    <div class="grid-container-widescreen">
-      <div class="grid-row grid-gap flex-child">
-        <div class="tablet:grid-col-9 tablet:grid-offset-1">
-          <div class="doj-brand display-flex flex-align-center font-serif-lg">
-            <img
-              src="{% static "img/doj-logo-footer.svg" %}"
-              alt=""
-              height="38"
-              class="margin-right-105"
-            />
-            <span>United States Department of Justice<span>
-          </div>
-          <h1 class="padding-top-5 margin-0 title font-serif-3xl">
-            Submit a concern to the Civil Rights Division
-          </h1>
-        </div>
-      </div>
-      {# Progress text for screen reader. #}
-      <div class="grid-row grid-gap margin-top-5">
-        <div class="tablet:grid-col-10 tablet:grid-offset-1">
-          <div aria-label="progress">
-            <span class="usa-sr-only">
-              Current step: {{ current_step_name }}. Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}.
-            </span>
-            <ol class="steps">
-              {% for step in ordered_step_names %}
-                <li class="step {% if step == current_step_name %}current{%else%}{%endif%}" {% if step == current_step_name %}aria-current="true"{%else%}aria-current="false"{% endif %}>
-                  {{ step }}
-                  {% if step != current_step_name %}
-                    <span class="usa-sr-only">
-                      {% if forloop.counter > wizard.steps.step1 %}not completed{% else %}completed{% endif %}
-                    </span>
-                  {% endif %}
-                </li>
-              {% endfor %}
-              </ol>
-            <div class="connecting-line"></div>
-          </div>
-        </div>
-      </div>
 
+<header class="crt-form-header">
+  <div class="grid-container-widescreen">
+    <div class="grid-row grid-gap flex-child">
+      <div class="tablet:grid-col-9 tablet:grid-offset-1">
+        <div class="doj-brand display-flex flex-align-center font-serif-lg">
+          <img
+            src="{% static "img/doj-logo-footer.svg" %}"
+            alt=""
+            height="38"
+            class="margin-right-105"
+          />
+          <span>United States Department of Justice<span>
+        </div>
+        <h1 class="padding-top-5 padding-bottom-1 margin-0 title text-bold">
+          Submit a concern to the Civil Rights Division
+        </h1>
+      </div>
     </div>
-  </header>
-</section>
+    {# Progress text for screen reader. #}
+    <div class="grid-row grid-gap margin-top-5 progress-bar">
+      <div class="tablet:grid-col-10 tablet:grid-offset-1">
+        <div aria-label="progress">
+          <span class="usa-sr-only">
+            Current step: {{ current_step_name }}. Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}.
+          </span>
+          <ol class="steps">
+            {% for step in ordered_step_names %}
+              <li class="step {% if step == current_step_name %}current{%else%}{%endif%}" {% if step == current_step_name %}aria-current="true"{%else%}aria-current="false"{% endif %}>
+                {{ step }}
+                {% if step != current_step_name %}
+                  <span class="usa-sr-only">
+                    {% if forloop.counter > wizard.steps.step1 %}not completed{% else %}completed{% endif %}
+                  </span>
+                {% endif %}
+              </li>
+            {% endfor %}
+            </ol>
+          <div class="connecting-line"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>

--- a/crt_portal/cts_forms/templates/forms/portal/header.html
+++ b/crt_portal/cts_forms/templates/forms/portal/header.html
@@ -1,0 +1,47 @@
+{% load static %}
+<section class="crt-form-header">
+  <header class="page-header-background flex-child">
+    <div class="grid-container-widescreen">
+      <div class="grid-row grid-gap flex-child">
+        <div class="tablet:grid-col-9 tablet:grid-offset-1">
+          <div class="doj-brand display-flex flex-align-center font-serif-lg">
+            <img
+              src="{% static "img/doj-logo-footer.svg" %}"
+              alt=""
+              height="38"
+              class="margin-right-105"
+            />
+            <span>United States Department of Justice<span>
+          </div>
+          <h1 class="padding-top-5 margin-0 title font-serif-3xl">
+            Submit a concern to the Civil Rights Division
+          </h1>
+        </div>
+      </div>
+      {# Progress text for screen reader. #}
+      <div class="grid-row grid-gap margin-top-5">
+        <div class="tablet:grid-col-10 tablet:grid-offset-1">
+          <div aria-label="progress">
+            <span class="usa-sr-only">
+              Current step: {{ current_step_name }}. Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}.
+            </span>
+            <ol class="steps">
+              {% for step in ordered_step_names %}
+                <li class="step {% if step == current_step_name %}current{%else%}{%endif%}" {% if step == current_step_name %}aria-current="true"{%else%}aria-current="false"{% endif %}>
+                  {{ step }}
+                  {% if step != current_step_name %}
+                    <span class="usa-sr-only">
+                      {% if forloop.counter > wizard.steps.step1 %}not completed{% else %}completed{% endif %}
+                    </span>
+                  {% endif %}
+                </li>
+              {% endfor %}
+              </ol>
+            <div class="connecting-line"></div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </header>
+</section>

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -6,50 +6,11 @@
 {% endblock %}
 
 {% block page_header %}
-  <header class="page-header-background flex-child">
-    <div class="grid-container">
-      <div class="grid-row grid-gap flex-child">
-        <div class="tablet:grid-col-7 tablet:grid-offset-2">
-          <h1 class="padding-top-5 margin-0">
-            Contact the Department of Justice about a civil rights concern
-          </h1>
-          <div class="intro-subtitle padding-y-3">
-            If you believe you or someone else has experienced a civil rights violation, please tell us what happened
-          </div>
-        </div>
-      </div>
-    </div>
-  </header>
+  {% include 'forms/portal/header.html' %}
 {% endblock %}
 
-{% block content %}
-  {# Progress text for screen reader. #}
-  <div class="page-header-background">
-    <div class="grid-container">
-      <div class="grid-row grid-gap">
-        <div class="tablet:grid-col-7 tablet:grid-offset-2">
-          <div class="padding-bottom-4 padding-top-3" aria-label="progress">
-            <span class="usa-sr-only">
-              Current step: {{ current_step_name }}. Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}.
-            </span>
-            <ol class="steps">
-              {% for step in ordered_step_names %}
-                <li class="step {% if step == current_step_name %}current{%else%}{%endif%}" {% if step == current_step_name %}aria-current="true"{%else%}aria-current="false"{% endif %}>
-                  {{ step }}
-                  {% if step != current_step_name %}
-                    <span class="usa-sr-only">
-                      {% if forloop.counter > wizard.steps.step1 %}not completed{% else %}completed{% endif %}
-                    </span>
-                  {% endif %}
-                </li>
-              {% endfor %}
-              </ol>
-            <div class="connecting-line"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+  {% block content %}
+
 
   <div class="grid-container">
     <div class="grid-row grid-gap">

--- a/crt_portal/static/sass/custom/header.scss
+++ b/crt_portal/static/sass/custom/header.scss
@@ -1,7 +1,25 @@
 // Header area
 
+.crt-form-header {
+  background-color: $blue-warm-vivid-80;
+  color: white;
+  min-height: 464px;
+
+  header {
+    @include u-margin-top(8);
+  }
+
+  .title {
+    font-weight: 700;
+    line-height: 3.75rem;
+  }
+
+  .doj-brand {
+    font-weight: 700;
+  }
+}
 .page-header-background {
-  background-color: $light-beige;
+
 }
 
 .page-background {

--- a/crt_portal/static/sass/custom/header.scss
+++ b/crt_portal/static/sass/custom/header.scss
@@ -11,17 +11,22 @@
 
   .title {
     font-weight: 700;
+    font-size: 3.7rem;
     line-height: 3.75rem;
   }
 
   .doj-brand {
     font-weight: 700;
+    margin-top: 4rem;
   }
-}
-.page-header-background {
-
 }
 
 .page-background {
   background-color: $blue-warm-5;
+}
+
+.usa-banner {
+  .usa-banner__inner {
+    max-width: 87rem !important;
+  }
 }

--- a/crt_portal/static/sass/custom/layout.scss
+++ b/crt_portal/static/sass/custom/layout.scss
@@ -5,7 +5,7 @@ html, body {
   height: 100%;
 }
 
-body {
+.wrapper {
   display: flex;
   flex-direction: column;
   margin: 0;

--- a/crt_portal/static/sass/custom/progress.scss
+++ b/crt_portal/static/sass/custom/progress.scss
@@ -10,17 +10,17 @@ $steps-width: 100%;
 $label-font-size: .8em;
 $label-line-height: 1.25em;
 
-$counter-font-size: 1.25em;
+$counter-font-size: 13pt;
 
 $circle-diameter: 24px;
 $circle-border-width: 1px;
 $line-width: 1px;
 
-$visited-dark-blue: #1A4480;
-$outline-light-gray: #D8D8D8;
+$visited: #ffbe2e;
+$outline: white;
 
 .connecting-line {
-  border-bottom: 1px solid $outline-light-gray;
+  border-bottom: 1px solid white;
   position: relative;
   bottom: 52px;
   left: 15px;
@@ -54,7 +54,7 @@ ol.steps {
   .step {
     display: block;
     text-decoration: none;
-    color: black;
+    color: white;
   }
 
   .step::before,
@@ -78,10 +78,8 @@ ol.steps {
     height: $circle-diameter;
     line-height: $circle-diameter;
     margin: 0 auto .5em;
-
-    color: white;
-    background-color: $visited-dark-blue;
-    box-shadow: inset 0 0 0 $circle-border-width $visited-dark-blue;
+    color: $blue-warm-vivid-80;
+    background-color: $blue-warm-5;
   }
 
   // current milestone
@@ -89,17 +87,23 @@ ol.steps {
     &:focus {
       outline: 1px;
     }
-    .step {
+    &.step {
       font-weight: bold;
+
+      &::before {
+        background-color: $visited !important;
+        box-shadow: inset 0 0 0 $circle-border-width $visited;
+      }
     }
   }
 
   // unfinished milestone
   li.current   {
     ~ li.step::before {
-      color: black;
-      background-color: white;
-      box-shadow: inset 0 0 0 $circle-border-width $outline-light-gray;
+      color: white;
+      background-color: $blue-warm-vivid-80;
+      box-shadow: inset 0 0 0 $circle-border-width $outline;
+      border: 1px solid white;
     }
   }
 }

--- a/crt_portal/static/sass/custom/progress.scss
+++ b/crt_portal/static/sass/custom/progress.scss
@@ -19,12 +19,20 @@ $line-width: 1px;
 $visited: #ffbe2e;
 $outline: white;
 
+.progress-bar {
+  padding-bottom: 3.5rem;
+}
+
 .connecting-line {
   border-bottom: 1px solid white;
   position: relative;
   bottom: 52px;
   left: 15px;
   width: 95%;
+
+  @media only screen and (max-width: 480px) {
+    width: 90%;
+  }
 }
 
 // Steps Progress Bar

--- a/crt_portal/static/sass/custom/variables.scss
+++ b/crt_portal/static/sass/custom/variables.scss
@@ -4,6 +4,7 @@ $yellow: #FEE685;
 $gold: #FFBE2E;
 $light-beige: #F6F6F2;
 $blue-warm-vivid-70: #1A4480;
+$blue-warm-vivid-80: #162e51;
 $blue-warm-5: #ECF1F7;
 $blue-50: #2378C3;
 $blue-vivid-40: #2491FF;


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/232)

## What does this change?
Updates header design!

* This PR also remove the `flex` styling from the body element. This was causing the header to not resize appropriately on mobile. Instead, a wrapper div now encloses the `main` and `footer` tags to achieve the sticky footer effect. We'll want to keep an eye on this in IE 😬 


## Screenshots (for front-end PR):
<img width="1440" alt="Screen Shot 2020-02-20 at 8 02 45 AM" src="https://user-images.githubusercontent.com/1421848/74954263-ab859380-53b7-11ea-8e3b-ad9173360817.png">



## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
