### PR TITLE
Include slash after day on complaint detail page

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -83,7 +83,7 @@
         <tr>
           <th>Date of incident</th>
           <td>
-            {{ data.last_incident_month}}/{% if data.last_incident_day %}{{data.last_incident_day}}{%else%}-/{%endif%}{{data.last_incident_year}}
+            {{ data.last_incident_month}}/{% if data.last_incident_day %}{{data.last_incident_day}}{%else%}-{%endif%}/{{data.last_incident_year}}
           </td>
         </tr>
       </tr>


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/323)

## What does this change?
Adds a `/` to incident date on the complaint details show page, regardless of whether `day` is present or not.


## Screenshots (for front-end PR):
![Screen Shot 2020-02-21 at 10 44 59 AM](https://user-images.githubusercontent.com/1421848/75062354-823c3480-5497-11ea-82b5-fba09af72abf.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
