### PR TITLE
Step bug

### DIFF
--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% if wizard.steps.step1 and current_step_name %}
-      <title>Step {{ wizard.steps.step1 }}: {{ current_step_name }} - Contact the Civil Rights Division - Department of Justice</title>
+      <title>Step {{ stage_number }}: {{ current_step_name }} - Contact the Civil Rights Division - Department of Justice</title>
     {% else %}
       <title>Contact the Civil Rights Division - Department of Justice</title>
     {% endif %}

--- a/crt_portal/cts_forms/templates/forms/portal/header.html
+++ b/crt_portal/cts_forms/templates/forms/portal/header.html
@@ -23,7 +23,7 @@
       <div class="tablet:grid-col-10 tablet:grid-offset-1">
         <div aria-label="progress">
           <span class="usa-sr-only">
-            Current step: {{ current_step_name }}. Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}.
+            Current step: {{ current_step_name }}. Step {{ stage_number }} of {{ total_stages }}.
           </span>
           <ol class="steps">
             {% for step in ordered_step_names %}

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -388,7 +388,7 @@ class CRTReportWizard(SessionWizardView):
                 context.update({
                     'crime_help_text2': _('Please select if any that apply to your situation (optional)'),
                 })
-        elif current_step_name == _('Review and submit'):
+        elif current_step_name == _('Review'):
             form_data_dict = self.get_all_cleaned_data()
             # unpack values in data for display
             form_data_dict['primary_complaint'] = data_decode(

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -323,7 +323,7 @@ class CRTReportWizard(SessionWizardView):
             _('Personal characteristics'),
             _('Date'),
             _('Personal description'),
-            _('Review and submit'),
+            _('Review'),
         ]
 
         current_step_name = all_step_names[int(self.steps.current)]
@@ -362,7 +362,9 @@ class CRTReportWizard(SessionWizardView):
                 'wordsRemainingText': _(' words remaining'),
                 'wordLimitReachedText': _(' word limit reached'),
             },
-            'form_name': form_name
+            'form_name': form_name,
+            'stage_number': ordered_step_names.index(current_step_name) + 1,
+            'total_stages': len(ordered_step_names),
         })
 
         if current_step_name == _('Details'):


### PR DESCRIPTION
bug with [review page](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/294)

The final step was not lighting up . The screen reader for that page was off it was step 8 of s8 when there are only 7 stages to the progressbar.

## What does this change?
This will add parody with the screen reader text and the sighed experience for step name and number. I am adding the idea of stages to count the steps on the from which can have more than one wizard step.

## Screenshots (for front-end PR):
![Screen Shot 2020-03-03 at 2 23 51 PM](https://user-images.githubusercontent.com/4406333/75825691-b8f93100-5d5a-11ea-9066-781a917dc8a0.png)

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
