### PR TITLE
Use npm ci for deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
             apt-get install -yqq nodejs yarn && \
             npm i -g npm@^6 && \
             rm -rf /var/lib/apt/lists/*
-            npm install
+            npm ci --production
             node node_modules/gulp/bin/gulp build-sass
       - run:
           # database will be migrated in cloud.gov
@@ -192,7 +192,7 @@ jobs:
             apt-get install -yqq nodejs yarn && \
             npm i -g npm@^6 && \
             rm -rf /var/lib/apt/lists/*
-            npm install
+            npm ci --production
             node node_modules/gulp/bin/gulp build-sass
       - run:
           # database will be migrated in cloud.gov
@@ -248,7 +248,7 @@ jobs:
             apt-get install -yqq nodejs yarn && \
             npm i -g npm@^6 && \
             rm -rf /var/lib/apt/lists/*
-            npm install
+            npm ci --production
             node node_modules/gulp/bin/gulp build-sass
       - run:
           # database will be migrated in cloud.gov


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?
When building/deploying to dev, staging, and production, only install the essential javascript dependencies. Using[ npm ci ](https://docs.npmjs.com/cli/ci.html)and limiting installation to `dependencies`. 

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
