### PR TITLE
Use App registry to get models for data migration

### DIFF
--- a/crt_portal/cts_forms/migrations/0049_fix_other_duplicates.py
+++ b/crt_portal/cts_forms/migrations/0049_fix_other_duplicates.py
@@ -1,16 +1,16 @@
 from django.db import migrations, models
 
-from cts_forms.models import Report, ProtectedClass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
         ('cts_forms', '0046_update_primary_complaint'),
     ]
 
-    def retrieve_or_create_choices(*args, **defaults):
+    def retrieve_or_create_choices(apps, schema_editor):
         # remove other codes from "other" code from "Other", since codes are unique
+        Report = apps.get_model('cts_forms', 'Report')
+        ProtectedClass = apps.get_model('cts_forms', 'ProtectedClass')
+
         old_other = ProtectedClass.objects.get(code='Other')
         old_other.code = 'old'
         old_other.save()
@@ -23,9 +23,8 @@ class Migration(migrations.Migration):
         # pull records that need to be updated
         update_records = Report.objects.filter(protected_class__protected_class__in=['other', 'Other'])
         # loop through the records to add the correct relationship
-        if update_records.exists():
-            for record in update_records:
-                record.protected_class.add(real_other)
+        for record in update_records:
+            record.protected_class.add(real_other)
 
         # remove the incorrect "other" variants
         ProtectedClass.objects.get(protected_class='Other').delete()


### PR DESCRIPTION
## What does this change?
 Use [Django's App registry to retrieve model classes](https://docs.djangoproject.com/en/2.2/ref/migration-operations/#runpython) as they exist at the time of execution for data migration 0049.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
