### PR TITLE
Continuation of PR429 -- A11y fixes for release

### DIFF
--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -87,7 +87,7 @@
               </div>
               <div class="grid-col-auto">
                 <p class="usa-footer__logo-heading">
-                  {% trans "Civil Rights Division %}
+                  {% trans "Civil Rights Division" %}
                   <br/>{% trans "U.S. Department of Justice" %}
                 </p>
               </div>

--- a/crt_portal/cts_forms/templates/forms/pro_template.html
+++ b/crt_portal/cts_forms/templates/forms/pro_template.html
@@ -85,7 +85,7 @@
 
 {% block page_js %}
 {{ super }}
-<script nounce="{{request.csp_nonce}}">
+<script nonce="{{request.csp_nonce}}">
   (function(root) {
     root.CRT = root.CRT || {};
 


### PR DESCRIPTION
Follow-up to #429 to correct two small issues identified after review.

## What does this change?
Corrects `nonce` script tag and a translation template tag.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
