### PR TITLE
[WIP] added filter by statute

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -23,6 +23,7 @@ filter_options = {
     'create_date_start': '__gte',
     'create_date_end': '__lte',
     'public_id': '__contains',
+    'primary_statute': '__in',
     'summary': 'summary',
 }
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -904,6 +904,14 @@ class Filters(ModelForm):
             'class': 'usa-select'
         })
     )
+    primary_statute = ChoiceField(
+        required=False,
+        choices=_add_empty_choice(STATUTE_CHOICES),
+        widget=Select(attrs={
+            'name': 'primary_statute',
+            'class': 'usa-select'
+        })
+    )
     summary = CharField(
         widget=TextInput(
             attrs={
@@ -924,6 +932,7 @@ class Filters(ModelForm):
             'location_state',
             'status',
             'public_id',
+            'primary_statute',
         ]
 
         labels = {
@@ -933,7 +942,8 @@ class Filters(ModelForm):
             'contact_last_name': _('Contact last name'),
             'location_city_town': _('Incident location city'),
             'location_state': _('Incident location state'),
-            'public_id': _('Complaint ID')
+            'public_id': _('Complaint ID'),
+            'primary_statute': _('Statute')
         }
 
         widgets = {

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/active-filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/active-filters.html
@@ -23,6 +23,8 @@
           State
         {% elif key == 'public_id' %}
           Complaint ID
+        {% elif key == 'primary_statute' %}
+          Statute
         {% else %}
           {{key|capfirst}}
         {% endif %}: {{item}}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -14,6 +14,7 @@
     {% include 'forms/complaint_view/index/filters/status_filter.html' %}
     {% include 'forms/complaint_view/index/filters/summary_filter.html' %}
     {% include 'forms/complaint_view/index/filters/public_id_filter.html' %}
+    {% include 'forms/complaint_view/index/filters/primary_statute_filter.html' %}
   </div>
 </form>
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/primary_statute_filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/primary_statute_filter.html
@@ -1,0 +1,17 @@
+{% extends "forms/complaint_view/index/filter.html" %}
+
+{% block controls %}primary-statute{% endblock %}
+{% block label %}Statute{% endblock %}
+{% block id %}primary-statute{% endblock %}
+
+{% block content %}
+  <div id="primary-statute-filter">
+    <label for="id_{{form.fields.primary_statute.widget.attrs.name}}" class="usa-label margin-bottom-1">
+      <b>{{form.primary_statute.label }}</b>
+    </label>
+    {{ form.primary_statute }}
+  </div>
+  <button class="usa-button margin-top-2" type="submit">
+    Filter results
+  </button>
+{% endblock %}

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -118,6 +118,7 @@
     create_date_end: '',
     summary: '',
     public_id: '',
+    primary_statute: '',
     sort: '',
     page: '',
     per_page: ''
@@ -253,6 +254,7 @@
     var statusEl = formEl.querySelector('select[name="status"]');
     var summaryEl = formEl.querySelector('input[name="summary"]');
     var complaintIDEl = formEl.querySelector('input[name="public_id"');
+    var statuteEl = formEl.querySelector('select[name="primary_statute"]');
     /**
      * Update the filter data model when the user clears (clicks on) a filter tag,
      * and perform a new search with the updated filters applied.
@@ -331,6 +333,10 @@
     textInputView({
       el: complaintIDEl,
       name: 'public_id'
+    });
+    textInputView({
+      el: statuteEl,
+      name: 'primary_statute'
     });
     clearFiltersView({
       el: clearAllEl,


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/460)

## What does this change?
allow CRT internal user to filter records by statute
## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
