### PR TITLE
Update right-side labels from blue to dark gray

### DIFF
--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -5,7 +5,7 @@ $complaint-header-min-height: 200px;
   width: 100%;
 
   th {
-    color: $blue-warm-vivid-70;
+    color: $gray-warm-80;
     font-size: 1rem;
     font-weight: bold;
     padding-right: 0;


### PR DESCRIPTION
Attempt at changing the field labels (Name, Email, Phone, Address...) from blue to the normal dark gray (gray-warm-80, #2e2e2a)

[Link to ZenHub issue.](link-goes-here)

## What does this change?

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
