### PR TITLE
Filter bug (nonce issue)#334

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -122,7 +122,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'crt_portal.wsgi.application'
 
-
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
 
@@ -256,7 +255,7 @@ if environment in ['PRODUCTION', 'STAGE', 'DEVELOP']:
     CSP_FRAME_SRC = ("'self'", bucket)
     CSP_WORKER_SRC = ("'self'", bucket)
     CSP_FRAME_ANCESTORS = ("'self'", bucket)
-    CSP_STYLE_SRC = ("'self'", bucket)
+    CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", bucket)
     CSP_INCLUDE_NONCE_IN = ['script-src']
 
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1,7 +1,7 @@
 import urllib.parse
 import os
 
-from django.shortcuts import render_to_response, render, get_object_or_404
+from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.core.exceptions import PermissionDenied
@@ -105,7 +105,7 @@ def IndexView(request):
         'auth': 'DJFKDSFJSD'
     }
 
-    return render_to_response('forms/complaint_view/index/index.html', final_data)
+    return render(request, 'forms/complaint_view/index/index.html', final_data)
 
 
 class ShowView(View):
@@ -164,7 +164,7 @@ class ShowView(View):
             'return_url_args': request.POST.get('next', ''),
         })
 
-        return render(request, 'forms/complaint_view/show/index.html', output)
+        return render(self.request, 'forms/complaint_view/show/index.html', output)
 
 
 TEMPLATES = [
@@ -389,4 +389,4 @@ class CRTReportWizard(SessionWizardView):
         form_data_dict['protected_class'] = m2m_protected_class.values()
         form_data_dict['hatecrimes_trafficking'] = m2m_hatecrime.values()
 
-        return render_to_response('forms/confirmation.html', {'data_dict': form_data_dict})
+        return render(self.request, 'forms/confirmation.html', {'data_dict': form_data_dict})


### PR DESCRIPTION
[Filter bug (nonce issue)#334](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/334)

Hat tip to @Jkrzy!

## What does this change?
Removes deprecated `render_to_response` and replaces with `render`.
Allows for inline style scripting.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [X] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
