### PR TITLE
Updated text for title

### DIFF
--- a/crt_portal/cts_forms/templates/forms/portal/header.html
+++ b/crt_portal/cts_forms/templates/forms/portal/header.html
@@ -1,9 +1,12 @@
 {% load static %}
+{% load i18n %}
+{% trans "United States Department of Justice" as DOJ %}
+{% trans "Contact the Department of Justice to report a civil rights concern" as intro_text %}
 
 <header class="crt-form-header">
   <div class="grid-container">
     <div class="grid-row grid-gap flex-child">
-      <div class="tablet:grid-col-9 tablet:grid-offset-1">
+      <div class="tablet:grid-col-10 tablet:grid-offset-1">
         <div class="doj-brand display-flex flex-align-center font-serif-lg">
           <img
             src="{% static "img/doj-logo-footer.svg" %}"
@@ -11,10 +14,10 @@
             height="38"
             class="margin-right-105"
           />
-          <span>United States Department of Justice<span>
+          <span class='bold'>{{ DOJ }}<span>
         </div>
         <h1 class="padding-top-2 padding-bottom-1 margin-0 title">
-          Submit a concern to the Civil Rights Division
+          {{ intro_text }}
         </h1>
       </div>
     </div>

--- a/crt_portal/static/sass/custom/progress.scss
+++ b/crt_portal/static/sass/custom/progress.scss
@@ -20,7 +20,7 @@ $visited: #ffbe2e;
 $outline: white;
 
 .progress-bar {
-  padding-bottom: 3.5rem;
+  padding-bottom: 5rem;
 }
 
 .connecting-line {


### PR DESCRIPTION
The text change messed up the styling so I applied changes to match: https://app.zenhub.com/workspaces/doj-crt-form-design-flows-5d7a67fa86a8cd0001581ea0/issues/18f/crt-django/40

Added the translation tags to the template, since they were missing.

[Copy edits: Update form title #368](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/368)

## What does this change?
Updating the text for the title created an overflow issue solved that by
- bolding to the title
- made the title area on the grid-col-10 instead of 9 so the text breaks are in the same place
- added 5rem of padding to the bottom of the progress step bar

Confirming these with @AvivaOskow

## Screenshots (for front-end PR):
<img width="1105" alt="Screen Shot 2020-03-17 at 4 06 23 PM" src="https://user-images.githubusercontent.com/4406333/76910265-c76f3e80-686a-11ea-82c5-237a91684f72.png">

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
