### PR TITLE
Only show relevant follow up questions

### DIFF
--- a/crt_portal/cts_forms/templates/forms/pro_template.html
+++ b/crt_portal/cts_forms/templates/forms/pro_template.html
@@ -1,5 +1,6 @@
 {# not on public pages #}
 {% extends "forms/report_base.html" %}
+{% load static %}
 
 {{ super }}
 
@@ -28,30 +29,31 @@
 
 {% include "forms/question_cards/single_form.html" with field=form.servicemember card_title="Service member" %}
 
-{% include "forms/question_cards/single_form.html" with field=form.primary_complaint card_title="Primary concern" required=True %}
+<div class="crt-portal-card">
+  <div class="crt-portal-card__content crt-portal-card__content--lg">
+    <h2 id="Primary concern">Primary concern</h2>
+    {% include "forms/question_cards/single_question.html" with field=form.primary_complaint required=True %}
+
+    {# Optional questions: #}
+
+    {% include "forms/question_cards/single_question.html" with hidden=True field=form.public_or_private_employer label_class=question_group.help_cls %}
+
+    {% include "forms/question_cards/single_question.html" with hidden=True field=form.employer_size label_class=question_group.help_cls %}
+
+    {% include "forms/question_cards/single_question.html" with hidden=True field=form.public_or_private_school label_class=question_group.help_cls %}
+
+    {% include "forms/question_cards/single_question.html" with hidden=True field=form.inside_correctional_facility label_class=question_group.help_cls %}
+
+    {% include "forms/question_cards/single_question.html" with hidden=True field=form.correctional_facility_type label_class=question_group.help_cls %}
+
+    {% include "forms/question_cards/single_question.html" with hidden=True field=form.commercial_or_public_place label_class=question_group.help_cls %}
+
+    {% include "forms/question_cards/single_question.html" with hidden=True field=form.other_commercial_or_public_place label_class=question_group.help_cls %}
+  </div>
+</div>
 
 {% include "forms/question_cards/single_form.html" with field=form.hatecrimes_trafficking %}
 
-<div class="crt-portal-card">
-  <div class="crt-portal-card__content crt-portal-card__content--lg">
-    <h2 id="Follow up">Follow up questions</h2>
-
-    {% include "forms/question_cards/single_question.html" with field=form.public_or_private_employer label_class=question_group.help_cls %}
-
-    {% include "forms/question_cards/single_question.html" with field=form.employer_size label_class=question_group.help_cls %}
-    {% include "forms/question_cards/single_question.html" with field=form.public_or_private_school label_class=question_group.help_cls %}
-
-    {% include "forms/question_cards/single_question.html" with field=form.election_details label_class=question_group.help_cls %}
-
-    {% include "forms/question_cards/single_question.html" with field=form.inside_correctional_facility label_class=question_group.help_cls %}
-
-    {% include "forms/question_cards/single_question.html" with field=form.correctional_facility_type label_class=question_group.help_cls %}
-
-    {% include "forms/question_cards/single_question.html" with field=form.commercial_or_public_place label_class=question_group.help_cls %}
-
-    {% include "forms/question_cards/single_question.html" with field=form.other_commercial_or_public_place label_class=question_group.help_cls %}
-  </div>
-</div>
 
 {% include "forms/question_cards/location.html" with card_title="Incident location" %}
 
@@ -79,4 +81,9 @@
   </div>
 </div>
 
+{% endblock %}
+
+{% block page_js %}
+{{ super }}
+    <script src="{% static 'js/pro_form_show_hide.js' %}"></script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/question_cards/single_question.html
+++ b/crt_portal/cts_forms/templates/forms/question_cards/single_question.html
@@ -1,4 +1,5 @@
-<div class="form-group">
+<div class="form-group"{% if hidden == True %} style="display:none" id="div-{{ field.id_for_label }}">
+{% else %}>{% endif %}
   {% if field.label %}
     <h3><label
       for="{{ field.id_for_label }}"

--- a/crt_portal/cts_forms/templates/forms/question_cards/single_question.html
+++ b/crt_portal/cts_forms/templates/forms/question_cards/single_question.html
@@ -1,5 +1,4 @@
-<div class="form-group"{% if hidden == True %} style="display:none" id="div-{{ field.id_for_label }}">
-{% else %}>{% endif %}
+<div class="form-group"{% if hidden %} style="display:none" id="div-{{ field.id_for_label }}"{% endif %}>
   {% if field.label %}
     <h3><label
       for="{{ field.id_for_label }}"

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -356,7 +356,6 @@ class ProFormView(LoginRequiredMixin, SessionWizardView):
             'Contact',
             'Service member',
             'Primary concern',
-            'Follow up',
             'Incident location',
             'Personal characteristics',
             'Date',

--- a/crt_portal/static/js/pro_form_show_hide.js
+++ b/crt_portal/static/js/pro_form_show_hide.js
@@ -2,38 +2,47 @@
   root.CRT = root.CRT || {};
 
   function toggleFollowUpQuestions(event) {
-    var primary_complaint_id = event.target.id
+    var primary_complaint_id = event.target.id;
     var predicate_target_mapping = {
-     'id_0-primary_complaint_0': ['div-id_0-public_or_private_employer_0', 'div-id_0-employer_size_0'],
-     'id_0-primary_complaint_2': ['div-id_0-public_or_private_school_0'],
-     'id_0-primary_complaint_4': ['div-id_0-inside_correctional_facility_0', 'div-id_0-correctional_facility_type_0'],
-     'id_0-primary_complaint_5': ['div-id_0-commercial_or_public_place_0', 'div-id_0-other_commercial_or_public_place']
-    }
+      'id_0-primary_complaint_0': [
+        'div-id_0-public_or_private_employer_0',
+        'div-id_0-employer_size_0'
+      ],
+      'id_0-primary_complaint_2': ['div-id_0-public_or_private_school_0'],
+      'id_0-primary_complaint_4': [
+        'div-id_0-inside_correctional_facility_0',
+        'div-id_0-correctional_facility_type_0'
+      ],
+      'id_0-primary_complaint_5': [
+        'div-id_0-commercial_or_public_place_0',
+        'div-id_0-other_commercial_or_public_place'
+      ]
+    };
     // show
-    if(primary_complaint_id in predicate_target_mapping){
-      var targets = predicate_target_mapping[primary_complaint_id]
-      targets.forEach(function(question_id){
-        var target = document.getElementById(question_id)
-        target.style.display = 'block'
-      })
+    if (primary_complaint_id in predicate_target_mapping) {
+      var targets = predicate_target_mapping[primary_complaint_id];
+      targets.forEach(function(question_id) {
+        var target = document.getElementById(question_id);
+        target.style.display = 'block';
+      });
     }
     // hide
-    Object.keys(predicate_target_mapping).forEach(function(primary_id){
-      if(primary_complaint_id != primary_id){
-        var targets = predicate_target_mapping[primary_id]
-        targets.forEach(function(question_id){
-          var target = document.getElementById(question_id)
-          target.style.display = 'none'
-        })
+    Object.keys(predicate_target_mapping).forEach(function(primary_id) {
+      if (primary_complaint_id != primary_id) {
+        var targets = predicate_target_mapping[primary_id];
+        targets.forEach(function(question_id) {
+          var target = document.getElementById(question_id);
+          target.style.display = 'none';
+        });
       }
-    })
-  };
+    });
+  }
 
   // add listeners
   var primary_issues = document.querySelectorAll('*[id^="id_0-primary_complaint_"]');
-  primary_issues.forEach(function(radio_element){
+  primary_issues.forEach(function(radio_element) {
     radio_element.addEventListener('click', toggleFollowUpQuestions);
-  })
+  });
 
   return root;
 })(window, document);

--- a/crt_portal/static/js/pro_form_show_hide.js
+++ b/crt_portal/static/js/pro_form_show_hide.js
@@ -1,16 +1,6 @@
 (function(root, dom) {
   root.CRT = root.CRT || {};
 
-  function showQuestion(question_id) {
-    var target = document.getElementById(question_id)
-    target.style.display = 'block'
-  }
-
-  function hideQuestion(question_id) {
-    var target = document.getElementById(question_id)
-    target.style.display = 'none'
-  }
-
   function toggleFollowUpQuestions(event) {
     var primary_complaint_id = event.target.id
     var predicate_target_mapping = {
@@ -19,17 +9,22 @@
      'id_0-primary_complaint_4': ['div-id_0-inside_correctional_facility_0', 'div-id_0-correctional_facility_type_0'],
      'id_0-primary_complaint_5': ['div-id_0-commercial_or_public_place_0', 'div-id_0-other_commercial_or_public_place']
     }
-
+    // show
     if(primary_complaint_id in predicate_target_mapping){
       var targets = predicate_target_mapping[primary_complaint_id]
-      targets.forEach(question_id => showQuestion(question_id))
+      targets.forEach(function(question_id){
+        var target = document.getElementById(question_id)
+        target.style.display = 'block'
+      })
     }
-
+    // hide
     Object.keys(predicate_target_mapping).forEach(function(primary_id){
-      console.log(primary_id)
       if(primary_complaint_id != primary_id){
         var targets = predicate_target_mapping[primary_id]
-        targets.forEach(question_id => hideQuestion(question_id))
+        targets.forEach(function(question_id){
+          var target = document.getElementById(question_id)
+          target.style.display = 'none'
+        })
       }
     })
   };

--- a/crt_portal/static/js/pro_form_show_hide.js
+++ b/crt_portal/static/js/pro_form_show_hide.js
@@ -1,0 +1,44 @@
+(function(root, dom) {
+  root.CRT = root.CRT || {};
+
+  function showQuestion(question_id) {
+    var target = document.getElementById(question_id)
+    target.style.display = 'block'
+  }
+
+  function hideQuestion(question_id) {
+    var target = document.getElementById(question_id)
+    target.style.display = 'none'
+  }
+
+  function toggleFollowUpQuestions(event) {
+    var primary_complaint_id = event.target.id
+    var predicate_target_mapping = {
+     'id_0-primary_complaint_0': ['div-id_0-public_or_private_employer_0', 'div-id_0-employer_size_0'],
+     'id_0-primary_complaint_2': ['div-id_0-public_or_private_school_0'],
+     'id_0-primary_complaint_4': ['div-id_0-inside_correctional_facility_0', 'div-id_0-correctional_facility_type_0'],
+     'id_0-primary_complaint_5': ['div-id_0-commercial_or_public_place_0', 'div-id_0-other_commercial_or_public_place']
+    }
+
+    if(primary_complaint_id in predicate_target_mapping){
+      var targets = predicate_target_mapping[primary_complaint_id]
+      targets.forEach(question_id => showQuestion(question_id))
+    }
+
+    Object.keys(predicate_target_mapping).forEach(function(primary_id){
+      console.log(primary_id)
+      if(primary_complaint_id != primary_id){
+        var targets = predicate_target_mapping[primary_id]
+        targets.forEach(question_id => hideQuestion(question_id))
+      }
+    })
+  };
+
+  // add listeners
+  var primary_issues = document.querySelectorAll('*[id^="id_0-primary_complaint_"]');
+  primary_issues.forEach(function(radio_element){
+    radio_element.addEventListener('click', toggleFollowUpQuestions);
+  })
+
+  return root;
+})(window, document);


### PR DESCRIPTION
[[proform] Only show follow up question once related primary issue is selected#412.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/412)

## What does this change?
- When a primary reason that has a follow question up is chosen, that question shows up below the primary reason question
- Removes "follow up questions" as it's own step
- Removes Voting follow up question, since we are getting rid of that

To do:
- remove visibility of follow up question if a different primary issue is chosen

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
