### PR TITLE
Renames full summary to personal description

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
@@ -1,0 +1,6 @@
+<div class="crt-portal-card">
+  <div class="crt-portal-card__content">
+    <h3 class="complaint-card-heading text-uppercase">Personal Description</h3>
+    <p>{{ description|linebreaks }}</p>
+  </div>
+</div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/full_summary.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/full_summary.html
@@ -1,6 +1,0 @@
-<div class="crt-portal-card">
-  <div class="crt-portal-card__content">
-    <h3 class="complaint-card-heading text-uppercase">Full summary</h3>
-    <p>{{ summary|linebreaks }}</p>
-  </div>
-</div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -45,7 +45,7 @@
       <div class="tablet:grid-col-6">
         {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}
         {% include 'forms/complaint_view/show/complaint_details.html' with data=data primaty_complaint=primary_complaint summary=summary comment_box=summary_box.note %}
-        {% include 'forms/complaint_view/show/full_summary.html' with summary=data.violation_summary %}
+        {% include 'forms/complaint_view/show/description.html' with description=data.violation_summary %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
[Renaming "full summary" #339](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/339)

## What does this change?
Renames full summary to personal description
The CRT View says "personal description" instead of "full summary" and I renamed the templates to match the new words. The models aren't renamed since that would be a bigger lift.

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
