### PR TITLE
Icon tooltip

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
@@ -30,5 +30,4 @@
 {% block page_js %}
 {{ block.super }}
 <script src="{% static 'js/dropdown.js' %}"></script>
-<script src="{% static 'js/show_hide_narrative_summary.js' %}"></script>
 {%endblock%}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -24,6 +24,9 @@
           <span>
             <span class="details-date-label text-uppercase backend-blue">Received: </span>
             <span class="backend-blue">{{ data.create_date|date:'g:i a F j, Y' }}</span>
+            {% if data.intake_format %}
+            <span class="usa-sr-only"> from {{ data.intake_format }}</span>
+            {% endif %}
           </span>
           {% if data.intake_format == 'web' %}
             <img src="{% static "img/intake-icons/ic_web.svg" %}" class="icon margin-left-2" alt="from the public web form">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -28,16 +28,20 @@
             <span class="usa-sr-only"> from {{ data.intake_format }}</span>
             {% endif %}
           </span>
-          {% if data.intake_format == 'web' %}
-            <img src="{% static "img/intake-icons/ic_web.svg" %}" class="icon margin-left-2" alt="from the public web form">
-          {% elif data.intake_format == 'email' %}
-            <img src="{% static "img/intake-icons/ic_email.svg" %}" class="icon margin-left-2" alt="from email">
-          {% elif data.intake_format == 'letter' %}
-            <img src="{% static "img/intake-icons/ic_letter.svg" %}" class="icon margin-left-2" alt="from a letter">
-          {% elif data.intake_format == 'phone' %}
-            <img src="{% static "img/intake-icons/ic_contact.svg" %}" class="icon margin-left-2" alt="from phone">
-          {% elif data.intake_format == 'fax' %}
-            <img src="{% static "img/intake-icons/ic_fax.svg" %}" class="icon margin-left-2" alt="from fax">
+          {% if data.intake_format %}
+            <div class="tooltip"><span class="tooltiptext">from {{ data.intake_format }}</div>
+            {% if data.intake_format == 'web' %}
+              <img src="{% static "img/intake-icons/ic_web.svg" %}" class="icon margin-left-2" alt="from web">
+            {% elif data.intake_format == 'email' %}
+              <img src="{% static "img/intake-icons/ic_email.svg" %}" class="icon margin-left-2" alt="from email">
+            {% elif data.intake_format == 'letter' %}
+              <img src="{% static "img/intake-icons/ic_letter.svg" %}" class="icon margin-left-2" alt="from a letter">
+            {% elif data.intake_format == 'phone' %}
+              <img src="{% static "img/intake-icons/ic_contact.svg" %}" class="icon margin-left-2" alt="from phone">
+            {% elif data.intake_format == 'fax' %}
+              <img src="{% static "img/intake-icons/ic_fax.svg" %}" class="icon margin-left-2" alt="from fax">
+            {% endif %}
+          </div>
           {% endif %}
         </p class="display-flex">
         <p>
@@ -67,3 +71,8 @@
   </div>
 </div>
 {% endblock %}
+
+{% block page_js %}
+{{ block.super }}
+<script src="{% static 'js/show_hide_narrative_summary.js' %}"></script>
+{%endblock%}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -16,9 +16,7 @@
           <h2 class="margin-right-205 margin-top-0 margin-bottom-0 backend-blue">
             ID: {{ data.public_id }}
           </h2>
-          <span class="status-tag status-{{data.status}} margin-top-05">
-            {{ data.status }}
-          </span>
+          <span class="status-tag status-{{data.status}} margin-top-05">{{ data.status }}</span>
         </div>
         <p class="display-flex">
           <span>
@@ -29,7 +27,8 @@
             {% endif %}
           </span>
           {% if data.intake_format %}
-            <div class="tooltip"><span class="tooltiptext">from {{ data.intake_format }}</div>
+            <span class="tooltip">
+              <span class="tooltiptext backend-blue">from {{ data.intake_format }}</span>
             {% if data.intake_format == 'web' %}
               <img src="{% static "img/intake-icons/ic_web.svg" %}" class="icon margin-left-2" alt="from web">
             {% elif data.intake_format == 'email' %}
@@ -41,10 +40,10 @@
             {% elif data.intake_format == 'fax' %}
               <img src="{% static "img/intake-icons/ic_fax.svg" %}" class="icon margin-left-2" alt="from fax">
             {% endif %}
-          </div>
+            </span>
           {% endif %}
-        </p class="display-flex">
-        <p>
+        </p>
+        <p class="display-flex">
           <span class="details-date-label text-uppercase backend-blue">Last Updated: </span>
           <span class="backend-blue">{{ data.modified_date|date:'g:i a F j, Y' }}</span>
         </p>

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -81,3 +81,28 @@ $complaint-header-min-height: 200px;
 .usa-prose #current-summary-text {
   line-height: 1.4; // USWDS override
 }
+
+/* Tooltip container */
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+/* Tooltip text */
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 8rem;
+  text-align: left;
+  padding: .3rem 0;
+  padding-left: 2.4rem;
+  border-radius: .3rem;
+  position: absolute;
+  z-index: 1;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  padding-top: 0rem;
+  color:$blue-warm-vivid-80-t;
+}


### PR DESCRIPTION
[[a11y] Not able to to focus intake type on details page#448](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/448)

## What does this change?
Accessibility improvements to icons:
- Adds voice over only text for "from phone" etc.
- Adds tooltip for icon

## Screenshots (for front-end PR):
![Screen Shot 2020-04-22 at 4 05 59 PM](https://user-images.githubusercontent.com/4406333/80042853-f9507200-84b4-11ea-8c73-10f6766cc085.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
