### PR TITLE
[WIP] Show/hide summary form

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
@@ -2,32 +2,33 @@
 {% load static %}
 {% block usa_banner %}{% endblock %}
 {% block page_header %}
-  <header class="intake-header">
-    <div class="title">
-      <div class="title-icon">
-        <img src="{% static 'img/intake-icons/ic_home.svg' %}" alt="" class="icon" />
-      </div>
+<header class="intake-header">
+  <div class="title">
+    <div class="title-icon">
+      <img src="{% static 'img/intake-icons/ic_home.svg' %}" alt="" class="icon" />
+    </div>
 
-      <h1 class="title-copy">
-        CRT Complaint Records
-      </h1>
-    </div>
-    <div class="intake-actions">
-      <a class="add-record" href="/form/new/" label="create record" name="Create record">
-        <img src="{% static 'img/intake-icons/ic_add.svg'%}" alt="" class="icon" />
-        Add new record
-      </a>
-      <a href="/accounts/logout" class="outline-button outline-button--light">
-        <img src="{% static 'img/intake-icons/ic_settings.svg'%}" alt="" class="icon" />
-        log out
-      </a>
-    </div>
-  </header>
+    <h1 class="title-copy">
+      CRT Complaint Records
+    </h1>
+  </div>
+  <div class="intake-actions">
+    <a class="add-record" href="/form/new/" label="create record" name="Create record">
+      <img src="{% static 'img/intake-icons/ic_add.svg'%}" alt="" class="icon" />
+      Add new record
+    </a>
+    <a href="/accounts/logout" class="outline-button outline-button--light">
+      <img src="{% static 'img/intake-icons/ic_settings.svg'%}" alt="" class="icon" />
+      log out
+    </a>
+  </div>
+</header>
 {% endblock %}
 {% block body_class %}class="intake-bg"{% endblock %}
 {% block main_class %} class="margin-top-5"{% endblock %}
 {% block usa_footer %}{% endblock %}
 {% block page_js %}
-  {{ block.super }}
-  <script src="{% static 'js/dropdown.js' %}"></script>
+{{ block.super }}
+<script src="{% static 'js/dropdown.js' %}"></script>
+<script src="{% static 'js/show_hide_narrative_summary.js' %}"></script>
 {%endblock%}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions/comment_summary.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions/comment_summary.html
@@ -1,23 +1,16 @@
-<form
-  id="comment-actions-{{ id_name }}"
-  class="usa-form"
-  method="post"
-  action="{% url 'crt_forms:save-report-comment' report_id=data.pk %}"
-  novalidate
->
+<form id="comment-actions-{{ id_name }}" class="usa-form" method="post"
+  action="{% url 'crt_forms:save-report-comment' report_id=data.pk %}" novalidate>
   {% csrf_token %}
   <fieldset class="usa-fieldset usa-prose">
-
     <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
     <input type="hidden" value="{{ is_summary }}" name="is_summary" id="is_summary-{{ id_name }}" />
     <input type="hidden" value="{{ data.pk }}" name="report_id" id="report_id-{{ id_name }}" />
-
     <div class="margin-bottom-2">
       <label class="bold backend-blue">
         {{ label }}
       </label>
       {{ comments.note }}
     </div>
-    <button aria-label="send new comment" class="usa-button" type="submit">{{ button_text }}</button>
+    <button aria-label="{{ button_aria_label }}" class="usa-button" type="submit">{{ button_text }}</button>
   </fieldset>
 </form>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -6,100 +6,110 @@
 
 {% block title %}Reported Compliant{% endblock %}
 {% block icon %}
-  <img src="{% static "img/intake-icons/ic_folder.svg" %}" alt="icon" class="icon" />
+<img src="{% static "img/intake-icons/ic_folder.svg" %}" alt="icon" class="icon" />
 {% endblock %}
 
 {% block card_content %}
-  <div class=blue-background>
-  {% if summary %}
-    <p class="bold backend-blue">Summary</p>
-    {{ summary }}
-  {% else %}
-    {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="summary" is_summary=True note='comments.note' button_text='Save' label='Summary' %}
-  {% endif %}
+<div class=blue-background>
+  <div id="current-summary">
+    {% if summary %}
+    <label class="bold backend-blue">
+      Summary
+    </label>
+    <div>
+      {{summary}}
+    </div>
+    <button aria-label="edit summary" class="usa-button" type="button">Edit</button>
+    {% endif %}
   </div>
 
-  <table class="usa-table usa-table--borderless complaint-card-table">
-    <tr>
-      <th>Primary issue</th>
-      <td>
-        <strong>{{primary_complaint.0}}</strong>
-      </td>
-      <tr>
-        <th>Hate crime</th>
-        <td>
-          {% if crimes.physical_harm %}
-            Yes (checked)
-          {% else %}
-            No (unchecked)
-          {% endif %}
-        </td>
-      </tr>
-      <tr>
-        <th>Human Trafficking</th>
-        <td>
-          {% if crimes.trafficking %}
-            Yes (checked)
-          {% else %}
-            No (unchecked)
-          {% endif %}
-        </td>
-      </tr>
-      <tr>
-        <th>Relevant Details</th>
-        <td>
-          {% if data.election_details %}
-            Election type (federal/local): {{ data.election_details }}
-          {% elif data.commercial_or_public_place %}
-            {% render_commercial_public_space_view data.commercial_or_public_place data.other_commercial_or_public_place %}
-          {% elif data.inside_correctional_facility %}
-            {% render_correctional_facility_view data.inside_correctional_facility data.correctional_facility_type %}
-          {% elif data.public_or_private_school %}
-            School type: {% if data.public_or_private_school == 'not_sure' %} Not sure {% else %} {{ data.public_or_private_school|title }} {% endif %}
-          {% elif data.public_or_private_employer %}
-            {% render_employer_info_view data.public_or_private_employer data.employer_size %}
-          {% else %}
-            —
-          {% endif %}
-        </td>
-      </tr>
-      <tr>
-        <th>Location name</th>
-        <td>{{data.location_name|default:"-"}}</td>
-      </tr>
-      <tr>
-        <th>City, State</th>
-        <td>
-          {{data.location_city_town|default:"-"}},
-          {{data.location_state|default:"-"}}
-        </td>
-      </tr>
-      <tr>
-        <th>Reported reason</th>
-        <td>
-          {% for p_class in p_class_list %}
-            {% if not forloop.last %}
-              {{p_class}},
-            {% else %}
-              {{p_class}}
-            {% endif %}
-          {% endfor %}
-          {% if data.other_class %}
-            <br>
-            Other: {{data.other_class}}
-          {% endif %}
-        </td>
-      </tr>
-      <tr>
-        <th>Service Member</th>
-        <td>{{data.servicemember|title|default:"—"}}</td>
-      </tr>
-      <tr>
-        <th>Date of incident</th>
-        <td>
-          {{ data.last_incident_month}}/{% if data.last_incident_day %}{{data.last_incident_day}}{%else%}-{%endif%}/{{data.last_incident_year}}
-        </td>
-      </tr>
-    </tr>
-  </table>
+  <div class="edit-summary">
+    {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="summary" is_summary=True note='comments.note' button_text='Save' button_aria_label='save summary' label='Summary' %}
+  </div>
+</div>
+
+<table class="usa-table usa-table--borderless complaint-card-table">
+  <tr>
+    <th>Primary issue</th>
+    <td>
+      <strong>{{primary_complaint.0}}</strong>
+    </td>
+  <tr>
+    <th>Hate crime</th>
+    <td>
+      {% if crimes.physical_harm %}
+      Yes (checked)
+      {% else %}
+      No (unchecked)
+      {% endif %}
+    </td>
+  </tr>
+  <tr>
+    <th>Human Trafficking</th>
+    <td>
+      {% if crimes.trafficking %}
+      Yes (checked)
+      {% else %}
+      No (unchecked)
+      {% endif %}
+    </td>
+  </tr>
+  <tr>
+    <th>Relevant Details</th>
+    <td>
+      {% if data.election_details %}
+      Election type (federal/local): {{ data.election_details }}
+      {% elif data.commercial_or_public_place %}
+      {% render_commercial_public_space_view data.commercial_or_public_place data.other_commercial_or_public_place %}
+      {% elif data.inside_correctional_facility %}
+      {% render_correctional_facility_view data.inside_correctional_facility data.correctional_facility_type %}
+      {% elif data.public_or_private_school %}
+      School type: {% if data.public_or_private_school == 'not_sure' %} Not sure {% else %}
+      {{ data.public_or_private_school|title }} {% endif %}
+      {% elif data.public_or_private_employer %}
+      {% render_employer_info_view data.public_or_private_employer data.employer_size %}
+      {% else %}
+      —
+      {% endif %}
+    </td>
+  </tr>
+  <tr>
+    <th>Location name</th>
+    <td>{{data.location_name|default:"-"}}</td>
+  </tr>
+  <tr>
+    <th>City, State</th>
+    <td>
+      {{data.location_city_town|default:"-"}},
+      {{data.location_state|default:"-"}}
+    </td>
+  </tr>
+  <tr>
+    <th>Reported reason</th>
+    <td>
+      {% for p_class in p_class_list %}
+      {% if not forloop.last %}
+      {{p_class}},
+      {% else %}
+      {{p_class}}
+      {% endif %}
+      {% endfor %}
+      {% if data.other_class %}
+      <br>
+      Other: {{data.other_class}}
+      {% endif %}
+    </td>
+  </tr>
+  <tr>
+    <th>Service Member</th>
+    <td>{{data.servicemember|title|default:"—"}}</td>
+  </tr>
+  <tr>
+    <th>Date of incident</th>
+    <td>
+      {{ data.last_incident_month}}/{% if data.last_incident_day %}{{data.last_incident_day}}{%else%}-{%endif%}/{{data.last_incident_year}}
+    </td>
+  </tr>
+  </tr>
+</table>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -2,52 +2,52 @@
 {% load static %}
 
 {% block content %}
-  <div class="complaint-show-body">
-    <div class="grid-container-widescreen">
-      <div class="grid-row margin-bottom-1">
-        <div class="tablet:grid-col-4 grid-offset-1 padding-left-05">
-          <div class="display-flex">
-            <a class="outline-button outline-button--dark" href="/form/view{{ return_url_args }}">
-              <img src="{% static "img/intake-icons/ic_arrow_forward.svg" %}" class="icon">
-              Back to all
-            </a>
+<div class="complaint-show-body">
+  <div class="grid-container-widescreen">
+    <div class="grid-row margin-bottom-1">
+      <div class="tablet:grid-col-4 grid-offset-1 padding-left-05">
+        <div class="display-flex">
+          <a class="outline-button outline-button--dark" href="/form/view{{ return_url_args }}">
+            <img src="{% static "img/intake-icons/ic_arrow_forward.svg" %}" class="icon">
+            Back to all
+          </a>
+        </div>
+        <div class="display-flex flex-align-center details-id">
+          <h2 class="margin-right-205 margin-top-0 margin-bottom-0 backend-blue">
+            ID: {{ data.public_id }}
+          </h2>
+          <span class="status-tag status-{{data.status}} margin-top-05">
+            {{ data.status }}
+          </span>
+        </div>
+        <p>
+          <span class="details-date-label text-uppercase backend-blue">Received: </span>
+          <span class="backend-blue">{{ data.create_date|date:'g:i a F j, Y' }}</span>
+        </p>
+        <p>
+          <span class="details-date-label text-uppercase backend-blue">Last Updated: </span>
+          <span class="backend-blue">{{ data.modified_date|date:'g:i a F j, Y' }}</span>
+        </p>
+      </div>
+    </div>
+    <div class="grid-row grid-gap-lg">
+      <div class="tablet:grid-col-4 grid-offset-1">
+        {% include 'forms/complaint_view/show/actions.html' with title="Actions" icon="img/intake-icons/ic_check-circle.svg" %}
+        <div class="activity-stream">
+          {% include 'forms/complaint_view/show/activity_stream.html' with title="Activity" icon="img/intake-icons/ic_activity.svg" %}
+        </div>
+        <div class="crt-portal-card">
+          <div class="crt-portal-card__content">
+            {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="comment" is_summary=False note=comments.note button_text='Send' button_aria_label='send comment' label='New comment' %}
           </div>
-          <div class="display-flex flex-align-center details-id">
-            <h2 class="margin-right-205 margin-top-0 margin-bottom-0 backend-blue">
-              ID: {{ data.public_id }}
-            </h2>
-            <span class="status-tag status-{{data.status}} margin-top-05">
-              {{ data.status }}
-            </span>
-          </div>
-          <p>
-            <span class="details-date-label text-uppercase backend-blue">Received: </span>
-            <span class="backend-blue">{{ data.create_date|date:'g:i a F j, Y' }}</span>
-          </p>
-          <p>
-            <span class="details-date-label text-uppercase backend-blue">Last Updated: </span>
-            <span class="backend-blue">{{ data.modified_date|date:'g:i a F j, Y' }}</span>
-          </p>
         </div>
       </div>
-      <div class="grid-row grid-gap-lg">
-        <div class="tablet:grid-col-4 grid-offset-1">
-          {% include 'forms/complaint_view/show/actions.html' with title="Actions" icon="img/intake-icons/ic_check-circle.svg" %}
-          <div class="activity-stream">
-            {% include 'forms/complaint_view/show/activity_stream.html' with title="Activity" icon="img/intake-icons/ic_activity.svg" %}
-          </div>
-          <div class="crt-portal-card">
-            <div class="crt-portal-card__content">
-              {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="comment" is_summary=False note=comments.note button_text='Send' label='New comment' %}
-            </div>
-          </div>
-        </div>
-        <div class="tablet:grid-col-6">
-          {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}
-          {% include 'forms/complaint_view/show/complaint_details.html' with data=data primaty_complaint=primary_complaint summary=summary %}
-          {% include 'forms/complaint_view/show/full_summary.html' with summary=data.violation_summary button_text='Send' %}
-        </div>
+      <div class="tablet:grid-col-6">
+        {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}
+        {% include 'forms/complaint_view/show/complaint_details.html' with data=data primaty_complaint=primary_complaint summary=summary %}
+        {% include 'forms/complaint_view/show/full_summary.html' with summary=data.violation_summary button_text='Send' %}
       </div>
     </div>
   </div>
+</div>
 {% endblock %}

--- a/crt_portal/static/js/show_hide_narrative_summary.js
+++ b/crt_portal/static/js/show_hide_narrative_summary.js
@@ -1,0 +1,30 @@
+(function() {
+  function showSummaryForm() {
+    summaryForm.classList.remove('display-none');
+    summary.classList.add('display-none');
+  }
+
+  function hideSummaryForm() {
+    summaryForm.classList.add('display-none');
+    summary.classList.remove('display-none');
+  }
+
+  function addShowFormHandler() {
+    var editButton = summary.getElementsByTagName('button')[0];
+    editButton.addEventListener('click', showSummaryForm);
+  }
+
+  /* created as an empty element and populated if a summary exists */
+  var summary = document.getElementById('current-summary');
+
+  /* in contrast, summaryForm will always exist on the page */
+  var summaryForm = document.getElementById('comment-actions-summary');
+  var saveButton = summaryForm.getElementsByTagName('button')[0];
+
+  saveButton.addEventListener('click', hideSummaryForm);
+
+  if (summary.childElementCount > 0) {
+    addShowFormHandler();
+    summaryForm.classList.add('display-none');
+  }
+})();


### PR DESCRIPTION
## What does this change?
Adds JS functionality to show/hide the summary edit form. When there is no summary, the box displays automatically; when there is a summary, the summary will show until the "edit" button is clicked.

TO DO:
- make it pretty
- make the input box shrinky

## Screenshots (for front-end PR):
[will add after pretty]

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
