### PR TITLE
Summary search

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -23,6 +23,7 @@ filter_options = {
     'create_date_start': '__gte',
     'create_date_end': '__lte',
     'public_id': '__contains',
+    'summary': 'summary',
 }
 
 
@@ -49,6 +50,10 @@ def report_filter(request):
                 month = int(request.GET.getlist(field)[0][4:6])
                 day = int(request.GET.getlist(field)[0][6:])
                 kwargs[f'create_date{filter_options[field]}'] = datetime.date(year, month, day)
+            elif filter_options[field] == 'summary':
+                # assumes summaries are edited so there is only one per report - that is current behavior
+                kwargs['internal_comments__note__search'] = request.GET.getlist(field)[0]
+                kwargs['internal_comments__is_summary'] = True
 
     # returns a filtered query, and a dictionary that we can use to keep track of the filters we apply
     return Report.objects.filter(**kwargs), filters

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -10,6 +10,7 @@ from django.forms import (
     Textarea,
     ModelMultipleChoiceField,
     Select,
+    CharField,
 )
 from django.utils.translation import gettext_lazy as _
 
@@ -926,6 +927,7 @@ class Filters(ModelForm):
                                  widget=Select(attrs={
                                      'name': 'location_state',
                                      'class': 'usa-select'}))
+    summary = CharField(widget=TextInput(attrs={'class': 'usa-input'}))
 
     class Meta:
         model = Report

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -922,12 +922,23 @@ class Filters(ModelForm):
             'class': 'usa-select',
         })
     )
-    location_state = ChoiceField(required=False,
-                                 choices=_add_empty_choice(STATES_AND_TERRITORIES),
-                                 widget=Select(attrs={
-                                     'name': 'location_state',
-                                     'class': 'usa-select'}))
-    summary = CharField(widget=TextInput(attrs={'class': 'usa-input'}))
+    location_state = ChoiceField(
+        required=False,
+        choices=_add_empty_choice(STATES_AND_TERRITORIES),
+        widget=Select(attrs={
+            'name': 'location_state',
+            'class': 'usa-select'
+        })
+    )
+    summary = CharField(
+        widget=TextInput(
+            attrs={
+                'class': 'usa-input',
+                'name': 'summary',
+            },
+        ),
+        required=False,
+    )
 
     class Meta:
         model = Report

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -248,3 +248,8 @@ class Report(models.Model):
                 return district_query[0].district
 
         return None
+
+    @property
+    def get_summary(self):
+        """Return most recent summary provided by an intake specialist"""
+        return self.internal_comments.filter(is_summary=True).order_by('-modified_date').first()

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -55,8 +55,8 @@
         </td>
         <td>
           <a class="td-link display-block" href="{{datum.url}}">
-            {% with summary=datum.report.violation_summary|default:"—" %}
-              {{ summary|truncatechars:120 }}
+            {% with summary=datum.report.get_summary|default:"—" %}
+              {{ summary.note|truncatechars:120 }}
             {% endwith %}
           </a>
         </td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -55,8 +55,8 @@
         </td>
         <td>
           <a class="td-link display-block" href="{{datum.url}}">
-            {% with summary=datum.report.get_summary|default:"—" %}
-              {{ summary.note|truncatechars:120 }}
+            {% with summary=datum.report.get_summary %}
+              {{ summary.note|default:"—"|truncatechars:120 }}
             {% endwith %}
           </a>
         </td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -12,6 +12,7 @@
     {% include 'forms/complaint_view/index/filters/contact_filter.html' %}
     {% include 'forms/complaint_view/index/filters/incident_location_filter.html' %}
     {% include 'forms/complaint_view/index/filters/status_filter.html' %}
+    {% include 'forms/complaint_view/index/filters/summary_filter.html' %}
   </div>
 </form>
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/summary_filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/summary_filter.html
@@ -1,0 +1,14 @@
+{% extends "forms/complaint_view/index/filter.html" %}
+
+{% block controls %}summary{% endblock %}
+{% block label %}Summary{% endblock %}
+{% block id %}summary{% endblock %}
+{% block content %}
+  <label for="id_summary">
+    <span class="usa-sr-only">summary</span>
+  </label>
+   {{ form.summary }}
+  <button class="usa-button margin-top-2" type="submit">
+    Filter results
+  </button>
+{% endblock %}

--- a/crt_portal/cts_forms/tests/tests.py
+++ b/crt_portal/cts_forms/tests/tests.py
@@ -511,13 +511,6 @@ class CRT_FILTER_Tests(TestCase):
         test_report.assigned_section = test_report.assign_section()
         test_report.save()
 
-        summary = CommentAndSummary.objects.create(
-            note="service animal",
-            is_summary=True,
-        )
-
-        test_report.internal_comments.add(comment)
-
         self.client = Client()
         # we are not running the tests against the production database, so this shouldn't be producing real users anyway.
         self.test_pass = secrets.token_hex(32)
@@ -633,7 +626,14 @@ class CRT_FILTER_Tests(TestCase):
 
     def test_summary_filter(self):
         """This is a many to may field so it works differently than the other searches. Also checking stemming"""
-        summary_filter = 'summay=service animals'
+        summary = CommentAndSummary.objects.create(
+            note="service animal",
+            is_summary=True,
+        )
+        test_report = Report.objects.all()[0]
+        test_report.internal_comments.add(summary)
+
+        summary_filter = 'summary=service animals'
         response = self.client.get(f'{self.url_base}?{summary_filter}')
         reports = response.context['data_dict']
 

--- a/crt_portal/cts_forms/tests/tests.py
+++ b/crt_portal/cts_forms/tests/tests.py
@@ -10,7 +10,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 
-from ..models import ProtectedClass, Report, HateCrimesandTrafficking
+from ..models import ProtectedClass, Report, HateCrimesandTrafficking, CommentAndSummary
 from ..model_variables import (
     PROTECTED_CLASS_CHOICES,
     PROTECTED_CLASS_ERROR,
@@ -148,8 +148,14 @@ class Valid_CRT_view_Tests(TestCase):
         self.assertTrue(self.test_report.contact_phone in self.content)
 
     def test_violation_summary(self):
-        # formatting the summary is done in the template
-        self.assertTrue(self.test_report.violation_summary[:119] in self.content)
+        """Report table renders internal summary"""
+        summary_text = "Internal summary test"
+        summary = CommentAndSummary(is_summary=True, note=summary_text)
+        summary.save()
+        self.test_report.internal_comments.add(summary)
+
+        response = self.client.get(reverse('crt_forms:crt-forms-index'))
+        self.assertContains(response, summary_text)
 
     def test_incident_location(self):
         self.assertTrue(self.test_report.location_city_town in self.content)

--- a/crt_portal/cts_forms/tests/tests.py
+++ b/crt_portal/cts_forms/tests/tests.py
@@ -511,6 +511,13 @@ class CRT_FILTER_Tests(TestCase):
         test_report.assigned_section = test_report.assign_section()
         test_report.save()
 
+        summary = CommentAndSummary.objects.create(
+            note="service animal",
+            is_summary=True,
+        )
+
+        test_report.internal_comments.add(comment)
+
         self.client = Client()
         # we are not running the tests against the production database, so this shouldn't be producing real users anyway.
         self.test_pass = secrets.token_hex(32)
@@ -618,6 +625,16 @@ class CRT_FILTER_Tests(TestCase):
     def test_state_filter(self):
         state_filter = 'location_state=OH'
         response = self.client.get(f'{self.url_base}?{state_filter}')
+        reports = response.context['data_dict']
+
+        report_len = len(reports)
+
+        self.assertEquals(report_len, 1)
+
+    def test_summary_filter(self):
+        """This is a many to may field so it works differently than the other searches. Also checking stemming"""
+        summary_filter = 'summay=service animals'
+        response = self.client.get(f'{self.url_base}?{summary_filter}')
         reports = response.context['data_dict']
 
         report_len = len(reports)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -132,14 +132,12 @@ def serialize_data(report, request, report_id):
         report.other_class,
     )
 
-    summary_query = report.internal_comments.filter(is_summary=True).order_by('-modified_date')
-    if len(summary_query) > 0:
-        summary = summary_query[0]
+    summary = report.get_summary()
+    if summary:
         summary_box = CommentActions(
             initial={'note': summary.note}
         )
     else:
-        summary = None
         summary_box = CommentActions()
 
     output = {

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -132,7 +132,7 @@ def serialize_data(report, request, report_id):
         report.other_class,
     )
 
-    summary = report.get_summary()
+    summary = report.get_summary
     if summary:
         summary_box = CommentActions(
             initial={'note': summary.note}

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -250,7 +250,7 @@
     var activeFiltersEl = dom.querySelector('[data-active-filters]');
     var clearAllEl = dom.querySelector('[data-clear-filters]');
     var statusEl = formEl.querySelector('select[name="status"]');
-    var summaryEl = formEl.querySelector('select[name="summary"]');
+    var summaryEl = formEl.querySelector('input[name="summary"]');
 
     /**
      * Update the filter data model when the user clears (clicks on) a filter tag,

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -116,6 +116,7 @@
     location_city_town: '',
     create_date_start: '',
     create_date_end: '',
+    summary: '',
     sort: '',
     page: '',
     per_page: ''
@@ -249,6 +250,7 @@
     var activeFiltersEl = dom.querySelector('[data-active-filters]');
     var clearAllEl = dom.querySelector('[data-clear-filters]');
     var statusEl = formEl.querySelector('select[name="status"]');
+    var summaryEl = formEl.querySelector('select[name="summary"]');
 
     /**
      * Update the filter data model when the user clears (clicks on) a filter tag,
@@ -320,6 +322,10 @@
     textInputView({
       el: statusEl,
       name: 'status'
+    });
+    textInputView({
+      el: summaryEl,
+      name: 'summary'
     });
     clearFiltersView({
       el: clearAllEl,


### PR DESCRIPTION
[Filter by summary - View all table #413](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/413)

## What does this change?
Adds search for the summary field on the view all table. This uses the vector capability in postgres, so it has stemming. The use case that has come up is looking for "service animal" and "service animals"

Builds off of the PR that shows summary in the table view. **merge #378 first**

## Screenshots (for front-end PR):
![Screen Shot 2020-04-09 at 10 44 53 AM](https://user-images.githubusercontent.com/4406333/78926848-a73e3400-7a52-11ea-94b9-160132ed9af8.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
