### PR TITLE
[WIP] horizontal scroll fix for overflowing CRT view all table

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -1,6 +1,6 @@
 {% load sortable_table_heading %}
 {% load static %}
-
+<div class="crt-xscroll">
 <table class="usa-table crt-table sort-table">
   <thead>
     <tr>
@@ -71,7 +71,7 @@
     </tbody>
   {% endif %}
 </table>
-
+</div>
 
 {% if not data_dict %}
 <div class="crt-portal-card table-message">

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -30,6 +30,10 @@ $green-cool-vivid: 'green-cool-10v';
   border-bottom: 1px solid $gray-cool-10;
 }
 
+.crt-xscroll {
+  overflow-x: scroll;
+}
+
 .crt-table {
   @extend .usa-table;
   background: $white;


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/333)

## What does this change?
fix the horizontal scroll bar for view all table

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
