### PR TITLE
intake_format bug

### DIFF
--- a/crt_portal/cts_forms/tests/tests.py
+++ b/crt_portal/cts_forms/tests/tests.py
@@ -33,6 +33,7 @@ from ..forms import (
     When,
     ProForm,
 )
+from ..views import save_form
 from .test_data import SAMPLE_REPORT
 
 
@@ -890,17 +891,9 @@ class Complaint_Update_Tests(TestCase):
 
 
 class ProFormTest(TestCase):
-    def test_required_fields(self):
-        form = ProForm(data={})
-        self.assertFalse(form.is_valid())
-        self.assertEquals(
-            form.errors,
-            {'primary_complaint': ['Please select a primary reason to continue.']}
-        )
-
-    def test_full_example(self):
+    def setUp(self):
         data = copy.deepcopy(SAMPLE_REPORT)
-        data.update({
+        self.data = data.update({
             'contact_address_line_1': '123',
             'contact_address_line_2': 'Apt 234',
             'contact_city': 'test',
@@ -924,8 +917,35 @@ class ProFormTest(TestCase):
             'crt_reciept_month': 2,
             'intake_format': 'phone',
         })
-        form = ProForm(data=data)
+
+    def test_required_fields(self):
+        form = ProForm(data={})
+        self.assertFalse(form.is_valid())
+        self.assertEquals(
+            form.errors,
+            {'primary_complaint': ['Please select a primary reason to continue.']}
+        )
+
+    def test_full_example(self):
+        form = ProForm(data=self.data)
         self.assertTrue(form.is_valid())
+
+
+class TestIntakeFormat(TestCase):
+    def setUp(self):
+        self.form_data_dict = copy.deepcopy(SAMPLE_REPORT)
+        self.form_data_dict['protected_class'] = ProtectedClass.objects.none()
+        self.form_data_dict['hatecrimes_trafficking'] = HateCrimesandTrafficking.objects.none()
+
+    def test_intake_save_web(self):
+        data, saved_object = save_form(self.form_data_dict, intake_format='web')
+        self.assertEquals(saved_object.intake_format, 'web')
+
+    def test_intake_save_ProForm(self):
+        form_data_dict = copy.deepcopy(self.form_data_dict)
+        form_data_dict['intake_format'] = 'phone'
+        data, saved_object = save_form(form_data_dict)
+        self.assertEquals(saved_object.intake_format, 'phone')
 
 
 class LoginRequiredTests(TestCase):

--- a/crt_portal/cts_forms/tests/tests.py
+++ b/crt_portal/cts_forms/tests/tests.py
@@ -892,8 +892,8 @@ class Complaint_Update_Tests(TestCase):
 
 class ProFormTest(TestCase):
     def setUp(self):
-        data = copy.deepcopy(SAMPLE_REPORT)
-        self.data = data.update({
+        data_sample = copy.deepcopy(SAMPLE_REPORT)
+        data_sample.update({
             'contact_address_line_1': '123',
             'contact_address_line_2': 'Apt 234',
             'contact_city': 'test',
@@ -917,6 +917,7 @@ class ProFormTest(TestCase):
             'crt_reciept_month': 2,
             'intake_format': 'phone',
         })
+        self.data = data_sample
 
     def test_required_fields(self):
         form = ProForm(data={})

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -314,7 +314,8 @@ class SaveCommentView(LoginRequiredMixin, FormView):
         return render(request, 'forms/complaint_view/show/index.html', output)
 
 
-def save_form(form_data_dict):
+def save_form(form_data_dict, **kwargs):
+    print(form_data_dict)
     m2m_protected_class = form_data_dict.pop('protected_class')
     m2m_hatecrime = form_data_dict.pop('hatecrimes_trafficking')
     r = Report.objects.create(**form_data_dict)
@@ -331,7 +332,8 @@ def save_form(form_data_dict):
 
     r.assigned_section = r.assign_section()
     r.district = r.assign_district()
-    r.intake_format = 'web'
+    if kwargs.get('intake_format'):
+        r.intake_format = kwargs.get('intake_format')
     r.save()
     # adding this back for the save page results
     form_data_dict['protected_class'] = m2m_protected_class.values()
@@ -624,7 +626,7 @@ class CRTReportWizard(SessionWizardView):
 
     def done(self, form_list, form_dict, **kwargs):
         form_data_dict = self.get_all_cleaned_data()
-        _, report = save_form(form_data_dict)
+        _, report = save_form(form_data_dict, intake_format='web')
         return render(
             self.request, 'forms/confirmation.html',
             {

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -315,7 +315,6 @@ class SaveCommentView(LoginRequiredMixin, FormView):
 
 
 def save_form(form_data_dict, **kwargs):
-    print(form_data_dict)
     m2m_protected_class = form_data_dict.pop('protected_class')
     m2m_hatecrime = form_data_dict.pop('hatecrimes_trafficking')
     r = Report.objects.create(**form_data_dict)


### PR DESCRIPTION
[intake type #433](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/433)

## What does this change?
Corrects intake format bug where all were assigned web and adds a test to the save function for intake type

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
