### PR TITLE
updated text in activity log

### DIFF
--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -164,7 +164,7 @@ class ShowView(View):
                 updates[key] = value
                 action_verb_target = ' '.join(key.split('_'))
                 action_verb = f"updated {action_verb_target}"
-                action_description = f"with value {value}"
+                action_description = f"to {value}"
 
                 action.send(
                     request.user,


### PR DESCRIPTION
last bit of [Activity log](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/253)

## What does this change?
update text on activity log
person updated <field> to <new value> 
## Screenshots (for front-end PR):
From local
<img width="406" alt="Screen Shot 2020-02-25 at 6 10 47 PM" src="https://user-images.githubusercontent.com/4406333/75296088-46d49980-57fa-11ea-8899-393bd87e4b99.png">

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
