### PR TITLE
Remove incorrect optional from location_name

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -267,7 +267,6 @@ class LocationForm(ModelForm):
             label='State',
             help_text="Where did this happen?",
         )
-        self.fields['location_state'].widget.attrs['list'] = 'states'
 
         self.question_groups = [
             QuestionGroup(

--- a/crt_portal/cts_forms/templates/forms/snippets/input.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/input.html
@@ -4,7 +4,7 @@
       for="{{ field.id_for_label }}"
       class="{{label_class}} margin-bottom-0"
     >
-      {{ field.label }} {% if field.required != True %}<em>(Optional)</em>{% endif %}
+      {{ field.label }} {% if field.field.required != True %}<em>(Optional)</em>{% endif %}
     </label>
   {% endif %}
   {% if field.help_text %}


### PR DESCRIPTION
## What does this change?
Currently, the `location name` field is incorrectly marked as `optional`.  This is especially confusing as the `location name` field IS highlighted with the correct error class and message when missing.

This PR corrects the issue, so the user knows they cannot skip this field.

## Screenshots (for front-end PR):
<img width="614" alt="Screen Shot 2020-02-27 at 3 24 26 PM" src="https://user-images.githubusercontent.com/1421848/75496193-53313180-5975-11ea-8f23-311e64d6239f.png">



## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
