### PR TITLE
Render error classes on email inputs

### DIFF
--- a/crt_portal/cts_forms/templatetags/with_input_error.py
+++ b/crt_portal/cts_forms/templatetags/with_input_error.py
@@ -2,7 +2,7 @@ from django import template
 
 register = template.Library()
 
-text_input_types = ['text', 'number', 'select']
+text_input_types = ['text', 'number', 'select', 'email']
 
 
 def is_textarea(widget):
@@ -13,11 +13,11 @@ def is_textarea(widget):
 def with_input_error(field):
     widget = field.field.widget
 
-    if bool(field.errors) and (is_textarea(widget) or widget.input_type in text_input_types):
+    if field.errors and (is_textarea(widget) or widget.input_type in text_input_types):
         css_classes = widget.attrs.get('class', None)
         return field.as_widget(attrs={'class': f"usa-input--error error-focus {css_classes}"})
 
-    if bool(field.errors) and widget.input_type in ['radio', 'checkbox']:
+    if field.errors and widget.input_type in ['radio', 'checkbox']:
         css_classes = widget.attrs.get('class', None)
         return field.as_widget(attrs={'class': f"error-focus {css_classes}"})
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/471)

## What does this change?
Includes email inputs in the list of inputs for which we add css classes indicating an error status to inputs with validation failures.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
