### PR TITLE
Render most recent internal summary on view all page

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -248,3 +248,8 @@ class Report(models.Model):
                 return district_query[0].district
 
         return None
+
+    @property
+    def get_summary(self):
+        """Return most recent summary provided by an intake specialist"""
+        return self.internal_comments.filter(is_summary=True).order_by('-modified_date').first()

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -55,8 +55,8 @@
         </td>
         <td>
           <a class="td-link display-block" href="{{datum.url}}">
-            {% with summary=datum.report.violation_summary|default:"—" %}
-              {{ summary|truncatechars:120 }}
+            {% with summary=datum.report.get_summary|default:"—" %}
+              {{ summary.note|truncatechars:120 }}
             {% endwith %}
           </a>
         </td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -55,8 +55,8 @@
         </td>
         <td>
           <a class="td-link display-block" href="{{datum.url}}">
-            {% with summary=datum.report.get_summary|default:"—" %}
-              {{ summary.note|truncatechars:120 }}
+            {% with summary=datum.report.get_summary %}
+              {{ summary.note|default:"—"|truncatechars:120 }}
             {% endwith %}
           </a>
         </td>

--- a/crt_portal/cts_forms/tests/tests.py
+++ b/crt_portal/cts_forms/tests/tests.py
@@ -10,7 +10,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 
-from ..models import ProtectedClass, Report, HateCrimesandTrafficking
+from ..models import ProtectedClass, Report, HateCrimesandTrafficking, CommentAndSummary
 from ..model_variables import (
     PROTECTED_CLASS_CHOICES,
     PROTECTED_CLASS_ERROR,
@@ -148,8 +148,14 @@ class Valid_CRT_view_Tests(TestCase):
         self.assertTrue(self.test_report.contact_phone in self.content)
 
     def test_violation_summary(self):
-        # formatting the summary is done in the template
-        self.assertTrue(self.test_report.violation_summary[:119] in self.content)
+        """Report table renders internal summary"""
+        summary_text = "Internal summary test"
+        summary = CommentAndSummary(is_summary=True, note=summary_text)
+        summary.save()
+        self.test_report.internal_comments.add(summary)
+
+        response = self.client.get(reverse('crt_forms:crt-forms-index'))
+        self.assertContains(response, summary_text)
 
     def test_incident_location(self):
         self.assertTrue(self.test_report.location_city_town in self.content)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -132,14 +132,12 @@ def serialize_data(report, request, report_id):
         report.other_class,
     )
 
-    summary_query = report.internal_comments.filter(is_summary=True).order_by('-modified_date')
-    if len(summary_query) > 0:
-        summary = summary_query[0]
+    summary = report.get_summary()
+    if summary:
         summary_box = CommentActions(
             initial={'note': summary.note}
         )
     else:
-        summary = None
         summary_box = CommentActions()
 
     output = {

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -132,7 +132,7 @@ def serialize_data(report, request, report_id):
         report.other_class,
     )
 
-    summary = report.get_summary()
+    summary = report.get_summary
     if summary:
         summary_box = CommentActions(
             initial={'note': summary.note}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/434)

## What does this change?
The 'summary' column in the view all table is now displays the information from the 'summary field' (intake specialist's description of the complaint) on the complaint details page.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
