### PR TITLE
Push down complaint header

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block page_header %}
-<header class="page-header-background">
+<header class="page-header-background margin-bottom-5">
   <div class="grid-container">
     <div class="grid-row flex-align-center">
       <div class="grid-col-fill">


### PR DESCRIPTION
## What does this change?

* Pushes down the complaint header on details page

## Screenshots (for front-end PR):
<img width="1438" alt="Screen Shot 2020-02-25 at 8 51 58 AM" src="https://user-images.githubusercontent.com/1421848/75268236-1d8d1c80-57ac-11ea-80a8-4787c3afc544.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
