### PR TITLE
Fix dropdowns for IE11

### DIFF
--- a/crt_portal/cts_forms/templates/forms/portal/header.html
+++ b/crt_portal/cts_forms/templates/forms/portal/header.html
@@ -11,7 +11,6 @@
           <img
             src="{% static "img/doj-logo-footer.svg" %}"
             alt=""
-            height="38"
             class="margin-right-105"
           />
           <span class='bold'>{{ DOJ }}<span>

--- a/crt_portal/static/js/dropdown.js
+++ b/crt_portal/static/js/dropdown.js
@@ -8,7 +8,7 @@
     var control = el.querySelector('[data-crt-dropdown-control]');
     var content = el.querySelector('.content');
     var isVisible = true;
-    
+
     return {
       get el() {
         return el;
@@ -104,12 +104,12 @@
      * dropdowns
      **/
     var node = hasParentNode(event.target, function(n) {
-      for (i=0; i < n.classList.length; i++) {
-       if (n.classList[i].indexOf('crt-dropdown') === -1){
-         return false;
-       } else {
-         return true;
-       }
+      for (i = 0; i < n.classList.length; i++) {
+        if (n.classList[i].indexOf('crt-dropdown') === -1) {
+          return false;
+        } else {
+          return true;
+        }
       }
     });
 

--- a/crt_portal/static/js/dropdown.js
+++ b/crt_portal/static/js/dropdown.js
@@ -8,7 +8,7 @@
     var control = el.querySelector('[data-crt-dropdown-control]');
     var content = el.querySelector('.content');
     var isVisible = true;
-
+    
     return {
       get el() {
         return el;
@@ -19,13 +19,13 @@
       get isVisible() {
         return isVisible;
       },
-      hide() {
+      hide: function() {
         isVisible = false;
         content.setAttribute('hidden', !isVisible);
         control.setAttribute('aria-expanded', isVisible);
         el.classList.remove('expanded');
       },
-      show() {
+      show: function() {
         isVisible = true;
         content.removeAttribute('hidden');
         control.setAttribute('aria-expanded', isVisible);
@@ -104,16 +104,22 @@
      * dropdowns
      **/
     var node = hasParentNode(event.target, function(n) {
-      return n.classList.contains('crt-dropdown');
+      for (i=0; i < n.classList.length; i++) {
+       if (n.classList[i].indexOf('crt-dropdown') === -1){
+         return false;
+       } else {
+         return true;
+       }
+      }
     });
 
     if (!node) {
       closeAllDropdowns();
     } else {
       // A node here indicates that the click event happened within a dropdown
-      var maybeDropdown = dropdowns.find(function(dropdown) {
+      var maybeDropdown = dropdowns.filter(function(dropdown) {
         return dropdown.control === event.target;
-      });
+      })[0];
 
       dropdownToggle(maybeDropdown);
     }

--- a/crt_portal/static/sass/custom/footer.scss
+++ b/crt_portal/static/sass/custom/footer.scss
@@ -1,4 +1,7 @@
 // Footer Styles
+footer {
+  width: 100%; // IE11 fix
+}
 .usa-footer__logo-heading {
 //  @include h4
   color: white;

--- a/crt_portal/static/sass/custom/header.scss
+++ b/crt_portal/static/sass/custom/header.scss
@@ -18,6 +18,10 @@
   .doj-brand {
     font-size: 1.125rem;
     margin-top: 4rem;
+    img {
+      height: 38px;
+      width: 38px;
+    }
   }
 }
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/357)

## What does this change?
Makes the Javascript that opens and closes the filters backwards-compatible with IE11.

While testing this, I also uncovered a bug that makes loading filters from a query string break in IE11. We're currently using `Object.assign` to parse the page's query string and persist filters across page loads (so if, say, someone wants to sort by both contact name AND incident location, that's possible). That shouldn't be a big lift to backport for IE 11, but it seemed different enough that maybe it should be its own issue.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
