### PR TITLE
Contact text updates

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -159,18 +159,18 @@ class Contact(ModelForm):
             QuestionGroup(
                 self,
                 ('contact_first_name', 'contact_last_name'),
-                group_name=_('Your name'),
-                help_text=_('Leave the fields blank if you\'d like to file anonymously'),
-                ally_id=a11y.name_id
+                group_name=CONTACT_QUESTIONS['contact_name_title'],
+                ally_id=a11y.name_id,
             ),
             QuestionGroup(
                 self,
                 ('contact_email', 'contact_phone', 'contact_address_line_1', 'contact_address_line_2'),
                 group_name=CONTACT_QUESTIONS['contact_title'],
-                help_text=_('You are not required to provide contact information, but it will help us if we need to gather more information about the incident you are reporting or to respond to your submission'),
-                ally_id=a11y.contact_info_id
+                ally_id=a11y.contact_info_id,
             )
         ]
+        self.help_text = CONTACT_QUESTIONS['contact_help_text'],
+        self.lede_text = _('If you believe you or someone else has experienced a civil rights violation, please tell us what happened.')
 
 
 class PrimaryReason(ModelForm):

--- a/crt_portal/cts_forms/question_text.py
+++ b/crt_portal/cts_forms/question_text.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 # contact
 CONTACT_QUESTIONS = {
     'contact_title': _('Contact information'),
+    'contact_help_text': _('You are not required to provide your name or contact information. If you want to remain anonymous, leave this section blank. If you choose to provide your contact information, we will only use it to respond to your submission.'),
     'contact_name_title': _('Your name'),
     'contact_first_name': _('First name'),
     'contact_last_name': _('Last name'),

--- a/crt_portal/cts_forms/templates/forms/report_contact_info.html
+++ b/crt_portal/cts_forms/templates/forms/report_contact_info.html
@@ -13,6 +13,7 @@
 <div class="crt-portal-card crt-portal-card">
   <div class="crt-portal-card__content crt-portal-card__content--lg">
     {{ block.super }}
+    <p>{{ form.help_text.0 }}</p>
 
     {% include "forms/question_cards/contact.html" %}
   </div>


### PR DESCRIPTION
[Copy edits: Update contact page#369](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/369)

## What does this change?
Moves the position of the text and updates it to match the source of truth.
One exception is that I did not add the privacy policy since we haven't implemented it yet.

Source of truth:
https://docs.google.com/document/d/1-HLdb21JA6_EuMHZTOi7KXFWWV4mT2Af54Tzzijl2E8/edit#heading=h.1q591albj4nl

I also make sure the leade text will be translatable later
I also grouped all the contact question text together.
## Screenshots (for front-end PR):
![page1-contact](https://user-images.githubusercontent.com/4406333/76913197-87608980-6873-11ea-817e-049eab87115a.png)

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
