### PR TITLE
Revert "Use npm ci for deploys"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
             apt-get install -yqq nodejs yarn && \
             npm i -g npm@^6 && \
             rm -rf /var/lib/apt/lists/*
-            npm ci --production
+            npm install
             node node_modules/gulp/bin/gulp build-sass
       - run:
           # database will be migrated in cloud.gov
@@ -192,7 +192,7 @@ jobs:
             apt-get install -yqq nodejs yarn && \
             npm i -g npm@^6 && \
             rm -rf /var/lib/apt/lists/*
-            npm ci --production
+            npm install
             node node_modules/gulp/bin/gulp build-sass
       - run:
           # database will be migrated in cloud.gov
@@ -248,7 +248,7 @@ jobs:
             apt-get install -yqq nodejs yarn && \
             npm i -g npm@^6 && \
             rm -rf /var/lib/apt/lists/*
-            npm ci --production
+            npm install
             node node_modules/gulp/bin/gulp build-sass
       - run:
           # database will be migrated in cloud.gov


### PR DESCRIPTION
Reverts usdoj-crt/crt-portal#386
revering this since we are getting errors, we can merge the outstanding ready things and circle back on this https://app.circleci.com/pipelines/github/usdoj-crt/crt-portal/1562/workflows/191b2140-1c2b-488b-a203-b4e5908c680e/jobs/2003