### PR TITLE
Update activity log

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -61,7 +61,7 @@ class ActivityStreamUpdater(object):
     def get_actions(self):
         """Parse incoming changed data for activity stream entry"""
         for field in self.changed_data:
-            yield f"updated {' '.join(field.split('_'))}:", f"from {self.initial[field]} to {self.cleaned_data[field]}"
+            yield f"{' '.join(field.split('_')).capitalize()}:", f'Updated from "{self.initial[field]}" to "{self.cleaned_data[field]}"'
 
     def update_activity_stream(self, user):
         """Send all actions to activity stream"""
@@ -1043,7 +1043,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
     def get_actions(self):
         """Parse incoming changed data for activity stream entry"""
         for field in self.changed_data:
-            yield f"updated {' '.join(field.split('_'))}:", f"from {self.initial[field]} to {self.cleaned_data[field]}"
+            yield f"{' '.join(field.split('_')).capitalize()}:", f'Updated from "{self.initial[field]}" to "{self.cleaned_data[field]}"'
 
     def update_activity_stream(self, user):
         """Send all actions to activity stream"""

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -61,7 +61,7 @@ class ActivityStreamUpdater(object):
     def get_actions(self):
         """Parse incoming changed data for activity stream entry"""
         for field in self.changed_data:
-            yield f"updated {' '.join(field.split('_'))}", f"from {self.initial[field]} to {self.cleaned_data[field]}"
+            yield f"updated {' '.join(field.split('_'))}:", f"from {self.initial[field]} to {self.cleaned_data[field]}"
 
     def update_activity_stream(self, user):
         """Send all actions to activity stream"""
@@ -1043,7 +1043,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
     def get_actions(self):
         """Parse incoming changed data for activity stream entry"""
         for field in self.changed_data:
-            yield f"updated {' '.join(field.split('_'))}", f"from {self.initial[field]} to {self.cleaned_data[field]}"
+            yield f"updated {' '.join(field.split('_'))}:", f"from {self.initial[field]} to {self.cleaned_data[field]}"
 
     def update_activity_stream(self, user):
         """Send all actions to activity stream"""

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -61,7 +61,7 @@ class ActivityStreamUpdater(object):
     def get_actions(self):
         """Parse incoming changed data for activity stream entry"""
         for field in self.changed_data:
-            yield f"updated {' '.join(field.split('_'))}", f" to {self.cleaned_data[field]}"
+            yield f"updated {' '.join(field.split('_'))}", f"from {self.initial[field]} to {self.cleaned_data[field]}"
 
     def update_activity_stream(self, user):
         """Send all actions to activity stream"""
@@ -1043,7 +1043,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
     def get_actions(self):
         """Parse incoming changed data for activity stream entry"""
         for field in self.changed_data:
-            yield f"updated {' '.join(field.split('_'))}", f" to {self.cleaned_data[field]}"
+            yield f"updated {' '.join(field.split('_'))}", f"from {self.initial[field]} to {self.cleaned_data[field]}"
 
     def update_activity_stream(self, user):
         """Send all actions to activity stream"""

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
@@ -9,13 +9,13 @@
     {% for activity in activity_stream %}
       <li class="activity-stream-item">
         <div class="display-flex flex-justify">
-          <b>{{activity.actor.username}}</b>
+          <b>{{ activity.actor.username }}</b>
           <span class="date font-sans-sm flex-align-end">
-            {{ activity.timestamp|date:'n/d/y'}} {{ activity.timestamp|time}}
+            {{ activity.timestamp|date:'n/d/y' }} {{ activity.timestamp|time }}
           </span>
         </div>
         <p class="margin-top-05">
-          {{activity.verb}} {{activity.description|linebreaks}}
+          {{ activity.verb }}{{ activity.description|linebreaks }}
         </p>
       </li>
     {% endfor %}

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -16,10 +16,11 @@ class ComplaintActionTests(SimpleTestCase):
         self.form = ComplaintActions()
 
     def test_get_actions_returns_verb_and_description_for_each_changed_field(self):
-        self.form.changed_data = ['field_test']
-        self.form.cleaned_data = {'field_test': 'verb'}
+        self.form.initial['assigned_section'] = 'old'
+        self.form.changed_data = ['assigned_section']
+        self.form.cleaned_data = {'assigned_section': 'verb'}
         actions = [action for action in self.form.get_actions()]
-        self.assertEqual(actions, [("updated field test", " to verb")])
+        self.assertEqual(actions, [('Assigned section:', 'Updated from "old" to "verb"')])
 
 
 class ActionTests(TestCase):

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -307,10 +307,10 @@ class SaveCommentView(LoginRequiredMixin, FormView):
             comment = comment_form.save()
             report.internal_comments.add(comment)
             if comment.is_summary:
-                verb = 'Updated summary: ' if instance else 'Added summary: '
+                verb = 'updated summary: ' if instance else 'added summary: '
             else:
                 # If not a summary, this is a comment
-                verb = 'Updated comment: ' if instance else 'Added comment: '
+                verb = 'updated comment: ' if instance else 'added comment: '
 
             messages.add_message(request, messages.SUCCESS, f'Successfully {verb[:-2].lower()}.')
             comment_form.update_activity_stream(request.user, report, verb)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -307,10 +307,11 @@ class SaveCommentView(LoginRequiredMixin, FormView):
             comment = comment_form.save()
             report.internal_comments.add(comment)
             if comment.is_summary:
-                verb = 'updated summary: ' if instance else 'added summary: '
+                verb = 'Updated summary: ' if instance else 'Added summary: '
+
             else:
                 # If not a summary, this is a comment
-                verb = 'updated comment: ' if instance else 'added comment: '
+                verb = 'Updated comment: ' if instance else 'Added comment: '
 
             messages.add_message(request, messages.SUCCESS, f'Successfully {verb[:-2].lower()}.')
             comment_form.update_activity_stream(request.user, report, verb)


### PR DESCRIPTION
[Capture 'To' and 'From' states in the activity log #466](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/466)

## What does this change?
Now messages for activity log changes will be: 

`username`     `date stamp`
`Field`:
Updated from `initial` to `new data`

Summaries and comments just have the text so they look the same:
`username`     `date stamp`
New/Updated comment/summary:
`comment`

## Screenshots (for front-end PR):
My username on local is "1"
![Screen Shot 2020-04-30 at 2 30 08 PM](https://user-images.githubusercontent.com/4406333/80761451-713f1d80-8aef-11ea-8401-da3f3c73bc84.png)
![Screen Shot 2020-04-30 at 2 36 13 PM](https://user-images.githubusercontent.com/4406333/80761768-0a6e3400-8af0-11ea-85a1-4b384fdd1a92.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
