### PR TITLE
UX tweaks to summary editing

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions/comment_summary.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions/comment_summary.html
@@ -15,5 +15,9 @@
       {{ comment_box }}
     </div>
     <button aria-label="{{ button_aria_label }}" class="usa-button" type="submit">{{ button_text }}</button>
+    {% if show_cancel %}
+      <button class="usa-button usa-button--unstyled button--cancel" type="button">Cancel</button>
+    {% endif %}
+    
   </fieldset>
 </form>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions/comment_summary.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions/comment_summary.html
@@ -10,6 +10,7 @@
     {% endif %}
     <div class="margin-bottom-2">
       <label class="bold backend-blue">
+        
         {{ label }}
       </label>
       {{ comment_box }}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -24,7 +24,7 @@
   </div>
 
   <div class="edit-summary">
-    {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="summary" is_summary=True button_text='Save' button_aria_label='save summary' label='Summary' comment=summary comment_box=comment_box %}
+    {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="summary" is_summary=True button_text='Save' button_aria_label='save summary' show_cancel='true' label='Summary' comment=summary comment_box=comment_box %}
   </div>
 </div>
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -20,7 +20,6 @@
     <div id="current-summary-text">
       {{ summary.note }}
     </div>
-    <br>
     {% endif %}
   </div>
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -18,7 +18,7 @@
     </label>
     <button aria-label="edit summary" class="usa-button usa-button--unstyled button--edit" type="button">Edit</button>
     <div id="current-summary-text">
-      {{ summary.note }}
+      {{ summary.note | linebreaks }}
     </div>
     {% endif %}
   </div>

--- a/crt_portal/static/js/show_hide_narrative_summary.js
+++ b/crt_portal/static/js/show_hide_narrative_summary.js
@@ -23,7 +23,10 @@
   }
 
   function setSummaryInputHeight() {
-    summaryInput.style.height = summaryInput.scrollHeight + 'px';
+    /* we're not interested in shrinking the box, just in growing it */
+    if (parseInt(summaryInput.style.height) < summaryInput.scrollHeight) {
+      summaryInput.style.height = (summaryInput.scrollHeight + 16) + 'px';
+    }
   }
 
   /* created as an empty element and populated if a summary exists */
@@ -40,10 +43,13 @@
 
   /* check to see if there's text in the summary box before making the save button active */
   summaryInput.addEventListener('input', setButtonDisabled);
+
   if (summary) {
     /* set the form's initial height to the height of the existing summary */
-    summaryInput.style.height = summary.scrollHeight + 'px';
-  } 
+    var summaryText = document.getElementById('current-summary-text');
+    /* 16 offsets the padding of the input (0.5rem or 8px top and bottom); otherwise short text is cut off */
+    summaryInput.style.height = (summaryText.scrollHeight + 16) + 'px';
+  }
 
   /* grow the form to the height of the text */
   summaryInput.addEventListener('input', setSummaryInputHeight);

--- a/crt_portal/static/js/show_hide_narrative_summary.js
+++ b/crt_portal/static/js/show_hide_narrative_summary.js
@@ -44,11 +44,13 @@
   /* check to see if there's text in the summary box before making the save button active */
   summaryInput.addEventListener('input', setButtonDisabled);
 
-  if (summary) {
+  if (summary.childElementCount > 0) {
     /* set the form's initial height to the height of the existing summary */
     var summaryText = document.getElementById('current-summary-text');
     /* 16 offsets the padding of the input (0.5rem or 8px top and bottom); otherwise short text is cut off */
     summaryInput.style.height = (summaryText.scrollHeight + 16) + 'px';
+  } else {
+    summaryInput.style.height = '2.5rem';
   }
 
   /* grow the form to the height of the text */

--- a/crt_portal/static/js/show_hide_narrative_summary.js
+++ b/crt_portal/static/js/show_hide_narrative_summary.js
@@ -1,4 +1,4 @@
-(function () {
+(function() {
   function showSummaryForm() {
     summaryForm.classList.remove('display-none');
     summary.classList.add('display-none');
@@ -25,7 +25,7 @@
   function setSummaryInputHeight() {
     /* we're not interested in shrinking the box, just in growing it */
     if (parseInt(summaryInput.style.height) < summaryInput.scrollHeight) {
-      summaryInput.style.height = (summaryInput.scrollHeight + 16) + 'px';
+      summaryInput.style.height = summaryInput.scrollHeight + 16 + 'px';
     }
   }
 
@@ -48,7 +48,7 @@
     /* set the form's initial height to the height of the existing summary */
     var summaryText = document.getElementById('current-summary-text');
     /* 16 offsets the padding of the input (0.5rem or 8px top and bottom); otherwise short text is cut off */
-    summaryInput.style.height = (summaryText.scrollHeight + 16) + 'px';
+    summaryInput.style.height = summaryText.scrollHeight + 16 + 'px';
   } else {
     summaryInput.style.height = '2.5rem';
   }

--- a/crt_portal/static/js/show_hide_narrative_summary.js
+++ b/crt_portal/static/js/show_hide_narrative_summary.js
@@ -17,7 +17,7 @@
   function setButtonDisabled() {
     if (summaryInput.value.length > 0 && saveButton.hasAttribute('disabled')) {
       saveButton.removeAttribute('disabled');
-    } else {
+    } else if (summaryInput.value.length === 0 && !saveButton.hasAttribute('disabled')) {
       saveButton.setAttribute('disabled', true);
     }
   }

--- a/crt_portal/static/js/show_hide_narrative_summary.js
+++ b/crt_portal/static/js/show_hide_narrative_summary.js
@@ -29,6 +29,7 @@
   var summaryForm = document.getElementById('comment-actions-summary');
   var summaryInput = summaryForm.getElementsByTagName('textarea')[0];
   var saveButton = summaryForm.getElementsByTagName('button')[0];
+  var cancelButton = summaryForm.getElementsByClassName('button--cancel')[0];
 
   /* disable the save button on page load because there are no changes to save yet */
   saveButton.setAttribute('disabled', 'true');
@@ -36,6 +37,7 @@
   /* check to see if there's text in the summary box before making the save button active */
   summaryInput.addEventListener('input', setButtonDisabled);
   saveButton.addEventListener('click', hideSummaryForm);
+  cancelButton.addEventListener('click', hideSummaryForm);
 
   if (summary.childElementCount > 0) {
     addShowFormHandler();

--- a/crt_portal/static/js/show_hide_narrative_summary.js
+++ b/crt_portal/static/js/show_hide_narrative_summary.js
@@ -22,6 +22,10 @@
     }
   }
 
+  function setSummaryInputHeight() {
+    summaryInput.style.height = summaryInput.scrollHeight + 'px';
+  }
+
   /* created as an empty element and populated if a summary exists */
   var summary = document.getElementById('current-summary');
 
@@ -36,6 +40,13 @@
 
   /* check to see if there's text in the summary box before making the save button active */
   summaryInput.addEventListener('input', setButtonDisabled);
+  if (summary) {
+    /* set the form's initial height to the height of the existing summary */
+    summaryInput.style.height = summary.scrollHeight + 'px';
+  } 
+
+  /* grow the form to the height of the text */
+  summaryInput.addEventListener('input', setSummaryInputHeight);
   saveButton.addEventListener('click', hideSummaryForm);
   cancelButton.addEventListener('click', hideSummaryForm);
 

--- a/crt_portal/static/js/show_hide_narrative_summary.js
+++ b/crt_portal/static/js/show_hide_narrative_summary.js
@@ -1,4 +1,4 @@
-(function() {
+(function () {
   function showSummaryForm() {
     summaryForm.classList.remove('display-none');
     summary.classList.add('display-none');
@@ -14,13 +14,27 @@
     editButton.addEventListener('click', showSummaryForm);
   }
 
+  function setButtonDisabled() {
+    if (summaryInput.value.length > 0 && saveButton.hasAttribute('disabled')) {
+      saveButton.removeAttribute('disabled');
+    } else {
+      saveButton.setAttribute('disabled', true);
+    }
+  }
+
   /* created as an empty element and populated if a summary exists */
   var summary = document.getElementById('current-summary');
 
   /* in contrast, summaryForm will always exist on the page */
   var summaryForm = document.getElementById('comment-actions-summary');
+  var summaryInput = summaryForm.getElementsByTagName('textarea')[0];
   var saveButton = summaryForm.getElementsByTagName('button')[0];
 
+  /* disable the save button on page load because there are no changes to save yet */
+  saveButton.setAttribute('disabled', 'true');
+
+  /* check to see if there's text in the summary box before making the save button active */
+  summaryInput.addEventListener('input', setButtonDisabled);
   saveButton.addEventListener('click', hideSummaryForm);
 
   if (summary.childElementCount > 0) {

--- a/crt_portal/static/sass/custom/buttons.scss
+++ b/crt_portal/static/sass/custom/buttons.scss
@@ -11,3 +11,14 @@
     display: inline-block;
   }
 }
+
+.button--cancel {
+  @include u-color('secondary-dark');
+  @include u-margin-left(0.5rem);
+  &:hover,
+  &:active,
+  &:focus {
+    @include u-color('secondary');
+    background-color: transparent !important;
+  }
+}

--- a/crt_portal/static/sass/custom/buttons.scss
+++ b/crt_portal/static/sass/custom/buttons.scss
@@ -15,7 +15,6 @@
 .button--cancel {
   @include u-color('secondary-dark');
   margin-left: 0.5rem;
-  @include u-margin-left(0.5rem);
   &:hover,
   &:active,
   &:focus {

--- a/crt_portal/static/sass/custom/buttons.scss
+++ b/crt_portal/static/sass/custom/buttons.scss
@@ -2,7 +2,7 @@
   @include u-font-size('body', 'sm');
   float: right;
   &:before {
-    @include u-margin-right(10px);
+    margin-right: 10px;
     background-image: url(../img/ic_edit.svg);
     background-repeat: none;
     content: '';
@@ -14,6 +14,7 @@
 
 .button--cancel {
   @include u-color('secondary-dark');
+  margin-left: 0.5rem;
   @include u-margin-left(0.5rem);
   &:hover,
   &:active,

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -76,3 +76,9 @@ $complaint-header-min-height: 200px;
   @include u-margin-top(0.5rem);
   @include u-margin-right(3rem);
 }
+
+.activity-stream-list.usa-list,
+.usa-prose #current-summary-text {
+  line-height: 1.4; // USWDS override
+  color: black;
+}

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -76,3 +76,7 @@ $complaint-header-min-height: 200px;
   @include u-margin-top(0.5rem);
   @include u-margin-right(3rem);
 }
+
+.edit-summary textarea {
+  min-height: 2.5rem; // we set the height dynamically with JS, so we need to make sure it isn't tiny when there's nothing in the form yet
+}

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -76,7 +76,3 @@ $complaint-header-min-height: 200px;
   @include u-margin-top(0.5rem);
   @include u-margin-right(3rem);
 }
-
-.edit-summary textarea {
-  min-height: 2.5rem; // we set the height dynamically with JS, so we need to make sure it isn't tiny when there's nothing in the form yet
-}

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -80,5 +80,4 @@ $complaint-header-min-height: 200px;
 .activity-stream-list.usa-list,
 .usa-prose #current-summary-text {
   line-height: 1.4; // USWDS override
-  color: black;
 }

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -73,8 +73,8 @@ $complaint-header-min-height: 200px;
 }
 
 #current-summary-text {
-  @include u-margin-top(0.5rem);
-  @include u-margin-right(3rem);
+  margin-top: 0.5rem;
+  margin-right: 3rem;
 }
 
 .activity-stream-list.usa-list,


### PR DESCRIPTION
## What does this change?
Fixes editing experience to match mocks.
Adjusts leading in Activity list and summary to 1.4.

## Screenshots (for front-end PR):
### Item with preexisting summary:
On page load:
<img width="558" alt="Screen Shot 2020-04-07 at 4 22 25 PM" src="https://user-images.githubusercontent.com/509309/78725132-10576780-78ec-11ea-83e3-cbf6963d533b.png">

On opening edit box:
<img width="551" alt="Screen Shot 2020-04-07 at 4 22 30 PM" src="https://user-images.githubusercontent.com/509309/78725185-2c5b0900-78ec-11ea-89a5-0611cccc78d8.png">

On edit:
<img width="568" alt="Screen Shot 2020-04-07 at 4 22 49 PM" src="https://user-images.githubusercontent.com/509309/78725208-38df6180-78ec-11ea-90f8-ede3203430c8.png">

### Item with no preexisting summary
On page load:
<img width="568" alt="Screen Shot 2020-04-07 at 4 33 42 PM" src="https://user-images.githubusercontent.com/509309/78725757-932cf200-78ed-11ea-8149-125a7aaf598a.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
