### PR TITLE
CRT view filter updates

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -912,19 +912,18 @@ class ProForm(
 
 class Filters(ModelForm):
     status = ChoiceField(
+        required=False,
         choices=_add_empty_choice(STATUS_CHOICES),
         widget=Select(attrs={
             'name': 'status',
             'class': 'usa-select',
         })
     )
-    location_state = ChoiceField(
-        choices=_add_empty_choice(STATES_AND_TERRITORIES),
-        widget=Select(attrs={
-            'name': 'location_state',
-            'class': 'usa-select',
-        })
-    )
+    location_state = ChoiceField(required=False,
+                                 choices=_add_empty_choice(STATES_AND_TERRITORIES),
+                                 widget=Select(attrs={
+                                     'name': 'location_state',
+                                     'class': 'usa-select'}))
 
     class Meta:
         model = Report

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/active-filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/active-filters.html
@@ -1,11 +1,13 @@
 {% load static %}
+{% load get_field_label %}
+
 <div id="active-filters" data-active-filters>
   {% for key, value in filters.items %}
     {% for item in value %}
       <span class="usa-sr-only">{{key}}: {{item}}</span>
       <button
         class="filter-tag"
-        aria-label="Remove filter {{ key}}: {{item}} from the list"
+        aria-label="Remove filter {{'Report'|get_field_label:key}}: {{item}} from the list"
         data-filter-name="{{key}}"
         data-filter-value="{{item}}"
       >

--- a/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
@@ -6,7 +6,7 @@
       id="{{id}}"
       href="{{sort_url}}{{filter_state}}"
       class="sort-link display-block {% if is_descending %}sort-up{% else %}sort-down{% endif %}"
-      aria-label="Sort complaints by property {{ heading }} {% if is_descending %}descending{% else %}ascending{% endif %}"
+      aria-label="Sort complaints by {{ heading }} {% if is_descending %}descending{% else %}ascending{% endif %}"
     >
       <span>{{ heading }}</span>
     </a>

--- a/crt_portal/cts_forms/templatetags/get_field_label.py
+++ b/crt_portal/cts_forms/templatetags/get_field_label.py
@@ -1,12 +1,19 @@
 from django import template
 from django.apps import apps
-
+from django.core.exceptions import FieldDoesNotExist
 register = template.Library()
 
 
 @register.filter(name='get_field_label')
 def get_field_label(value, arg):
-    """Return label for given model/field from cts_forms app"""
-    model = apps.get_model('cts_forms', value)
-    field = model._meta.get_field(arg)
+    """
+    Return label for given model/field from cts_forms app
+    If no field exists, we expect it's a filter field like
+    `create_date_end',  strip underscores for display
+    """
+    try:
+        model = apps.get_model('cts_forms', value)
+        field = model._meta.get_field(arg)
+    except FieldDoesNotExist:
+        return arg.replace('_', ' ')
     return field.verbose_name

--- a/crt_portal/cts_forms/templatetags/get_field_label.py
+++ b/crt_portal/cts_forms/templatetags/get_field_label.py
@@ -1,0 +1,12 @@
+from django import template
+from django.apps import apps
+
+register = template.Library()
+
+
+@register.filter(name='get_field_label')
+def get_field_label(value, arg):
+    """Return label for given model/field from cts_forms app"""
+    model = apps.get_model('cts_forms', value)
+    field = model._meta.get_field(arg)
+    return field.verbose_name


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/288)

## What does this change?
Adds screen-readable field labels for `Remove filter` buttons.
Remove's `required` attribute from `Location` and `Status` filters

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
