### PR TITLE
Add alt text to error page image

### DIFF
--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -26,7 +26,7 @@
   <div class="tablet:grid-col-8 tablet:grid-offset-2">
     <div class="crt-success-card">
       <div class="crt-success-card__content">
-          <h2>{{ status }}<img src="{% static "img/alerts/error-red.svg" %}" width="50px" height="50px" class="padding-top-3"></h2>
+          <h2>{{ status }}<img src="{% static 'img/alerts/error-red.svg' %}" alt="Error indicator with exclamation mark in red circle" width="50px" height="50px" class="padding-top-3"></h2>
           <h3>{{ message }}</h3>
           <p>{{ helptext }}</p>
           </div>


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/444)

## What does this change?
Adding `alt` text to the image on the error page template.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
