### PR TITLE
Success messaging for complaint updates

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1044,7 +1044,7 @@ class CommentActions(ModelForm):
             },
         )
         self.fields['note'].label = 'New comment'
-        self.fields['is_summary'] = TextInput()
+        self.fields['is_summary'] = CharField()
 
     def update_activity_stream(user, report, comment, verb):
         """Send all actions to activity stream"""

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1046,13 +1046,13 @@ class CommentActions(ModelForm):
         self.fields['note'].label = 'New comment'
         self.fields['is_summary'] = CharField()
 
-    def update_activity_stream(user, report, comment, verb):
+    def update_activity_stream(self, user, report, verb):
         """Send all actions to activity stream"""
         from actstream import action
         action.send(
             user,
             verb=verb,
-            description=comment,
+            description=self.instance.note,
             target=report
         )
 

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.core.validators import RegexValidator, MaxValueValidator
 from django.utils.functional import cached_property
 from django.contrib.auth import get_user_model
-
+from django.urls import reverse
 from .phone_regex import phone_validation_regex
 
 from .model_variables import (
@@ -227,7 +227,7 @@ class Report(models.Model):
                 return 'EOS'
             elif self.__is_not_disabled(protected_classes):
                 return 'EOS'
-            elif self.public_or_private_school == 'private'and not self.__is_not_disabled(protected_classes):
+            elif self.public_or_private_school == 'private' and not self.__is_not_disabled(protected_classes):
                 return 'DRS'
 
         elif self.primary_complaint == 'police':
@@ -256,3 +256,6 @@ class Report(models.Model):
     def get_summary(self):
         """Return most recent summary provided by an intake specialist"""
         return self.internal_comments.filter(is_summary=True).order_by('-modified_date').first()
+
+    def get_absolute_url(self):
+        return reverse('crt_forms:crt-forms-show', kwargs={"id": self.id})

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -49,13 +49,8 @@
         </p>
       </div>
       <div class="tablet:grid-col-6">
-        {% if messages %}
-          <ul class="messages">
-              {% for message in messages %}
-              <li role="alert" {% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-              {% endfor %}
-          </ul>
-        {% endif %}
+        {% include 'partials/messages.html' %}
+
       </div>
     </div>
     <div class="grid-row grid-gap-lg">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -48,6 +48,15 @@
           <span class="backend-blue">{{ data.modified_date|date:'g:i a F j, Y' }}</span>
         </p>
       </div>
+      <div class="tablet:grid-col-6">
+        {% if messages %}
+          <ul class="messages">
+              {% for message in messages %}
+              <li role="alert" {% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+              {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
     </div>
     <div class="grid-row grid-gap-lg">
       <div class="tablet:grid-col-4 grid-offset-1">

--- a/crt_portal/cts_forms/templates/partials/messages.html
+++ b/crt_portal/cts_forms/templates/partials/messages.html
@@ -2,7 +2,7 @@
 <h2 class="messages">
     <ul class="messages blue-background usa-prose" >
         {% for message in messages %}
-            <li role="alert" {% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+            <li class="update-status{% if message.tags %} {{ message.tags }}{% endif %}">{{ message }}</li>
         {% endfor %}
     </ul>
 </h2>

--- a/crt_portal/cts_forms/templates/partials/messages.html
+++ b/crt_portal/cts_forms/templates/partials/messages.html
@@ -1,0 +1,7 @@
+{% if messages %}
+<ul class="messages blue-background usa-prose" >
+    {% for message in messages %}
+        <li role="alert" {% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+    {% endfor %}
+</ul>
+{% endif %}

--- a/crt_portal/cts_forms/templates/partials/messages.html
+++ b/crt_portal/cts_forms/templates/partials/messages.html
@@ -1,7 +1,9 @@
 {% if messages %}
-<ul class="messages blue-background usa-prose" >
-    {% for message in messages %}
-        <li role="alert" {% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-    {% endfor %}
-</ul>
+<h2 class="messages">
+    <ul class="messages blue-background usa-prose" >
+        {% for message in messages %}
+            <li role="alert" {% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+        {% endfor %}
+    </ul>
+</h2>
 {% endif %}

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -53,19 +53,20 @@ class CommentActionTests(TestCase):
                 'is_summary': False,
                 'note': self.note,
             },
+            follow=True
         )
 
     def test_post(self):
         """A logged in user can post a comment"""
         self.assertEquals(self.response.status_code, 200)
 
-    def test_creates_commment(self):
+    def test_creates_comment(self):
         """A comment is created and associated with the right report"""
         comment_id = CommentAndSummary.objects.get(note=self.note).pk
         report = Report.objects.filter(internal_comments__pk=comment_id)[0]
         self.assertEquals(report.pk, self.pk)
 
-    def test_adds_commment_to_activity(self):
+    def test_adds_comment_to_activity(self):
         """The comment shows up in the report's activity log"""
         response = self.client.get(
             reverse('crt_forms:crt-forms-show', kwargs={'id': self.pk})
@@ -86,6 +87,7 @@ class CommentActionTests(TestCase):
                 'note': update,
                 'comment_id': comment_id,
             },
+            follow=True
         )
         content = str(response.content)
         self.assertTrue('updated note' in content)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -285,11 +285,11 @@ class ShowView(LoginRequiredMixin, View):
         """Prepare update success message for rendering in template"""
         updated_fields = [form[field].field.widget.label for field in form.changed_data]
         if len(updated_fields) == 1:
-            message = f"Successfully updated {updated_fields[0]}"
+            message = f"Successfully updated {updated_fields[0]}."
         else:
             fields = ', '.join(updated_fields[:-1])
             fields += f', and {updated_fields[-1]}'
-            message = f"Successfully updated {fields}"
+            message = f"Successfully updated {fields}."
 
         return message
 

--- a/crt_portal/static/js/focus_alert.js
+++ b/crt_portal/static/js/focus_alert.js
@@ -40,6 +40,13 @@ function prepareErrors() {
     error_message.setAttribute('role', 'alert');
     error_message.setAttribute('aria-live', 'assertive');
   }
+
+  var alerts = document.getElementsByClassName('update-status');
+  for(let i = 0 ; i < alerts.length; i++) {
+    let alert = alerts[i];
+    alert.setAttribute('role', 'alert');
+    alert.setAttribute('aria-live', 'assertive');
+  }
 }
 
 function triggerAlert() {

--- a/crt_portal/static/js/focus_alert.js
+++ b/crt_portal/static/js/focus_alert.js
@@ -42,7 +42,7 @@ function prepareErrors() {
   }
 
   var alerts = document.getElementsByClassName('update-status');
-  for(let i = 0 ; i < alerts.length; i++) {
+  for (let i = 0; i < alerts.length; i++) {
     let alert = alerts[i];
     alert.setAttribute('role', 'alert');
     alert.setAttribute('aria-live', 'assertive');

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -107,6 +107,7 @@ $complaint-header-min-height: 200px;
   color:$blue-warm-vivid-80-t;
 }
 
+// Messages rendering
 ul.messages {
   border-style: solid;
   border-radius: 5px;
@@ -116,4 +117,8 @@ ul.messages {
   list-style: none;
   margin-top: 0px;
   padding: 1rem;
+}
+
+h2.messages {
+  margin-top: 0px;
 }

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -113,10 +113,11 @@ ul.messages {
   border-radius: 5px;
   border-width: 1px;
   font-size: 1.125rem;
-  border-color: #162e51;
+  border-color: $blue-warm-vivid-80;
   list-style: none;
   margin-top: 0px;
   padding: 1rem;
+  color: $blue-warm-vivid-80;
 }
 
 h2.messages {

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -106,3 +106,14 @@ $complaint-header-min-height: 200px;
   padding-top: 0rem;
   color:$blue-warm-vivid-80-t;
 }
+
+ul.messages {
+  border-style: solid;
+  border-radius: 5px;
+  border-width: 1px;
+  font-size: 1.125rem;
+  border-color: #162e51;
+  list-style: none;
+  margin-top: 0px;
+  padding: 1rem;
+}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/442)

## What does this change?
Alternative implementation for #412 .

We render a `success` confirmation message on page when a user performs an update action on the complaint details page. Update actions include any field in the `Actions` form as well as adding/updating the summary or a comment. 

Success message is descriptive of the changed fields. 

## Implementation note
This includes a bit of refactoring for the way we handle incoming POST data on the complaint details page, `SaveCommentView`. I ran into some unexpected behavior where new `CommentAndSummary` objects were being created on page load and successful submissions were rendering a page at the `save-report-comment` url instead of redirecting to the Complaint details url.


## Screenshots (for front-end PR):
<img width="1301" alt="Screen Shot 2020-04-23 at 10 04 19 AM" src="https://user-images.githubusercontent.com/3485564/80108011-d1f7b480-8549-11ea-952a-b05aec0a8bbb.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
