### PR TITLE
Add status role to `no results` filter message

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -79,7 +79,7 @@
     <div class="grid-container padding-bottom-2">
       <div class="align-center">
         <img alt="filter icon" src="{% static 'img/filters.svg' %}" class="margin-top-1" />
-        <p class="margin-bottom-1 margin-top-1"><b>No records found</b></p>
+        <p class="margin-bottom-1 margin-top-1" role="status"><b>No records found</b></p>
         <em>Try adjusting your filters to see more records</em>
       </div>
     </div>


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/439)

## What does this change?
Adds status role to `no results` filter message

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
