### PR TITLE
Adds label to status on detail view

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -23,6 +23,9 @@
         {% include "forms/complaint_view/show/actions/assigned_section.html" %}
       </div>
       <div class="margin-bottom-2">
+        <label class="intake-label">
+          Status
+        </label>
         {{ actions.status }}
       </div>
       <button class="usa-button" type="submit">Apply changes</button>


### PR DESCRIPTION
[CRT detail view](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/231)

## What does this change?
We were missing a label for status, this adds the label, we do need to switch to the new dropdown style, but that can be a separate PR.

## Screenshots (for front-end PR):
![Screen Shot 2020-03-03 at 2 48 13 PM](https://user-images.githubusercontent.com/4406333/75827417-7e919300-5d5e-11ea-8f58-2b57f140e57a.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
