### PR TITLE
Alert a11y fix

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -46,7 +46,7 @@
 
           {% block form_questions %}
             {% if page_errors %}
-              <section id="page-errors" class="display-none page-errors margin-bottom-2" role="alert" aria-live="assertive">
+              <section id="page-errors" class="page-errors margin-bottom-2" role="alert" aria-live="assertive">
                 {{ num_page_errors }} error{{ num_page_errors|pluralize }}: {{ page_errors_desc }}
               </section>
             {% endif %}

--- a/crt_portal/static/js/focus_alert.js
+++ b/crt_portal/static/js/focus_alert.js
@@ -1,4 +1,13 @@
 function prepareErrors() {
+
+  // Find elements with class'usa-input--error'
+  var errors = document.getElementsByClassName('usa-input--error');
+  // add focus to first error
+  if(errors.length > 0){
+    var first_error = errors[0]
+    first_error.focus()
+  }
+
   var pageErrors = document.getElementById('page-errors');
   if (!pageErrors) {
     return;

--- a/crt_portal/static/js/focus_alert.js
+++ b/crt_portal/static/js/focus_alert.js
@@ -4,18 +4,15 @@ function prepareErrors() {
   var errors = document.getElementsByClassName('usa-input--error');
   // add focus to first error
   if(errors.length > 0){
+    // add focus to the first error
     var first_error = errors[0]
     first_error.focus()
+    // read first error message
+    var error_message = document.getElementsByClassName('usa-alert__body')[0]
+    error_message.setAttribute("role", "alert");
+    error_message.setAttribute("aria-live", "assertive")
+    console.log(error_message)
   }
-
-  var pageErrors = document.getElementById('page-errors');
-  if (!pageErrors) {
-    return;
-  }
-
-  // Page level errors begin hidden, and are revealed once the DOM has loaded
-  // This makes screen readers think a new element has been inserted into the page.
-  pageErrors.classList.remove('display-none');
 }
 
 function triggerAlert() {

--- a/crt_portal/static/js/focus_alert.js
+++ b/crt_portal/static/js/focus_alert.js
@@ -1,17 +1,16 @@
 function prepareErrors() {
-
   // Find elements with class'usa-input--error'
   var errors = document.getElementsByClassName('usa-input--error');
   // add focus to first error
-  if(errors.length > 0){
+  if (errors.length > 0) {
     // add focus to the first error
-    var first_error = errors[0]
-    first_error.focus()
+    var first_error = errors[0];
+    first_error.focus();
     // read first error message
-    var error_message = document.getElementsByClassName('usa-alert__body')[0]
-    error_message.setAttribute("role", "alert");
-    error_message.setAttribute("aria-live", "assertive")
-    console.log(error_message)
+    var error_message = document.getElementsByClassName('usa-alert__body')[0];
+    error_message.setAttribute('role', 'alert');
+    error_message.setAttribute('aria-live', 'assertive');
+    console.log(error_message);
   }
 }
 

--- a/crt_portal/static/js/focus_alert.js
+++ b/crt_portal/static/js/focus_alert.js
@@ -10,7 +10,6 @@ function prepareErrors() {
     var error_message = document.getElementsByClassName('usa-alert__body')[0];
     error_message.setAttribute('role', 'alert');
     error_message.setAttribute('aria-live', 'assertive');
-    console.log(error_message);
   }
 }
 


### PR DESCRIPTION
[Location name/city/state error is reading entire group#343](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/343)

## What does this change?
- Adds focus to the first error on the page
- Reads out that error
- Doesn't read out the messages on the top

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
