### PR TITLE
Add consistency for disabled pagination

### DIFF
--- a/crt_portal/cts_forms/templates/forms/snippets/pagination.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/pagination.html
@@ -14,7 +14,7 @@
           </a>
         </li>
       {% else %}
-        <li class="nav-arrow disabled-nav">
+        <li class="nav-arrow disabled-nav" aria-hidden='true'>
           <div>
             {% include "forms/snippets/nav_arrow.html" %}
           </div>


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/440)

## What does this change?
Disables the `back` pagination button both visually and for keyboard navigation/screen readers. Now matches disabled state of `forward` button

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
