### PR TITLE
Making the pro-form have a 'submit' button

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -53,7 +53,11 @@
           <div class="margin-top-5">
             <input id="submit-next"
                   type="submit"
-                  value={% if submit_button %}"Submit"{% else %}"{% trans 'Next' %}"{% endif %}
+                  value={% if submit_button %}
+                          "{% trans 'Submit' %}"
+                        {% else %}
+                          "{% trans 'Next' %}"
+                        {% endif %}
                   class="usa-button" />
 
             {% if wizard.steps.prev %}

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -53,7 +53,7 @@
           <div class="margin-top-5">
             <input id="submit-next"
                   type="submit"
-                  value="{% trans 'Next' %}"
+                  value={% if submit_button %}"Submit"{% else %}"{% trans 'Next' %}"{% endif %}
                   class="usa-button" />
 
             {% if wizard.steps.prev %}

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -280,6 +280,7 @@ class ProFormView(LoginRequiredMixin, SessionWizardView):
             },
             'ordered_step_names': ordered_step_names,
             'stage_link': True,
+            'submit_button': True,
         })
 
         return context


### PR DESCRIPTION
[change "next" button text to "submit"#408](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/408)

## What does this change?
Making the pro-form have a 'submit' button the public form still has the submit button.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
