### PR TITLE
Ie11 tweaks for complaint contact edit

### DIFF
--- a/crt_portal/static/js/edit_contact_info.js
+++ b/crt_portal/static/js/edit_contact_info.js
@@ -14,9 +14,19 @@
     editButton.addEventListener('click', showContactForm);
   }
 
+  function getFormState(form) {
+    //  Serialize form values into a comma delimited string
+    var serializedForm = new Array();
+    for (var i = 0; i < form.elements.length; i++) {
+      var field = form.elements[i];
+      serializedForm.push(field.value);
+    }
+    return serializedForm.join(',');
+  }
+
   function setButtonDisabled() {
     // Save Button only enabled if form has been modified
-    var currentState = Array.from(new FormData(contactForm), e => e[1]).join(',');
+    var currentState = getFormState(contactForm);
     if (initialState === currentState) {
       saveButton.setAttribute('disabled', true);
     } else {
@@ -29,8 +39,7 @@
   var saveButton = contactForm.getElementsByTagName('button')[0];
   var cancelButton = contactForm.getElementsByClassName('button--cancel')[0];
 
-  var initialState = Array.from(new FormData(contactForm), e => e[1]).join(',');
-
+  var initialState = getFormState(contactForm);
   contactForm.addEventListener('input', setButtonDisabled);
   cancelButton.addEventListener('click', hideContactForm);
 

--- a/crt_portal/static/js/edit_contact_info.js
+++ b/crt_portal/static/js/edit_contact_info.js
@@ -34,14 +34,26 @@
     }
   }
 
+  function addFormUpdateEvents(form) {
+    // Generate listenable events for all form inputs, using `change` for IE11 support
+    for (var i = 0; i < form.elements.length; i++) {
+      var field = form.elements[i];
+      if (field.nodeName == 'INPUT') {
+        field.addEventListener('input', setButtonDisabled);
+      } else if (field.nodeName == 'SELECT') {
+        field.addEventListener('change', setButtonDisabled);
+      }
+    }
+  }
+
   var contactInfo = document.getElementById('contact-info');
   var contactForm = document.getElementById('contact-edit-form');
   var saveButton = contactForm.getElementsByTagName('button')[0];
   var cancelButton = contactForm.getElementsByClassName('button--cancel')[0];
 
   var initialState = getFormState(contactForm);
-  contactForm.addEventListener('input', setButtonDisabled);
-  cancelButton.addEventListener('click', hideContactForm);
 
+  addFormUpdateEvents(contactForm);
+  cancelButton.addEventListener('click', hideContactForm);
   addShowFormHandler();
 })();


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/431)

## What does this change?
Reworking the javascript implementation to toggle contact edit form and enable the save button to accommodate IE11.

Most interestingly, we iterate through the form fields and apply eventListeners individually so that we may use ` change` event listener on the `select` element for State. IE11 did not generate an `input` event with the previous implementation.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
