### PR TITLE
Sections need to be uppercased

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -961,7 +961,7 @@ class Filters(ModelForm):
 
         widgets = {
             'assigned_section': CrtMultiSelect(attrs={
-                'classes': 'text-uppercase',
+                'class': 'text-uppercase',
                 'name': 'assigned_section'
             }),
             'contact_first_name': TextInput(attrs={
@@ -1009,7 +1009,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
             widget=ComplaintSelect(
                 label='Status',
                 attrs={
-                    'classes': 'crt-dropdown__data',
+                    'class': 'crt-dropdown__data',
                 },
 
             ),
@@ -1020,7 +1020,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
             widget=ComplaintSelect(
                 label='Primary statute',
                 attrs={
-                    'classes': 'text-uppercase crt-dropdown__data',
+                    'class': 'text-uppercase crt-dropdown__data',
                 },
             ),
             choices=_add_empty_choice(STATUTE_CHOICES),
@@ -1030,7 +1030,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
             widget=ComplaintSelect(
                 label='Judicial district',
                 attrs={
-                    'classes': 'text-uppercase crt-dropdown__data',
+                    'class': 'text-uppercase crt-dropdown__data',
                 },
             ),
             choices=_add_empty_choice(DISTRICT_CHOICES),

--- a/crt_portal/cts_forms/templates/forms/widgets/complaint_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/complaint_select.html
@@ -1,4 +1,4 @@
-<select id="{{widget.attrs.id}}" name="{{widget.name}}" class="usa-select text-bold {{widget.attrs.classes}}">
+<select id="{{widget.attrs.id}}" name="{{widget.name}}" class="usa-select text-bold {{widget.attrs.class}}">
   {% for group_name, group_choices, group_index in widget.optgroups %}
     {% for option in group_choices %}
       {% include option.template_name with option=option %}


### PR DESCRIPTION
Keeping the names for assigning classes in forms.py the same

This fixes the problem where the sections are title cased instead of upper cased.

To populate the class field, we can now always use "class", instead of sometimes using "classes" and sometimes "class."
