### PR TITLE
Capitalize section names for filter selection

### DIFF
--- a/crt_portal/cts_forms/templates/forms/widgets/multi_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/multi_select.html
@@ -1,4 +1,4 @@
-<select class="complaint-multi-select {{widget.attrs.classes}}" multiple name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+<select class="complaint-multi-select {{widget.attrs.class}}" multiple name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
   {% for group_name, group_choices, group_index in widget.optgroups %}
     {% if group_name %}
       <optgroup label="{{ group_name }}">


### PR DESCRIPTION


## What does this change?
Building off the work in #424, we apply the expected CSS to the Section `select` input on the view-all complaints page.

## Implementation note
The way we're rendering `select` widgets feels like an area where we could make some maintainability improvements.

At the moment the flow looks like below and could be simplified:
1. CHOICES defined as a constant (e.g.  `('new', _('New'))`)
2. We render the `value` of the choice, not the label defined above (`new` instead of `_('New')`)
3. We capitalize the first letter of the `value` (`New`)
4. We sometimes override the form widget to add the `text-uppercase` css class (`NEW`)

## Screenshots (for front-end PR):
<img width="221" alt="Screen Shot 2020-04-29 at 12 43 24 PM" src="https://user-images.githubusercontent.com/3485564/80622617-0b7f6280-8a17-11ea-8799-357981715b35.png">
## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
