### PR TITLE
Style summary editing

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -10,17 +10,17 @@
 {% endblock %}
 
 {% block card_content %}
-<div class=blue-background>
+<div class="blue-background usa-prose">
   <div id="current-summary">
     {% if summary %}
-    <label class="bold backend-blue">
+    <label class="bold backend-blue" for="current-summary-text">
       Summary
     </label>
-    <div>
+    <button aria-label="edit summary" class="usa-button usa-button--unstyled button--edit" type="button">Edit</button>
+    <div id="current-summary-text">
       {{ summary.note }}
     </div>
     <br>
-    <button aria-label="edit summary" class="usa-button" type="button">Edit</button>
     {% endif %}
   </div>
 

--- a/crt_portal/static/img/ic_edit.svg
+++ b/crt_portal/static/img/ic_edit.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 64 (93537) - https://sketch.com -->
+    <title>ic_edit</title>
+    <desc>Created with Sketch.</desc>
+    <g id="CRT-narraitve" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="4---submitted" transform="translate(-1143.000000, -681.000000)">
+            <g id="ic_edit" transform="translate(1141.000000, 679.000000)">
+                <path d="M2,11.5 L2,14 L4.5,14 L11.8733333,6.62666667 L9.37333333,4.12666667 L2,11.5 Z M13.8066667,4.69333333 C14.0666667,4.43333333 14.0666667,4.01333333 13.8066667,3.75333333 L12.2466667,2.19333333 C11.9866667,1.93333333 11.5666667,1.93333333 11.3066667,2.19333333 L10.0866667,3.41333333 L12.5866667,5.91333333 L13.8066667,4.69333333 Z" id="Shape" fill="#162E51" fill-rule="nonzero"></path>
+                <polygon id="Path" points="0 0 16 0 16 16 0 16"></polygon>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/crt_portal/static/sass/custom/buttons.scss
+++ b/crt_portal/static/sass/custom/buttons.scss
@@ -1,0 +1,13 @@
+.button--edit {
+  @include u-font-size('body', 'sm');
+  float: right;
+  &:before {
+    @include u-margin-right(10px);
+    background-image: url(../img/ic_edit.svg);
+    background-repeat: none;
+    content: '';
+    height: 12px;
+    width: 12px;
+    display: inline-block;
+  }
+}

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -1,4 +1,3 @@
-
 $complaint-header-min-height: 200px;
 
 .complaint-card-table {
@@ -21,13 +20,15 @@ $complaint-header-min-height: 200px;
     word-break: break-word;
   }
 
-  th, td {
+  th,
+  td {
     border-top: 0;
-    padding-bottom: .8rem;
+    padding-bottom: 0.8rem;
   }
 
   tr:last-child {
-    th, td {
+    th,
+    td {
       border: none;
     }
   }
@@ -41,8 +42,8 @@ $complaint-header-min-height: 200px;
 
   .activity-stream-list {
     .activity-stream-item {
-      border-bottom: 1px solid #C6CACE;
-      padding: .5rem 0 .5rem 0;
+      border-bottom: 1px solid #c6cace;
+      padding: 0.5rem 0 0.5rem 0;
 
       &:first-child {
         padding-top: 0;
@@ -68,5 +69,10 @@ $complaint-header-min-height: 200px;
 }
 
 .backend-blue {
-   @include u-color($blue-warm-vivid-80-t);
+  @include u-color($blue-warm-vivid-80-t);
+}
+
+#current-summary-text {
+  @include u-margin-top(0.5rem);
+  @include u-margin-right(3rem);
 }

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -17,14 +17,13 @@
       font-size: 1.375rem;
       font-weight: 400;
       line-height: 3.75rem;
-      margin-left: .8rem;
+      margin-left: 0.8rem;
     }
   }
 
   .intake-actions {
     @include flex-container();
     justify-content: space-between;
-
 
     .add-record {
       @extend .crt-button;
@@ -94,7 +93,7 @@
   &.expanded {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    box-shadow: 0 20px 10px hsla(0,0%,39.2%,.2);
+    box-shadow: 0 20px 10px hsla(0, 0%, 39.2%, 0.2);
   }
   &--stroke {
     @include u-border($blue-warm-vivid-80-t);
@@ -115,7 +114,7 @@
     cursor: pointer;
     font-size: 1rem;
     justify-content: center;
-    padding: .5rem 1rem .5rem 1rem;
+    padding: 0.5rem 1rem 0.5rem 1rem;
     text-align: left;
     width: 100%;
 
@@ -131,7 +130,7 @@
     background: $white;
     border-radius: 3px;
     border-top-left-radius: 0px;
-    box-shadow: 0 15px 10px hsla(0,0%,39.2%,.2);
+    box-shadow: 0 15px 10px hsla(0, 0%, 39.2%, 0.2);
     left: 0;
     min-width: 16rem;
     padding: 1.5rem;
@@ -165,7 +164,7 @@
 
   .icon {
     height: 1rem;
-    margin-right: .5rem;
+    margin-right: 0.5rem;
   }
 }
 
@@ -209,11 +208,11 @@
     width: 1rem;
 
     &.right {
-      margin-left: .6rem;
+      margin-left: 0.6rem;
     }
 
     &.left {
-      margin-right: .6rem;
+      margin-right: 0.6rem;
     }
   }
 }
@@ -244,7 +243,7 @@
 
 .intake-table {
   border-radius: 5px;
-  box-shadow: 0 1px 6px 2px rgba(0,0,0,0.14);
+  box-shadow: 0 1px 6px 2px rgba(0, 0, 0, 0.14);
 }
 
 .intake-table-header {
@@ -295,8 +294,7 @@
   font-weight: 900;
 }
 
-.blue-background{
+.blue-background {
   @include u-bg($blue-warm-5-t);
   padding: 1rem;
-
 }

--- a/crt_portal/static/sass/styles.scss
+++ b/crt_portal/static/sass/styles.scss
@@ -30,6 +30,7 @@
 @import 'custom/complaint';
 @import 'custom/alerts';
 @import 'custom/banner';
+@import 'custom/buttons';
 @import 'custom/footer';
 @import 'custom/form';
 @import 'custom/header';
@@ -42,4 +43,3 @@
 @import 'custom/table';
 @import 'custom/typography';
 @import 'custom/confirmation';
-


### PR DESCRIPTION
Note: PR against #369, not `develop`

## What does this change?

## Screenshots (for front-end PR):
If no summary provided, page will load with comment box open (@Jacklynn, I swear I've seen a mock of this open, but I couldn't find it):
<img width="622" alt="Screen Shot 2020-04-03 at 12 14 30 PM" src="https://user-images.githubusercontent.com/509309/78392043-c5b0b500-75a4-11ea-9733-f8c4e89a3b16.png">

If summary exists, page will load with summary edit view:
<img width="623" alt="Screen Shot 2020-04-03 at 12 14 46 PM" src="https://user-images.githubusercontent.com/509309/78392073-d2350d80-75a4-11ea-8a9c-448708b2553f.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
