### PR TITLE
Generate csv path w/ BASE_DIR for 0061.load_zips.py

### DIFF
--- a/crt_portal/cts_forms/migrations/0061_load_zips.py
+++ b/crt_portal/cts_forms/migrations/0061_load_zips.py
@@ -1,9 +1,10 @@
+import logging
 import os
-
 from csv import DictReader
+
+from django.conf import settings
 from django.db import migrations, models
 
-import logging
 logger = logging.getLogger(__name__)
 
 circle = os.environ.get('CIRCLE', False)
@@ -16,7 +17,8 @@ class Migration(migrations.Migration):
     ]
 
     def load_zip_data(apps, schema_editor):
-        with open('data/zip_codes_by_district.csv') as csvfile:
+        csv_path = os.path.join(settings.BASE_DIR, '..', 'data/zip_codes_by_district.csv')
+        with open(csv_path) as csvfile:
             csvreader = DictReader(csvfile)
             JudicialDistrict = apps.get_model('cts_forms', 'JudicialDistrict')
             # this takes too long and is not needed for tests


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/424)

## What does this change?
Grabbing path to needed csv file w/ BASE_DIR
Sorted imports

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
