### PR TITLE
update text on activity log

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -748,7 +748,7 @@ class ComplaintActions(ModelForm):
     def get_actions(self):
         """Parse incoming changed data for activity stream entry"""
         for field in self.changed_data:
-            yield f"updated {' '.join(field.split('_'))}", f" with value {self.cleaned_data[field]}"
+            yield f"updated {' '.join(field.split('_'))}", f" to {self.cleaned_data[field]}"
 
     def update_activity_stream(self, user):
         """Send all actions to activity stream"""

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -11,4 +11,4 @@ class ComplaintActionTests(SimpleTestCase):
         self.form.changed_data = ['field_test']
         self.form.cleaned_data = {'field_test': 'verb'}
         actions = [action for action in self.form.get_actions()]
-        self.assertEqual(actions, [("updated field test", " with value verb")])
+        self.assertEqual(actions, [("updated field test", " to verb")])


### PR DESCRIPTION
[update text on activity log.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/350)

## What does this change?
In the activity log, the messages should be formatted as follows:
'Updated X to Y'

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
