### PR TITLE
updates for screen reader

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block page_title %}
- <title>CRT Complaint Records{% for message in messages %}- {{ message }}{% endfor %}</title>
+ <title>CRT Complaint Records{% for message in messages %} - {{ message }}{% endfor %}</title>
 {% endblock %}
 
 {% block head %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -1,6 +1,10 @@
 {% extends "forms/complaint_view/intake_base.html" %}
 {% load static %}
 
+{% block page_title %}
+ <title>CRT Complaint Records{% for message in messages %}- {{ message }}{% endfor %}</title>
+{% endblock %}
+
 {% block head %}
 <link rel="stylesheet" href="{% static "css/accessible-autocomplete.min.css" %}" />
 {% endblock head %}
@@ -53,7 +57,7 @@
           <span class="backend-blue">{{ data.modified_date|date:'g:i a F j, Y' }}</span>
         </p>
       </div>
-      <div class="tablet:grid-col-6">
+      <div id="status-update" class="tablet:grid-col-6">
         {% include 'partials/messages.html' %}
       </div>
     </div>

--- a/crt_portal/cts_forms/templates/partials/messages.html
+++ b/crt_portal/cts_forms/templates/partials/messages.html
@@ -1,3 +1,4 @@
+<div id="status-update"></div>
 {% if messages %}
 <h2 class="messages">
     <ul class="messages blue-background usa-prose" >

--- a/crt_portal/cts_forms/templates/partials/messages.html
+++ b/crt_portal/cts_forms/templates/partials/messages.html
@@ -1,4 +1,3 @@
-<div id="status-update"></div>
 {% if messages %}
 <h2 class="messages">
     <ul class="messages blue-background usa-prose" >

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -275,7 +275,8 @@ class ShowView(LoginRequiredMixin, View):
             form.save()
             form.update_activity_stream(request.user)
             messages.add_message(request, messages.SUCCESS, form.success_message())
-            return redirect(report.get_absolute_url())
+            url = report.get_absolute_url()
+            return redirect(f"{url}#status-update")
         else:
             output = serialize_data(report, request, id)
             # Add form with errors to context
@@ -283,7 +284,12 @@ class ShowView(LoginRequiredMixin, View):
                 output.update({'contact_form': form})
             else:
                 output['actions'] = form
-            messages.add_message(request, messages.ERROR, form.FAIL_MESSAGE)
+            try:
+                fail_message = form.FAIL_MESSAGE
+            except AttributeError:
+                fail_message = 'No updates applied'
+
+            messages.add_message(request, messages.ERROR, fail_message)
 
             return render(request, 'forms/complaint_view/show/index.html', output)
 
@@ -315,7 +321,8 @@ class SaveCommentView(LoginRequiredMixin, FormView):
             messages.add_message(request, messages.SUCCESS, f'Successfully {verb[:-2].lower()}.')
             comment_form.update_activity_stream(request.user, report, verb)
 
-            return redirect(report.get_absolute_url())
+            url = report.get_absolute_url()
+            return redirect(f"{url}#status-update")
         else:
             # TODO handle form validation failures
             output = serialize_data(report, request, report_id)

--- a/crt_portal/static/js/focus_alert.js
+++ b/crt_portal/static/js/focus_alert.js
@@ -44,15 +44,23 @@ function prepareErrors() {
   var alerts = document.getElementsByClassName('update-status');
   for (let i = 0; i < alerts.length; i++) {
     let alert = alerts[i];
-    var region = document.getElementById('status-update')
+    var region = document.getElementById('status-update');
     var alertText = alert.textContent;
-    var message = document.createElement("p");
+    var message = document.createElement('p');
     var node = document.createTextNode(alertText);
     message.appendChild(node);
     message.setAttribute('role', 'alert');
     message.setAttribute('class', 'usa-sr-only');
-    message.setAttribute('id', Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15));
-    region.appendChild(message)
+    message.setAttribute(
+      'id',
+      Math.random()
+        .toString(36)
+        .substring(2, 15) +
+        Math.random()
+          .toString(36)
+          .substring(2, 15)
+    );
+    region.appendChild(message);
   }
 }
 

--- a/crt_portal/static/js/focus_alert.js
+++ b/crt_portal/static/js/focus_alert.js
@@ -40,28 +40,6 @@ function prepareErrors() {
     error_message.setAttribute('role', 'alert');
     error_message.setAttribute('aria-live', 'assertive');
   }
-  // activate aria live elements for screen reader
-  var alerts = document.getElementsByClassName('update-status');
-  for (let i = 0; i < alerts.length; i++) {
-    let alert = alerts[i];
-    var region = document.getElementById('status-update');
-    var alertText = alert.textContent;
-    var message = document.createElement('p');
-    var node = document.createTextNode(alertText);
-    message.appendChild(node);
-    message.setAttribute('role', 'alert');
-    message.setAttribute('class', 'usa-sr-only');
-    message.setAttribute(
-      'id',
-      Math.random()
-        .toString(36)
-        .substring(2, 15) +
-        Math.random()
-          .toString(36)
-          .substring(2, 15)
-    );
-    region.appendChild(message);
-  }
 }
 
 function triggerAlert() {

--- a/crt_portal/static/js/focus_alert.js
+++ b/crt_portal/static/js/focus_alert.js
@@ -40,12 +40,19 @@ function prepareErrors() {
     error_message.setAttribute('role', 'alert');
     error_message.setAttribute('aria-live', 'assertive');
   }
-
+  // activate aria live elements for screen reader
   var alerts = document.getElementsByClassName('update-status');
   for (let i = 0; i < alerts.length; i++) {
     let alert = alerts[i];
-    alert.setAttribute('role', 'alert');
-    alert.setAttribute('aria-live', 'assertive');
+    var region = document.getElementById('status-update')
+    var alertText = alert.textContent;
+    var message = document.createElement("p");
+    var node = document.createTextNode(alertText);
+    message.appendChild(node);
+    message.setAttribute('role', 'alert');
+    message.setAttribute('class', 'usa-sr-only');
+    message.setAttribute('id', Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15));
+    region.appendChild(message)
   }
 }
 


### PR DESCRIPTION
This usually gets the status updates read by voice over, still a bit flaky.
I can't seem to do any better- I tied to fix it a few different ways. 
[[a11y] Add an alert when the details page is updated#442](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/442)

## What does this change?
- Usually reads the status alerts
    - adds  screen reader only alerts for the updates after page load, so they **should** be read by screen readers. (I want to try this with Terri and see if there might be a voiceover bug)
- when the form is update it links to the #status, this helps people using screen readers because they don't need to tab all the way into the screen

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
