### PR TITLE
Fix conditional proform logic for IE

### DIFF
--- a/crt_portal/static/js/pro_form_show_hide.js
+++ b/crt_portal/static/js/pro_form_show_hide.js
@@ -21,28 +21,28 @@
     // show
     if (primary_complaint_id in predicate_target_mapping) {
       var targets = predicate_target_mapping[primary_complaint_id];
-      targets.forEach(function(question_id) {
-        var target = document.getElementById(question_id);
+      for (i = 0; i < targets.length; i++) {
+        var target = document.getElementById(targets[i]);
         target.style.display = 'block';
-      });
+      }
     }
     // hide
     Object.keys(predicate_target_mapping).forEach(function(primary_id) {
       if (primary_complaint_id != primary_id) {
         var targets = predicate_target_mapping[primary_id];
-        targets.forEach(function(question_id) {
-          var target = document.getElementById(question_id);
+        for (i = 0; i < targets.length; i++) {
+          var target = document.getElementById(targets[i]);
           target.style.display = 'none';
-        });
+        }
       }
     });
   }
 
   // add listeners
   var primary_issues = document.querySelectorAll('*[id^="id_0-primary_complaint_"]');
-  primary_issues.forEach(function(radio_element) {
-    radio_element.addEventListener('click', toggleFollowUpQuestions);
-  });
+  for (i = 0; i < primary_issues.length; i++) {
+    primary_issues[i].addEventListener('click', toggleFollowUpQuestions);
+  }
 
   return root;
 })(window, document);


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/18F/crt-portal/issues/412#event-3281102119)

## What does this change?
IE11 was complaining about `forEach` being used on a `NodeList` instead of an array. I just swapped all three `forEach` statements out for the older style `for` loops. Requesting Joe as the reviewer since I think he has IE access.

## Screenshots (for front-end PR):
n/a
## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
