### PR TITLE
[WIP] Remove `role` attribute from checkbox labels

### DIFF
--- a/crt_portal/cts_forms/templates/forms/widgets/usa_checkbox_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/usa_checkbox_option.html
@@ -6,5 +6,5 @@
     class="usa-checkbox__input"
     {% include "django/forms/widgets/attrs.html" %}
   />
-  <label role="label" class="crt-checkbox__label" {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>{{ widget.label }}</label>
+  <label class="crt-checkbox__label" {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>{{ widget.label }}</label>
 </div>


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/446)

## What does this change?
Removing invalid `role` value from usa-checkbox <label> elements. Resolves the error below from Accessibility Insights.

```Title: WCAG 1.3.1,WCAG 4.1.1,WCAG 4.1.2: Ensures all elements with a role attribute use a valid value (label[for="id_0-hatecrimes_trafficking_0"])
Tags: Accessibility, WCAG 1.3.1, WCAG 4.1.1, WCAG 4.1.2, aria-roles

Issue: Ensures all elements with a role attribute use a valid value (aria-roles - https://dequeuniversity.com/rules/axe/3.5/aria-roles?application=msftAI)

Target application: Contact the Civil Rights Division - Department of Justice - http://127.0.0.1:8000/form/new/

Element path: label[for="id_0-hatecrimes_trafficking_0"]

Snippet: <label role="label" class="crt-checkbox__label" for="id_0-hatecrimes_trafficking_0">Physical harm or threats of violence based on race, color, national origin, religion, gender, sexual orientation, gender identity, or disability</label>

How to fix: 
Fix all of the following:
  Role must be one of the valid ARIA roles: label

Environment: Chrome version 81.0.4044.92
```
## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
