### PR TITLE
Fixing the template names in the location card for police and commercial

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_location.html
+++ b/crt_portal/cts_forms/templates/forms/report_location.html
@@ -7,9 +7,9 @@
       {{ block.super }}
 
       {% if form.name == 'PoliceLocation' %}
-        {% include "forms/report_police_location.html" with form=form %}
+        {% include "forms/question_cards/police_location.html" with form=form %}
       {% elif form.name == 'CommericalPublicLocation' %}
-        {% include 'forms/report_commercial_public_location.html' %}
+        {% include 'forms/question_cards/commercial_public_location.html' %}
       {% endif %}
 
       {% include 'forms/grouped_questions.html' %}


### PR DESCRIPTION
bug where the police location and commercial location steps were not rendering because they they didn't have the updated template name.