### PR TITLE
Add card-style layout to portal

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -6,7 +6,7 @@ from django.forms import ModelForm, ChoiceField, TypedChoiceField, TextInput, Em
 from django.utils.translation import gettext_lazy as _
 
 from .question_group import QuestionGroup
-from .widgets import UsaRadioSelect, UsaCheckboxSelectMultiple, CrtRadioArea, CrtMultiSelect, ComplaintSelect
+from .widgets import UsaRadioSelect, UsaCheckboxSelectMultiple, CrtPrimaryIssueRadioGroup, CrtMultiSelect, ComplaintSelect
 from .models import Report, ProtectedClass, HateCrimesandTrafficking
 from .model_variables import (
     ELECTION_CHOICES,
@@ -125,14 +125,14 @@ class PrimaryReason(ModelForm):
             'primary_complaint'
         ]
         widgets = {
-            'primary_complaint': CrtRadioArea
+            'primary_complaint': CrtPrimaryIssueRadioGroup
         }
 
     def __init__(self, *args, **kwargs):
         ModelForm.__init__(self, *args, **kwargs)
         self.fields['primary_complaint'] = ChoiceField(
             choices=PRIMARY_COMPLAINT_CHOICES,
-            widget=CrtRadioArea(attrs={
+            widget=CrtPrimaryIssueRadioGroup(attrs={
                 'choices_to_examples': PRIMARY_COMPLAINT_CHOICES_TO_EXAMPLES,
                 'choices_to_helptext': PRIMARY_COMPLAINT_CHOICES_TO_HELPTEXT,
             }),

--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -98,6 +98,5 @@
   <script src="{% static 'js/url_params_polyfill.js' %}"></script>
   <script src="{% static 'js/uswds.min.js' %}"></script>
   <script src="{% static 'js/focus_alert.js' %}"></script>
-  <script src="{% static 'js/add_class_on_event.js'%}"></script>
   {% block page_js %}{% endblock %}
 </html>

--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -98,5 +98,6 @@
   <script src="{% static 'js/url_params_polyfill.js' %}"></script>
   <script src="{% static 'js/uswds.min.js' %}"></script>
   <script src="{% static 'js/focus_alert.js' %}"></script>
+  <script src="{% static 'js/add_class_on_event.js'%}"></script>
   {% block page_js %}{% endblock %}
 </html>

--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-  <div class="grid-container">
+  <div class="grid-container margin-top-9 padding-top-2">
     <div class="grid-col-1"></div>
       <h1>We have successfully received your form:</h1>
 

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -23,7 +23,7 @@
                 {{ num_page_errors }} error{{ num_page_errors|pluralize }}: {{ page_errors_desc }}
               </section>
             {% endif %}
-            <div class="margin-bottom-4 {% if not page_errors %}margin-top-5{% endif %}">
+            <div class="margin-bottom-4">
               <h2 class="margin-0">{{ current_step_title }}</h2>
               {% if page_note %}
                 <p class="margin-top-1"><em>{{ page_note }}</em></p>
@@ -51,25 +51,24 @@
 
               {% block form_questions %}
               {% endblock %}
-
-              <div class="margin-top-5 margin-bottom-9">
-                <input id="submit-next"
-                      type="submit"
-                      value="{% trans 'Next' %}"
-                      class="usa-button" />
-                {% if wizard.steps.prev %}
-                  <button name="wizard_goto_step"
-                          type="submit"
-                          label="previous step"
-                          value="{{ wizard.steps.prev }}"
-                          class="look-like-link margin-top-2 display-block">
-                    {% trans "Back" %}
-                  </button>
-                {% endif %}
-              </div>
-            </form>
+            </div>
           </div>
-        </div>
+          <div class="margin-top-5">
+            <input id="submit-next"
+                  type="submit"
+                  value="{% trans 'Next' %}"
+                  class="usa-button" />
+            {% if wizard.steps.prev %}
+              <button name="wizard_goto_step"
+                      type="submit"
+                      label="previous step"
+                      value="{{ wizard.steps.prev }}"
+                      class="look-like-link margin-top-2 display-block">
+                {% trans "Back" %}
+              </button>
+            {% endif %}
+          </div>
+        </form>
       </div>
     </div>
   </div>

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -9,15 +9,33 @@
   {% include 'forms/portal/header.html' %}
 {% endblock %}
 
-  {% block content %}
-
-
+{% block content %}
   <div class="grid-container">
     <div class="grid-row grid-gap">
       <div class="tablet:grid-col-8 tablet:grid-offset-2"">
         {% block page_info_card %}{% endblock %}
-        <div class="crt-portal-card">
-          <div class="crt-portal-card__content">
+        <form id="report-form"
+              class="usa-form"
+              action="/report/"
+              method="post"
+              {% if form_autocomplete_off %}autocomplete="off"{% endif %}
+              {% if form_novalidate %}novalidate{% endif %}
+        >
+          {% csrf_token %}
+          {{ wizard.management_form }}
+
+          {% if form.non_field_errors %}
+            {% include "forms/snippets/error_alert.html" with errors=form.non_field_errors %}
+          {% endif %}
+
+          {% for hidden_field in form.hidden_fields %}
+            {% if hidden_field.errors %}
+              {% include "forms/snippets/error_alert.html" with errors=hidden_field.errors %}
+            {% endif %}
+            {{ hidden_field }}
+          {% endfor %}
+
+          {% block form_questions %}
             {% if page_errors %}
               <section id="page-errors" class="display-none page-errors margin-top-4 margin-bottom-2" role="alert" aria-live="assertive">
                 {{ num_page_errors }} error{{ num_page_errors|pluralize }}: {{ page_errors_desc }}
@@ -29,30 +47,7 @@
                 <p class="margin-top-1"><em>{{ page_note }}</em></p>
               {% endif %}
             </div>
-            <form id="report-form"
-                  class="usa-form"
-                  action="/report/"
-                  method="post"
-                  {% if form_autocomplete_off %}autocomplete="off"{% endif %}
-                  {% if form_novalidate %}novalidate{% endif %}>
-              {% csrf_token %}
-              {{ wizard.management_form }}
-
-              {% if form.non_field_errors %}
-                {% include "forms/snippets/error_alert.html" with errors=form.non_field_errors %}
-              {% endif %}
-
-              {% for hidden_field in form.hidden_fields %}
-                {% if hidden_field.errors %}
-                  {% include "forms/snippets/error_alert.html" with errors=hidden_field.errors %}
-                {% endif %}
-                {{ hidden_field }}
-              {% endfor %}
-
-              {% block form_questions %}
-              {% endblock %}
-            </div>
-          </div>
+          {% endblock %}
           <div class="margin-top-5">
             <input id="submit-next"
                   type="submit"
@@ -69,8 +64,6 @@
             {% endif %}
           </div>
         </form>
-      </div>
-    </div>
   </div>
 {% endblock %}
 

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -15,61 +15,61 @@
   <div class="grid-container">
     <div class="grid-row grid-gap">
       <div class="tablet:grid-col-8 tablet:grid-offset-2"">
-        {% if page_errors %}
-          <section id="page-errors" class="display-none page-errors margin-top-4 margin-bottom-2" role="alert" aria-live="assertive">
-            {{ num_page_errors }} error{{ num_page_errors|pluralize }}: {{ page_errors_desc }}
-          </section>
-        {% endif %}
-        <div class="margin-bottom-4 {% if not page_errors %}margin-top-5{% endif %}">
-          <h2 class="margin-0">{{ current_step_title }}</h2>
-          {% if page_note %}
-            <p class="margin-top-1"><em>{{ page_note }}</em></p>
-          {% endif %}
-        </div>
-      </div>
-    </div>
-
-    <div class="grid-row grid-gap">
-      <div class="tablet:grid-col-7 tablet:grid-offset-2">
-        <form id="report-form"
-              class="usa-form"
-              action="/report/"
-              method="post"
-              {% if form_autocomplete_off %}autocomplete="off"{% endif %}
-              {% if form_novalidate %}novalidate{% endif %}>
-          {% csrf_token %}
-          {{ wizard.management_form }}
-
-          {% if form.non_field_errors %}
-            {% include "forms/snippets/error_alert.html" with errors=form.non_field_errors %}
-          {% endif %}
-
-          {% for hidden_field in form.hidden_fields %}
-            {% if hidden_field.errors %}
-              {% include "forms/snippets/error_alert.html" with errors=hidden_field.errors %}
+        {% block page_info_card %}{% endblock %}
+        <div class="crt-portal-card">
+          <div class="crt-portal-card__content">
+            {% if page_errors %}
+              <section id="page-errors" class="display-none page-errors margin-top-4 margin-bottom-2" role="alert" aria-live="assertive">
+                {{ num_page_errors }} error{{ num_page_errors|pluralize }}: {{ page_errors_desc }}
+              </section>
             {% endif %}
-            {{ hidden_field }}
-          {% endfor %}
+            <div class="margin-bottom-4 {% if not page_errors %}margin-top-5{% endif %}">
+              <h2 class="margin-0">{{ current_step_title }}</h2>
+              {% if page_note %}
+                <p class="margin-top-1"><em>{{ page_note }}</em></p>
+              {% endif %}
+            </div>
+            <form id="report-form"
+                  class="usa-form"
+                  action="/report/"
+                  method="post"
+                  {% if form_autocomplete_off %}autocomplete="off"{% endif %}
+                  {% if form_novalidate %}novalidate{% endif %}>
+              {% csrf_token %}
+              {{ wizard.management_form }}
 
-          {% block form_questions %}
-          {% endblock %}
+              {% if form.non_field_errors %}
+                {% include "forms/snippets/error_alert.html" with errors=form.non_field_errors %}
+              {% endif %}
 
-          <div class="margin-top-5 margin-bottom-9">
-            <input id="submit-next"
-                   type="submit"
-                   value="{% trans 'Next' %}"
-                   class="usa-button" />
-            {% if wizard.steps.prev %}
-              <button name="wizard_goto_step"
+              {% for hidden_field in form.hidden_fields %}
+                {% if hidden_field.errors %}
+                  {% include "forms/snippets/error_alert.html" with errors=hidden_field.errors %}
+                {% endif %}
+                {{ hidden_field }}
+              {% endfor %}
+
+              {% block form_questions %}
+              {% endblock %}
+
+              <div class="margin-top-5 margin-bottom-9">
+                <input id="submit-next"
                       type="submit"
-                      label="previous step"
-                      value="{{ wizard.steps.prev }}"
-                      class="look-like-link margin-top-2 display-block">
-                {% trans "Back" %}
-              </button>
-            {% endif %}
+                      value="{% trans 'Next' %}"
+                      class="usa-button" />
+                {% if wizard.steps.prev %}
+                  <button name="wizard_goto_step"
+                          type="submit"
+                          label="previous step"
+                          value="{{ wizard.steps.prev }}"
+                          class="look-like-link margin-top-2 display-block">
+                    {% trans "Back" %}
+                  </button>
+                {% endif %}
+              </div>
+            </form>
           </div>
-        </form>
+        </div>
       </div>
     </div>
   </div>

--- a/crt_portal/cts_forms/templates/forms/report_class.html
+++ b/crt_portal/cts_forms/templates/forms/report_class.html
@@ -1,25 +1,28 @@
 {% extends "forms/report_base.html" %}
 {% load static %}
 {% block form_questions %}
+  <div class="crt-portal-card">
+    <div class="crt-portal-card__content">
+      {{ block.super }}
 
-<div data-toggle>
-{% include 'forms/grouped_questions.html' %}
-{% with field=wizard.form.other_class %}
-  <div class='other-class-option' class="padding-left-4">
-    <div class="blue-left-highlight">
-      <div>
-        <label for="{{ field.id_for_label }}">{{ field.help_text }}</label>
-        {{ field }}
-        <div class="margin-top-1">
-          {% include "forms/word_counter.html" with word_limit=10 %}
+      <div data-toggle>
+      {% include 'forms/grouped_questions.html' %}
+      {% with field=wizard.form.other_class %}
+        <div class='other-class-option' class="padding-left-4">
+          <div class="blue-left-highlight">
+            <div>
+              <label for="{{ field.id_for_label }}">{{ field.help_text }}</label>
+              {{ field }}
+              <div class="margin-top-1">
+                {% include "forms/word_counter.html" with word_limit=10 %}
+              </div>
+            </div>
+          </div>
         </div>
+      {% endwith %}
       </div>
     </div>
   </div>
-{% endwith %}
-</div>
-
-<div class="margin-bottom-5"></div>
 {% endblock %}
 
 {% block page_js %}

--- a/crt_portal/cts_forms/templates/forms/report_contact_info.html
+++ b/crt_portal/cts_forms/templates/forms/report_contact_info.html
@@ -1,0 +1,28 @@
+{% extends "forms/report_base.html" %}
+{% block form_questions %}
+  <div class="crt-portal-card">
+    <div class="crt-portal-card__content">
+      {{ block.super }}
+      {% include 'forms/grouped_questions.html' %}
+    </div>
+  </div>
+
+  <div class="crt-portal-card margin-top-3">
+    <div class="crt-portal-card__content">  
+      {% with field=wizard.form.servicemember %}
+        <fieldset class="usa-fieldset">
+          <legend class="em-text big margin-bottom-0">
+            {{field.label}}
+          </legend>
+          <em id="service-member-help-text">{{ field.help_text }}</em>
+          <div aria-labelledby="service-member-help-text">
+            {{ field }}
+            {% if field.errors %}
+              {% include "forms/snippets/error_alert.html" with errors=field.errors %}
+            {% endif %}
+          </div>
+        </fieldset>
+      {% endwith %}
+    </div>
+  </div>
+{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_date.html
+++ b/crt_portal/cts_forms/templates/forms/report_date.html
@@ -1,51 +1,56 @@
 {% extends "forms/report_base.html" %}
 
 {% block form_questions %}
-  <fieldset class="usa-fieldset">
-    <legend class="em-text ">
-      When did this happen?
-    </legend>
+  <div class="crt-portal-card">
+    <div class="crt-portal-card__content">
+      {{ block.super }}
+      <fieldset class="usa-fieldset">
+        <legend class="em-text ">
+          When did this happen?
+        </legend>
 
-    <p class="margin-top-0 margin-bottom-1" id="incident-date-help-text">
-      <em>
-        If this happened over a period of time or is still happening, please provide the most recent date. Please use the format MM/DD/YY.
-      </em>
-    </p>
-    {% with month=wizard.form.last_incident_month day=wizard.form.last_incident_day year=wizard.form.last_incident_year %}
-      <section class="usa-memorable-date">
-        <div class="grid-row grid-gap" aria-labelledby="incident-date-help-text">
-          <div class="mobile-lg:grid-col-3">
-            <label class="usa-label" for="{{ month.id_for_label }}">
-              {{ month.label }}
-            </label>
-            {{ month|withInputError }}
-          </div>
-          <div class="mobile-lg:grid-col-3">
-            <label class="usa-label" for="{{ day.id_for_label}}">
-              {{ day.label }} <span class="usa-sr-only">optional</span>
-            </label>
-            {{ day }}
-            <p class="margin-bottom-0 margin-top-1">
-              <em>Optional</em>
-            </p>
-          </div>
-          <div class="mobile-lg:grid-col-6">
-            <label class="usa-label" for="{{ year.id_for_label }}">
-              {{ year.label }}
-            </label>
-            {{ year|withInputError }}
-          </div>
-        </div>
-      </section>
-    {% if month.errors %}
-      {% include "forms/snippets/error_alert.html" with errors=month.errors %}
-    {% endif %}
-    {% if day.errors %}
-      {% include "forms/snippets/error_alert.html" with errors=day.errors %}
-    {% endif %}
-    {% if year.errors %}
-      {% include "forms/snippets/error_alert.html" with errors=year.errors %}
-    {% endif %}
-  </fieldset>
-  {% endwith %}
+        <p class="margin-top-0 margin-bottom-1" id="incident-date-help-text">
+          <em>
+            If this happened over a period of time or is still happening, please provide the most recent date. Please use the format MM/DD/YY.
+          </em>
+        </p>
+        {% with month=wizard.form.last_incident_month day=wizard.form.last_incident_day year=wizard.form.last_incident_year %}
+          <section class="usa-memorable-date">
+            <div class="grid-row grid-gap" aria-labelledby="incident-date-help-text">
+              <div class="mobile-lg:grid-col-3">
+                <label class="usa-label" for="{{ month.id_for_label }}">
+                  {{ month.label }}
+                </label>
+                {{ month|withInputError }}
+              </div>
+              <div class="mobile-lg:grid-col-3">
+                <label class="usa-label" for="{{ day.id_for_label}}">
+                  {{ day.label }} <span class="usa-sr-only">optional</span>
+                </label>
+                {{ day }}
+                <p class="margin-bottom-0 margin-top-1">
+                  <em>Optional</em>
+                </p>
+              </div>
+              <div class="mobile-lg:grid-col-6">
+                <label class="usa-label" for="{{ year.id_for_label }}">
+                  {{ year.label }}
+                </label>
+                {{ year|withInputError }}
+              </div>
+            </div>
+          </section>
+        {% if month.errors %}
+          {% include "forms/snippets/error_alert.html" with errors=month.errors %}
+        {% endif %}
+        {% if day.errors %}
+          {% include "forms/snippets/error_alert.html" with errors=day.errors %}
+        {% endif %}
+        {% if year.errors %}
+          {% include "forms/snippets/error_alert.html" with errors=year.errors %}
+        {% endif %}
+      </fieldset>
+    {% endwith %}
+  </div>
+</div>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_details.html
+++ b/crt_portal/cts_forms/templates/forms/report_details.html
@@ -1,26 +1,31 @@
 {% extends "forms/report_base.html" %}
 {% block form_questions %}
-  {% for field in wizard.form.visible_fields %}
+	<div class="crt-portal-card">
+		<div class="crt-portal-card__content">
+			{{ block.super }}
+			{% for field in wizard.form.visible_fields %}
 
-    <div class="margin-bottom-2">
-	  <label
-	    for="{{ field.id_for_label }}"
-	    class="{{label_class}} margin-bottom-0"
-	  >
-	    <span class="em-text display-block margin-bottom-1">{{ field.label }}</span>
-		{% if field.help_text %}
-		  <em>{{ field.help_text }}</em>
-		{% endif %}
-	  </label>
+				<div class="margin-bottom-2">
+				<label
+					for="{{ field.id_for_label }}"
+					class="{{label_class}} margin-bottom-0"
+				>
+					<span class="em-text display-block margin-bottom-1">{{ field.label }}</span>
+				{% if field.help_text %}
+					<em>{{ field.help_text }}</em>
+				{% endif %}
+				</label>
 
+			</div>
+			<div class="margin-bottom-4">
+				{{ field|withInputError }}
+				{% if field.errors %}
+					{% include "forms/snippets/error_alert.html" with errors=field.errors %}
+				{% endif %}
+			</div>
+
+				{% include "forms/word_counter.html" with word_limit=500 %}
+			{% endfor %}
+		</div>
 	</div>
-	<div class="margin-bottom-4">
-	  {{ field|withInputError }}
-	  {% if field.errors %}
-	    {% include "forms/snippets/error_alert.html" with errors=field.errors %}
-	  {% endif %}
-	</div>
-
-    {% include "forms/word_counter.html" with word_limit=500 %}
-  {% endfor %}
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_grouped_questions.html
+++ b/crt_portal/cts_forms/templates/forms/report_grouped_questions.html
@@ -1,20 +1,9 @@
 {% extends "forms/report_base.html" %}
 {% block form_questions %}
-  {% include 'forms/grouped_questions.html' %}
-  {% if wizard.form.servicemember %}
-    {% with field=wizard.form.servicemember %}
-        <fieldset class="usa-fieldset">
-          <legend class="em-text big margin-bottom-0">
-            {{field.label}}
-          </legend>
-          <em id="service-member-help-text">{{ field.help_text }}</em>
-          <div aria-labelledby="service-member-help-text">
-            {{ field }}
-            {% if field.errors %}
-              {% include "forms/snippets/error_alert.html" with errors=field.errors %}
-            {% endif %}
-          </div>
-        </fieldset>
-      {% endwith %}
-    {% endif %}
-  {% endblock %}
+  <div class="crt-portal-card">
+    <div class="crt-portal-card__content">
+      {{ block.super }}
+      {% include 'forms/grouped_questions.html' %}
+    </div>
+  </div>
+{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_location.html
+++ b/crt_portal/cts_forms/templates/forms/report_location.html
@@ -2,34 +2,40 @@
 {% load static %}
 
 {% block form_questions %}
-  {% if wizard.form.name == 'PoliceLocation' %}
-    {% include "forms/report_police_location.html" with form=form %}
-  {% elif wizard.form.name == 'CommericalPublicLocation' %}
-    {% include 'forms/report_commercial_public_location.html' %}
-  {% endif %}
+  <div class="crt-portal-card">
+    <div class="crt-portal-card__content">
+      {{ block.super }}
+    
+      {% if wizard.form.name == 'PoliceLocation' %}
+        {% include "forms/report_police_location.html" with form=form %}
+      {% elif wizard.form.name == 'CommericalPublicLocation' %}
+        {% include 'forms/report_commercial_public_location.html' %}
+      {% endif %}
 
-  {% include 'forms/grouped_questions.html' %}
-  
-  {% with city=wizard.form.location_city_town state=wizard.form.location_state %}
-    <div class="grid-row grid-gap margin-y-neg-2 margin-bottom-5">
-      <div class="mobile-lg:grid-col-8">
-        <label for="{{city.id_for_label}}">
-          {{ city.label }}
-        </label>
-        {{city|withInputError}}
-      </div>
-      <div class="mobile-lg:grid-col-4">
-        <label for="{{state.id_for_label}}">
-          {{state.label}}
-        </label>
-        {{state|withInputError}}
-      </div>
+      {% include 'forms/grouped_questions.html' %}
+      
+      {% with city=wizard.form.location_city_town state=wizard.form.location_state %}
+        <div class="grid-row grid-gap margin-y-neg-2 margin-bottom-5">
+          <div class="mobile-lg:grid-col-8">
+            <label for="{{city.id_for_label}}">
+              {{ city.label }}
+            </label>
+            {{city|withInputError}}
+          </div>
+          <div class="mobile-lg:grid-col-4">
+            <label for="{{state.id_for_label}}">
+              {{state.label}}
+            </label>
+            {{state|withInputError}}
+          </div>
+        </div>
+        {% if city.errors %}
+          {% include "forms/snippets/error_alert.html" with errors=city.errors %}
+        {% endif %}
+        {% if state.errors %}
+          {% include "forms/snippets/error_alert.html" with errors=state.errors %}
+        {% endif %}
+      {% endwith %}
     </div>
-    {% if city.errors %}
-      {% include "forms/snippets/error_alert.html" with errors=city.errors %}
-    {% endif %}
-    {% if state.errors %}
-      {% include "forms/snippets/error_alert.html" with errors=state.errors %}
-    {% endif %}
-  {% endwith %}
+  </div>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
+++ b/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
@@ -1,4 +1,5 @@
 {% extends "forms/report_base.html" %}
+{% load static %}
 {% block form_questions %}
   {% with primary_complaint_field=wizard.form.primary_complaint %}
     <fieldset class="usa-fieldset margin-bottom-5 question_{{primary_complaint_field.name}}">      
@@ -22,4 +23,8 @@
     </fieldset>
   {% endwith %}
   {% include "forms/grouped_questions.html" %}
+{% endblock %}
+{% block page_js %}
+  {{ block.super }}
+  <script src="{% static 'js/primary_complaint.js' %}"></script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
+++ b/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
@@ -1,28 +1,31 @@
 {% extends "forms/report_base.html" %}
 {% load static %}
 {% block form_questions %}
-  {% with primary_complaint_field=wizard.form.primary_complaint %}
-    <fieldset class="usa-fieldset margin-bottom-5 question_{{primary_complaint_field.name}}">      
-      <legend class="em-text margin-bottom-2">
-        {{ primary_complaint_field.label }}
-      </legend>
-
-      {% if primary_complaint_field.help_text %}
-        <div id="primary-complaint-help-text" class="margin-bottom-4">
-          <em>{{ primary_complaint_field.help_text }}</em>
+{% with primary_complaint_field=wizard.form.primary_complaint %}
+    <div class="crt-portal-card">
+      <div class="crt-portal-card__content">
+        {{ block.super }}
+        <div id="primary-complaint-help-text">
+          <p class="em-text">
+            {{ primary_complaint_field.label }}
+          </p>
+        
+          {% if primary_complaint_field.help_text %}
+            <div>
+              <em>{{ primary_complaint_field.help_text }}</em>
+            </div>
+          {% endif %}
         </div>
-      {% endif %}
-
-      <div aria-labelledby="primary-complaint-help-text">
-        {{ primary_complaint_field }}
-
-        {% if primary_complaint_field.errors %}
-          {% include "forms/snippets/error_alert.html" with errors=primary_complaint_field.errors %}
-        {% endif %}
       </div>
-    </fieldset>
+    </div>
+    <div role="group" aria-labelledby="primary-complaint-help-text" class="question_primary_complaint">
+      {{ primary_complaint_field }}
+
+      {% if primary_complaint_field.errors %}
+        {% include "forms/snippets/error_alert.html" with errors=primary_complaint_field.errors %}
+      {% endif %}
+    </div>
   {% endwith %}
-  {% include "forms/grouped_questions.html" %}
 {% endblock %}
 {% block page_js %}
   {{ block.super }}

--- a/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
@@ -1,42 +1,44 @@
-<div class="usa-radio">
-  <input type="radio"
-         name="{{ widget.name }}"
-         {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
-         class="usa-radio__input"
-         {% include "django/forms/widgets/attrs.html" %} />
-  <label class="crt-radio__label_area"
-         {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
-    <div class="label-text margin-top-2 padding-left-5">
-      <h3 class="margin-top-0 margin-bottom-1">
-        {{ widget.label }}<span class="usa-sr-only">.</span>
-      </h3>
-      {% if widget.value != None %}
-        {% for reason, helptext in widget.attrs.choices_to_helptext.items %}
-          {% if widget.value == reason %}
-            <em class="margin-top-1">{{ helptext }}</em>
-          {% endif %}
-        {% endfor %}
-      {% endif %}
-      {% if widget.value != None %}
-        {% for reason, examples in widget.attrs.choices_to_examples.items %}
-          {% if widget.value == reason %}
-            {% if examples %}
-              <div class="examples-title margin-top-2">
-                Examples:
-              </div>
-              <ul class="margin-top-1" role="presentation">
-                {% for example in examples %}
-                  <li class="primary-issue-example-li" role="listitem">
-                    {{ example }}<span class="usa-sr-only">.</span>
-                  </li>
-                {% endfor %}
-              </ul>
-            {% else %}
-              <div class="margin-bottom-2"></div>
+<div class="crt-portal-card crt-hover-card">
+  <div class="crt-portal-card__content">
+    <input type="radio"
+          name="{{ widget.name }}"
+          {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
+          class="usa-radio__input"
+          {% include "django/forms/widgets/attrs.html" %} />
+    <label class="crt-radio__label_area"
+          {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
+      <div class="label-text margin-top-2 padding-left-5">
+        <h3 class="margin-top-0 margin-bottom-1">
+          {{ widget.label }}<span class="usa-sr-only">.</span>
+        </h3>
+        {% if widget.value != None %}
+          {% for reason, helptext in widget.attrs.choices_to_helptext.items %}
+            {% if widget.value == reason %}
+              <em class="margin-top-1">{{ helptext }}</em>
             {% endif %}
-          {% endif %}
-        {% endfor %}
-      {% endif %}
-    </div>
-  </label>
+          {% endfor %}
+        {% endif %}
+        {% if widget.value != None %}
+          {% for reason, examples in widget.attrs.choices_to_examples.items %}
+            {% if widget.value == reason %}
+              {% if examples %}
+                <div class="examples-title margin-top-2">
+                  Examples:
+                </div>
+                <ul class="margin-top-1" role="presentation">
+                  {% for example in examples %}
+                    <li class="primary-issue-example-li" role="listitem">
+                      {{ example }}<span class="usa-sr-only">.</span>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <div class="margin-bottom-2"></div>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      </div>
+    </label>
+  </div>
 </div>

--- a/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
@@ -1,44 +1,40 @@
-<div class="crt-portal-card crt-hover-card">
-  <div class="crt-portal-card__content">
-    <input type="radio"
-          name="{{ widget.name }}"
-          {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
-          class="usa-radio__input"
-          {% include "django/forms/widgets/attrs.html" %} />
-    <label class="crt-radio__label_area"
-          {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
-      <div class="label-text margin-top-2 padding-left-5">
-        <h3 class="margin-top-0 margin-bottom-1">
-          {{ widget.label }}<span class="usa-sr-only">.</span>
-        </h3>
-        {% if widget.value != None %}
-          {% for reason, helptext in widget.attrs.choices_to_helptext.items %}
-            {% if widget.value == reason %}
-              <em class="margin-top-1">{{ helptext }}</em>
-            {% endif %}
-          {% endfor %}
+<input type="radio"
+      name="{{ widget.name }}"
+      {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
+      class="usa-radio__input"
+      {% include "django/forms/widgets/attrs.html" %} />
+<label class="crt-radio__label_area"
+      {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
+  <div class="label-text margin-top-2 padding-left-5">
+    <h3 class="margin-top-0 margin-bottom-1">
+      {{ widget.label }}<span class="usa-sr-only">.</span>
+    </h3>
+    {% if widget.value != None %}
+      {% for reason, helptext in widget.attrs.choices_to_helptext.items %}
+        {% if widget.value == reason %}
+          <em class="margin-top-1">{{ helptext }}</em>
         {% endif %}
-        {% if widget.value != None %}
-          {% for reason, examples in widget.attrs.choices_to_examples.items %}
-            {% if widget.value == reason %}
-              {% if examples %}
-                <div class="examples-title margin-top-2">
-                  Examples:
-                </div>
-                <ul class="margin-top-1" role="presentation">
-                  {% for example in examples %}
-                    <li class="primary-issue-example-li" role="listitem">
-                      {{ example }}<span class="usa-sr-only">.</span>
-                    </li>
-                  {% endfor %}
-                </ul>
-              {% else %}
-                <div class="margin-bottom-2"></div>
-              {% endif %}
-            {% endif %}
-          {% endfor %}
+      {% endfor %}
+    {% endif %}
+    {% if widget.value != None %}
+      {% for reason, examples in widget.attrs.choices_to_examples.items %}
+        {% if widget.value == reason %}
+          {% if examples %}
+            <div class="examples-title margin-top-2">
+              Examples:
+            </div>
+            <ul class="margin-top-1" role="presentation">
+              {% for example in examples %}
+                <li class="primary-issue-example-li" role="listitem">
+                  {{ example }}<span class="usa-sr-only">.</span>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <div class="margin-bottom-2"></div>
+          {% endif %}
         {% endif %}
-      </div>
-    </label>
+      {% endfor %}
+    {% endif %}
   </div>
-</div>
+</label>

--- a/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
@@ -1,4 +1,5 @@
-
+<div class="crt-portal-card crt-hover-card">
+  <div class="crt-portal-card__content">
     <input type="radio"
           name="{{ widget.name }}"
           {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
@@ -6,40 +7,38 @@
           {% include "django/forms/widgets/attrs.html" %} />
     <label class="crt-radio__label_area"
           {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
-      <div class="crt-portal-card crt-hover-card">
-        <div class="crt-portal-card__content">
-          <div class="label-text margin-top-4 padding-left-5">
-            <h3 class="margin-top-0 margin-bottom-1">
-              {{ widget.label }}<span class="usa-sr-only">.</span>
-            </h3>
-            {% if widget.value != None %}
-              {% for reason, helptext in widget.attrs.choices_to_helptext.items %}
-                {% if widget.value == reason %}
-                  <em class="margin-top-1">{{ helptext }}</em>
-                {% endif %}
-              {% endfor %}
+      <div class="label-text margin-top-2 padding-left-5">
+        <h3 class="margin-top-0 margin-bottom-1">
+          {{ widget.label }}<span class="usa-sr-only">.</span>
+        </h3>
+        {% if widget.value != None %}
+          {% for reason, helptext in widget.attrs.choices_to_helptext.items %}
+            {% if widget.value == reason %}
+              <em class="margin-top-1">{{ helptext }}</em>
             {% endif %}
-            {% if widget.value != None %}
-              {% for reason, examples in widget.attrs.choices_to_examples.items %}
-                {% if widget.value == reason %}
-                  {% if examples %}
-                    <div class="examples-title margin-top-2">
-                      Examples:
-                    </div>
-                    <ul class="margin-top-1" role="presentation">
-                      {% for example in examples %}
-                        <li class="primary-issue-example-li" role="listitem">
-                          {{ example }}<span class="usa-sr-only">.</span>
-                        </li>
-                      {% endfor %}
-                    </ul>
-                  {% else %}
-                    <div class="margin-bottom-2"></div>
-                  {% endif %}
-                {% endif %}
-              {% endfor %}
+          {% endfor %}
+        {% endif %}
+        {% if widget.value != None %}
+          {% for reason, examples in widget.attrs.choices_to_examples.items %}
+            {% if widget.value == reason %}
+              {% if examples %}
+                <div class="examples-title margin-top-2">
+                  Examples:
+                </div>
+                <ul class="margin-top-1" role="presentation">
+                  {% for example in examples %}
+                    <li class="primary-issue-example-li" role="listitem">
+                      {{ example }}<span class="usa-sr-only">.</span>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <div class="margin-bottom-2"></div>
+              {% endif %}
             {% endif %}
-          </div>
-        </div>
+          {% endfor %}
+        {% endif %}
       </div>
     </label>
+  </div>
+</div>

--- a/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
@@ -1,5 +1,4 @@
-<div class="crt-portal-card crt-hover-card">
-  <div class="crt-portal-card__content">
+
     <input type="radio"
           name="{{ widget.name }}"
           {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
@@ -7,38 +6,40 @@
           {% include "django/forms/widgets/attrs.html" %} />
     <label class="crt-radio__label_area"
           {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
-      <div class="label-text margin-top-2 padding-left-5">
-        <h3 class="margin-top-0 margin-bottom-1">
-          {{ widget.label }}<span class="usa-sr-only">.</span>
-        </h3>
-        {% if widget.value != None %}
-          {% for reason, helptext in widget.attrs.choices_to_helptext.items %}
-            {% if widget.value == reason %}
-              <em class="margin-top-1">{{ helptext }}</em>
+      <div class="crt-portal-card crt-hover-card">
+        <div class="crt-portal-card__content">
+          <div class="label-text margin-top-4 padding-left-5">
+            <h3 class="margin-top-0 margin-bottom-1">
+              {{ widget.label }}<span class="usa-sr-only">.</span>
+            </h3>
+            {% if widget.value != None %}
+              {% for reason, helptext in widget.attrs.choices_to_helptext.items %}
+                {% if widget.value == reason %}
+                  <em class="margin-top-1">{{ helptext }}</em>
+                {% endif %}
+              {% endfor %}
             {% endif %}
-          {% endfor %}
-        {% endif %}
-        {% if widget.value != None %}
-          {% for reason, examples in widget.attrs.choices_to_examples.items %}
-            {% if widget.value == reason %}
-              {% if examples %}
-                <div class="examples-title margin-top-2">
-                  Examples:
-                </div>
-                <ul class="margin-top-1" role="presentation">
-                  {% for example in examples %}
-                    <li class="primary-issue-example-li" role="listitem">
-                      {{ example }}<span class="usa-sr-only">.</span>
-                    </li>
-                  {% endfor %}
-                </ul>
-              {% else %}
-                <div class="margin-bottom-2"></div>
-              {% endif %}
+            {% if widget.value != None %}
+              {% for reason, examples in widget.attrs.choices_to_examples.items %}
+                {% if widget.value == reason %}
+                  {% if examples %}
+                    <div class="examples-title margin-top-2">
+                      Examples:
+                    </div>
+                    <ul class="margin-top-1" role="presentation">
+                      {% for example in examples %}
+                        <li class="primary-issue-example-li" role="listitem">
+                          {{ example }}<span class="usa-sr-only">.</span>
+                        </li>
+                      {% endfor %}
+                    </ul>
+                  {% else %}
+                    <div class="margin-bottom-2"></div>
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
             {% endif %}
-          {% endfor %}
-        {% endif %}
+          </div>
+        </div>
       </div>
     </label>
-  </div>
-</div>

--- a/crt_portal/cts_forms/templates/forms/widgets/multiple_inputs.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/multiple_inputs.html
@@ -1,0 +1,23 @@
+{% with id=widget.attrs.id %}
+<ul{% if id %} id="{{ id }}"{% endif %}{% if widget.attrs.class %} class="{{ widget.attrs.class }}"{% endif %}>
+  {% for group, options, index in widget.optgroups %}
+    {% if group %}
+      <li>
+        {{ group }}
+        <ul{% if id %} id="{{ id }}_{{ index }}"{% endif %}>
+    {% endif %}
+    {% for option in options %}
+      <li>
+        <div class="crt-portal-card crt-hover-card">
+          <div class="crt-portal-card__content">
+            {% include option.template_name with widget=option %}
+          </div>
+        </div>
+      </li>
+    {% endfor %}
+    {% if group %}
+      </ul></li>
+    {% endif %}
+  {% endfor %}
+</ul>
+{% endwith %}

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -185,7 +185,7 @@ class ShowView(View):
 
 TEMPLATES = [
     # Contact
-    'forms/report_grouped_questions.html',
+    'forms/report_contact_info.html',
     # Primary reason
     'forms/report_primary_complaint.html',
     # Hate crimes and trafficking

--- a/crt_portal/cts_forms/widgets.py
+++ b/crt_portal/cts_forms/widgets.py
@@ -7,9 +7,9 @@ class UsaRadioSelect(ChoiceWidget):
     option_template_name = '../templates/forms/widgets/usa_radio_option.html'
 
 
-class CrtRadioArea(ChoiceWidget):
+class CrtPrimaryIssueRadioGroup(ChoiceWidget):
     input_type = 'radio'
-    template_name = 'django/forms/widgets/radio.html'
+    template_name = '../templates/forms/widgets/multiple_inputs.html'
     option_template_name = '../templates/forms/widgets/crt_radio_area_option.html'
 
 

--- a/crt_portal/static/js/primary_complaint.js
+++ b/crt_portal/static/js/primary_complaint.js
@@ -1,0 +1,28 @@
+(function(doc) {
+  var SELECTED_CLASS = 'selected';
+  var cards = Array.prototype.slice.call(doc.querySelectorAll('.crt-hover-card'));
+
+  function addClass(target, className) {
+    target.classList.add(className);
+  }
+
+  function removeClass(target, className) {
+    target.classList.remove(className);
+  }
+
+  function handleRadioSelect(el) {
+    cards.forEach(function(card) {
+      removeClass(card, SELECTED_CLASS);
+    });
+
+    addClass(el, SELECTED_CLASS)
+  } 
+
+  cards.forEach(function(el) {
+    const eventTarget = el.querySelector('input[type="radio"]');
+
+    eventTarget.addEventListener('change', function() {
+      handleRadioSelect(el);
+    });
+  });
+})(document);

--- a/crt_portal/static/js/primary_complaint.js
+++ b/crt_portal/static/js/primary_complaint.js
@@ -15,11 +15,15 @@
       removeClass(card, SELECTED_CLASS);
     });
 
-    addClass(el, SELECTED_CLASS)
-  } 
+    addClass(el, SELECTED_CLASS);
+  }
 
   cards.forEach(function(el) {
     const eventTarget = el.querySelector('input[type="radio"]');
+
+    if (eventTarget.checked) {
+      handleRadioSelect(el);
+    }
 
     eventTarget.addEventListener('change', function() {
       handleRadioSelect(el);

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -11,12 +11,12 @@ form#report-form {
 
     li {
       margin-bottom: 1.5rem;
-    }
 
-    li.primary-issue-example-li {
-      margin-left: 18px;
-      margin-bottom: 1rem;
-      list-style: disc;
+      &.primary-issue-example-li {
+        margin-left: 18px;
+        margin-bottom: 1rem;
+        list-style: disc !important;
+      }
     }
   }
 
@@ -27,8 +27,7 @@ form#report-form {
 
 // Form styles
 .usa-form {
-  max-width: 30rem !important;
-
+  max-width: 100% !important;
   ul {
     margin-left: 0;
     padding-left: 0;
@@ -123,7 +122,8 @@ form#report-form {
     text-indent: 0;
 
     &:before {
-      position: absolute
+      top: 0;
+      vertical-align: middle;
     }
 
     .label-text {

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -202,3 +202,14 @@ form#report-form {
 .complaint-multi-select {
   min-width: 140px;
 }
+
+.crt-portal-card {
+  @include u-radius('lg');
+  @include u-shadow(3);
+  background: white;
+
+  .crt-portal-card__content {
+    @include u-margin-x(7);
+    @include u-padding-y(5);
+  }
+}

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -124,16 +124,9 @@ form#report-form {
 
   .crt-radio__label_area {
     @extend .usa-radio__label;
+    margin-bottom: 0;
+    padding-left: 0;
     text-indent: 0;
-    background-color: $gray-cool-4;
-    padding: 1.5rem;
-    border: 1px solid $gray-cool-4;
-    border-radius: 5px;
-    filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, .13));
-
-    &:hover {
-      background-color: $blue-warm-5;
-    }
 
     .label-text {
       position: relative;
@@ -164,6 +157,13 @@ form#report-form {
   .question_group_optional_tag {
     font-weight: lighter;
     color: $gray-warm-80;
+  }
+}
+
+.crt-hover-card {
+  &:hover {
+    background-color: $gray-cool-4;
+    cursor: pointer;
   }
 }
 
@@ -209,7 +209,7 @@ form#report-form {
   background: white;
 
   .crt-portal-card__content {
-    @include u-margin-x(7);
+    @include u-padding-x(7);
     @include u-padding-y(5);
   }
 }

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -159,15 +159,17 @@ form#report-form {
 
 input[type="radio"]:checked + .crt-radio__label_area {
   background-color: $blue-warm-5;
-  .crt-hover-card {
-    background-color: $blue-warm-5;
-  }
 }
+
+
 
 .crt-hover-card {
   &:hover {
     background-color: $gray-cool-4;
     cursor: pointer;
+  }
+  &.selected, &:hover.selected {
+    background-color: $blue-warm-5;
   }
 }
 

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -55,13 +55,6 @@ form#report-form {
     }
   }
 
-  .look-like-link {
-    padding: 0;
-    border: none;
-    background: none;
-    text-decoration: underline;
-  }
-
   .blue-left-highlight {
     border-left: 2px solid $blue-warm-vivid-70;
     padding-left: 1rem;
@@ -126,7 +119,12 @@ form#report-form {
     @extend .usa-radio__label;
     margin-bottom: 0;
     padding-left: 0;
+    position: relative;
     text-indent: 0;
+
+    &:before {
+      position: absolute
+    }
 
     .label-text {
       position: relative;
@@ -147,7 +145,6 @@ form#report-form {
 
   input[type="radio"]:checked + .crt-radio__label_area {
     background-color: $blue-warm-5;
-    border: 1px solid $blue-warm-vivid-70;
   }
 
   .crt-checkbox__label {
@@ -157,6 +154,13 @@ form#report-form {
   .question_group_optional_tag {
     font-weight: lighter;
     color: $gray-warm-80;
+  }
+}
+
+input[type="radio"]:checked + .crt-radio__label_area {
+  background-color: $blue-warm-5;
+  .crt-hover-card {
+    background-color: $blue-warm-5;
   }
 }
 
@@ -210,6 +214,7 @@ form#report-form {
 
   .crt-portal-card__content {
     @include u-padding-x(7);
-    @include u-padding-y(5);
+    @include u-padding-bottom(6);
+    @include u-padding-top(5);
   }
 }

--- a/crt_portal/static/sass/custom/layout.scss
+++ b/crt_portal/static/sass/custom/layout.scss
@@ -5,15 +5,24 @@ html, body {
   height: 100%;
 }
 
+body {
+  background-color: #f6f6f2;
+}
+
 .wrapper {
   display: flex;
   flex-direction: column;
   margin: 0;
 }
 
-main {
-  background-color: #f6f6f2;
+header {
   flex: 1 0 auto;
+}
+
+main {
+  flex: 1 0 auto;
+  margin-top: -4rem;
+  margin-bottom: 5rem;
 }
 
 footer {

--- a/crt_portal/static/sass/custom/layout.scss
+++ b/crt_portal/static/sass/custom/layout.scss
@@ -12,6 +12,7 @@ html, body {
 }
 
 main {
+  background-color: #f6f6f2;
   flex: 1 0 auto;
 }
 

--- a/crt_portal/static/sass/custom/typography.scss
+++ b/crt_portal/static/sass/custom/typography.scss
@@ -23,6 +23,13 @@ h3 {
   margin-bottom: 0.5rem;
 }
 
+.look-like-link {
+  padding: 0;
+  border: none;
+  background: none;
+  text-decoration: underline;
+}
+
 .usa-prose {
   p {
     margin-top: .5rem;

--- a/pa11y_scripts/.pa11y-local.json
+++ b/pa11y_scripts/.pa11y-local.json
@@ -131,10 +131,7 @@
             "wait for element #page-errors to be visible",
             "set field #id_10-last_incident_year to 2021",
             "click element #submit-next",
-            "wait for element #page-errors to be visible",
-            "set field #id_10-last_incident_year to 2019",
-            "click element #submit-next",
-            "wait for element #id_11-violation_summary to be visible"
+            "wait for element #page-errors to be visible"
           ],
           "screenCapture": "pa11y-screenshots/page5-date-error.png"
         },


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/232)

## What does this change?

This PR adds the card style layout to the portal forms, with a few caveats. To wit:

* Spacing is not 100% accurate on each card. Some forms have non-obvious interactions with the margins of other elements (like the `other` text element) that break the layout. I'll have a followup PR to address those

* The introductory paragraph is missing from the contact page.

## Screenshots (for front-end PR):

**Example of the new card layout**
![Screen Shot 2020-02-21 at 9 57 41 AM](https://user-images.githubusercontent.com/1421848/75059001-e6a7c580-5490-11ea-81f3-3ce42e0c32b9.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
