### PR TITLE
299 status filter

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -32,13 +32,18 @@ from .model_variables import (
     COMMERCIAL_OR_PUBLIC_PLACE_HELP_TEXT,
     PUBLIC_OR_PRIVATE_SCHOOL_CHOICES,
     STATUS_CHOICES,
+    EMPTY_CHOICE
 )
+
 from .phone_regex import phone_validation_regex
 
 import logging
 
 logger = logging.getLogger(__name__)
 
+def _add_empty_choice(choices):
+    """Add an empty option to list of choices"""
+    return (EMPTY_CHOICE,) + choices
 
 class ContactA11y():
     def __init__(self):
@@ -255,7 +260,7 @@ class LocationForm(ModelForm):
         }
         self.fields['location_city_town'].required = True
         self.fields['location_state'] = ChoiceField(
-            choices=(('', _('- Select -')),) + STATES_AND_TERRITORIES,
+            choices=_add_empty_choice(STATES_AND_TERRITORIES),
             widget=Select(attrs={
                 'aria-describedby': 'location-help-text',
                 'class': 'usa-select'
@@ -590,6 +595,19 @@ class When(ModelForm):
 
 
 class Filters(ModelForm):
+    status = ChoiceField(choices=_add_empty_choice(STATUS_CHOICES),
+                        widget=Select(attrs={
+                                    'name': 'status',
+                                    'class': 'usa-select',
+                                })
+                        )
+    location_state = ChoiceField(choices=_add_empty_choice(STATES_AND_TERRITORIES),
+                        widget=Select(attrs={
+                                    'name': 'location_state',
+                                    'class': 'usa-select',
+                                })
+                        )
+
     class Meta:
         model = Report
         fields = [
@@ -597,9 +615,23 @@ class Filters(ModelForm):
             'contact_first_name',
             'contact_last_name',
             'location_city_town',
-            'location_state'
+            'location_state',
+            'status',
         ]
+
+        labels = {
+            'assigned_section': _('View sections'),
+            'contact_first_name': _('Contact first name'),
+            'contact_last_name': _('Contact last name'),
+            'location_city_town': _('Incident location city'),
+            'location_state': _('Incident location state')
+        }
+
         widgets = {
+            'assigned_section': CrtMultiSelect(attrs={
+                'classes': 'text-uppercase',
+                'name': 'assigned_section'
+            }),
             'contact_first_name': TextInput(attrs={
                 'class': 'usa-input',
                 'name': 'contact_first_name'
@@ -611,39 +643,9 @@ class Filters(ModelForm):
             'location_city_town': TextInput(attrs={
                 'class': 'usa-input',
                 'name': 'location_city_town'
-            }),
-            'location_state': Select(attrs={
-                'name': 'location_state',
-                'class': 'usa-select'
             })
         }
 
-    def __init__(self, *args, **kwargs):
-        ModelForm.__init__(self, *args, **kwargs)
-
-        self.fields['assigned_section'] = MultipleChoiceField(
-            choices=SECTION_CHOICES,
-            widget=CrtMultiSelect(attrs={
-                'classes': 'text-uppercase',
-                'name': 'assigned_section'
-            }),
-            required=False
-        )
-        self.fields['location_state'] = ChoiceField(
-            choices=STATES_AND_TERRITORIES,
-            widget=Select(attrs={
-                'name': 'location_state',
-                'class': 'usa-select'
-            }),
-            required=False,
-        )
-
-        self.fields['assigned_section'].label = _('View sections')
-        self.fields['contact_first_name'].label = _('Contact first name')
-        self.fields['contact_last_name'].label = _('Contact last name')
-        self.fields['location_city_town'].label = _('Incident location city')
-
-        self.fields['location_state'].label = _('Incident location state')
 
 
 class ComplaintActions(ModelForm):

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -2,6 +2,8 @@
 
 from django.utils.translation import gettext_lazy as _
 
+EMPTY_CHOICE = ('', _('- Select -'))
+
 SERVICEMEMBER_CHOICES = (
     ('yes', _('Yes')),
     ('no', _('No')),

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/active-filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/active-filters.html
@@ -1,7 +1,7 @@
 {% load static %}
 <div id="active-filters" data-active-filters>
   {% for key, value in filters.items %}
-    {% for item in value %}      
+    {% for item in value %}
       <span class="usa-sr-only">{{key}}: {{item}}</span>
       <button
         class="filter-control filter-tag"
@@ -20,7 +20,7 @@
         {% elif key == 'location_state' %}
           State
         {% else %}
-          {{key}}
+          {{key|capfirst}}
         {% endif %}: {{item}}
         <img src="{% static 'img/intake-view-table-icons/ic_close.svg' %}" class="icon right">
       </button>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -11,6 +11,7 @@
     {% include 'forms/complaint_view/index/filters/section_filter.html' %}
     {% include 'forms/complaint_view/index/filters/contact_filter.html' %}
     {% include 'forms/complaint_view/index/filters/incident_location_filter.html' %}
+    {% include 'forms/complaint_view/index/filters/status_filter.html' %}
   </div>
 </form>
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/status_filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/status_filter.html
@@ -1,0 +1,14 @@
+{% extends "forms/complaint_view/index/filter.html" %}
+
+{% block controls %}status{% endblock %}
+{% block label %}Status{% endblock %}
+{% block id %}status{% endblock %}
+{% block content %}
+  <label for="id_{{form.fields.status.widget.attrs.name}}">
+    <span class="usa-sr-only">{{form.status.label}}</span>
+  </label>
+  {{ form.status }}
+  <button class="usa-button margin-top-2" type="submit">
+    Filter results
+  </button>
+{% endblock %}

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -248,6 +248,7 @@
     var locationStateEl = formEl.querySelector('select[name="location_state"]');
     var activeFiltersEl = dom.querySelector('[data-active-filters]');
     var clearAllEl = dom.querySelector('[data-clear-filters]');
+    var statusEl = formEl.querySelector('select[name="status"]');
 
     /**
      * Update the filter data model when the user clears (clicks on) a filter tag,
@@ -316,7 +317,10 @@
       el: activeFiltersEl,
       onClick: onFilterTagClick
     });
-
+    textInputView({
+      el: statusEl,
+      name: 'status'
+    });
     clearFiltersView({
       el: clearAllEl,
       onClick: clearAllFilters


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/299)

## What does this change?

Adding `Status` as a filter option on the all forms view.

A few other small tweaks included here

- A bit of refactoring for `forms.Filter` to move logic into the Meta subclass
- Using choice labels for section filter input
- Using empty initial selections for `Select` fields on the filters page

## Screenshots (for front-end PR):
<img width="1203" alt="Screen Shot 2020-03-02 at 10 39 26 AM" src="https://user-images.githubusercontent.com/3485564/75691378-20878180-5c72-11ea-9b64-551e9f091c47.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
