### PR TITLE
Use element specific listeners for word limits

### DIFF
--- a/crt_portal/static/js/word_count.js
+++ b/crt_portal/static/js/word_count.js
@@ -111,7 +111,9 @@
     }
   }
 
-  document.addEventListener('keyup', listenWordCount);
+  // Add listeners only to word-limited elements
+  const wordLimitedElements = Array.from(textAreaElem500).concat(Array.from(textAreaElem10));
+  wordLimitedElements.forEach(element => element.addEventListener('keyup', listenWordCount));
 
   // Fire `updateWordCount()` on page load because textarea may have
   // some initial content; for example if the user fills in the textarea,


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/445)

## What does this change?
Limits the trigger for our  word counting functionality to key strokes within `textarea` elements that have a word limit applied. 


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
