### PR TITLE
Gets the tags in line in CRT view

### DIFF
--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -194,4 +194,5 @@ $green-cool-vivid: 'green-cool-10v';
 
 #active-filters {
   display: flex;
+  flex-wrap: wrap;
 }

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -27,7 +27,7 @@ $green-cool-vivid: 'green-cool-10v';
 }
 
 .crt-table td, .crt-table th, .usa-prose>table td, .usa-prose>table th, .usa-table td, .usa-table th {
-  border-bottom: 1px solid $gray-cool-10; 
+  border-bottom: 1px solid $gray-cool-10;
 }
 
 .crt-table {
@@ -57,7 +57,7 @@ $green-cool-vivid: 'green-cool-10v';
     }
   }
 
-  tr {    
+  tr {
     th a:first-child, td a:first-child {
       padding-left: 1.3rem;
     }
@@ -76,7 +76,7 @@ $green-cool-vivid: 'green-cool-10v';
   &.usa-table {
     tr, td, th {
       border-left: 0;
-      border-right: 0;      
+      border-right: 0;
     }
 
     th {
@@ -190,4 +190,8 @@ $green-cool-vivid: 'green-cool-10v';
       background: url("/static/img/sort-down.svg");
     }
   }
+}
+
+#active-filters {
+  display: flex;
 }


### PR DESCRIPTION
small fix for [https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/232](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/232)

## What does this change?
currently the tags are in a straight line on the left hand side this puts them in a vertical line with wrapping if there are a lot of tags.
## Screenshots (for front-end PR):
![Screen Shot 2020-03-02 at 4 06 59 PM](https://user-images.githubusercontent.com/4406333/75729850-ef25aa80-5c9f-11ea-8ce0-8739c70e1316.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
