### PR TITLE
Fix links in header for IE11

### DIFF
--- a/crt_portal/static/js/progress-bar.js
+++ b/crt_portal/static/js/progress-bar.js
@@ -1,23 +1,43 @@
 (function() {
-  var offsetHeight = document
-    .getElementsByClassName('intake-header--progress-bar')[0]
-    .getBoundingClientRect().height;
-  var steps = document.getElementsByClassName('step');
-  function smoothScroll(el) {
-    el.preventDefault();
-    var anchor = el.target.getElementsByTagName('a')[0];
-    var scrollToSection = document.getElementById(anchor.attributes.href.nodeValue.slice(1));
-    var targetTop = scrollToSection.getBoundingClientRect().top;
-    var totalOffset = targetTop - offsetHeight - 40; // 40px == padding on card, so title doesn't abut header
-    window.scroll({
-      top: window.pageYOffset + totalOffset,
-      left: window.pageXOffset,
-      behavior: 'smooth'
-    });
+  // see if we're in a browser that supports smooth scrolling, aka not IE11 and some versions of Edge
+  // from https://stackoverflow.com/a/53672870
+  function supportsSmoothScroll() {
+    var supportsScroll = false;
+    try {
+      var div = document.createElement('div');
+      div.scrollTo({
+        top: 0,
+        get behavior() {
+          supportsScroll = true;
+          return 'smooth';
+        }
+      });
+    } catch (err) {
+      console.log(err);
+    }
+    return supportsScroll;
   }
-  for (i = 0; i < steps.length; i++) {
-    steps[i].addEventListener('click', function(el) {
-      smoothScroll(el);
-    });
+
+  if (supportsSmoothScroll() == true) {
+    var offsetHeight = document
+      .getElementsByClassName('intake-header--progress-bar')[0]
+      .getBoundingClientRect().height;
+    var steps = document.getElementsByClassName('step');
+    function smoothScroll(el) {
+      el.preventDefault();
+      var scrollToSection = document.getElementById(el.target.attributes.href.nodeValue.slice(1));
+      var targetTop = scrollToSection.getBoundingClientRect().top;
+      var totalOffset = targetTop - offsetHeight - 40; // 40px == padding on card, so title doesn't abut header
+      window.scroll({
+        top: window.pageYOffset + totalOffset,
+        left: window.pageXOffset,
+        behavior: 'smooth'
+      });
+    }
+    for (i = 0; i < steps.length; i++) {
+      steps[i].addEventListener('click', function(el) {
+        smoothScroll(el);
+      });
+    }
   }
 })(window);

--- a/crt_portal/static/js/progress-bar.js
+++ b/crt_portal/static/js/progress-bar.js
@@ -15,10 +15,12 @@
     } catch (err) {
       console.log(err);
     }
-    return supportsScroll;
+    // return supportsScroll;
+    return false; // JUST FOR TESTING, DUDE
   }
 
   if (supportsSmoothScroll() == true) {
+    // enable smooth scroll with position:sticky header for browsers that support it
     var offsetHeight = document
       .getElementsByClassName('intake-header--progress-bar')[0]
       .getBoundingClientRect().height;
@@ -39,5 +41,16 @@
         smoothScroll(el);
       });
     }
+  } else {
+    // if browser doesn't support scrolling and position: sticky, use position: fixed instead
+    var bar = document.getElementsByClassName('intake-header--progress-bar')[0];
+    var barOffset = bar.getBoundingClientRect().top;
+    window.addEventListener('scroll', function() {
+      if (window.pageYOffset >= barOffset) {
+        bar.style.position = 'fixed';
+      } else {
+        bar.style.position = 'relative'; // un-stick it when page is scrolled all the way up
+      }
+    });
   }
 })(window);

--- a/crt_portal/static/js/progress-bar.js
+++ b/crt_portal/static/js/progress-bar.js
@@ -5,7 +5,8 @@
   var steps = document.getElementsByClassName('step');
   function smoothScroll(el) {
     el.preventDefault();
-    var scrollToSection = document.getElementById(el.target.attributes.href.nodeValue.slice(1));
+    var anchor = el.target.getElementsByTagName('a')[0];
+    var scrollToSection = document.getElementById(anchor.attributes.href.nodeValue.slice(1));
     var targetTop = scrollToSection.getBoundingClientRect().top;
     var totalOffset = targetTop - offsetHeight - 40; // 40px == padding on card, so title doesn't abut header
     window.scroll({

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -46,6 +46,7 @@
   @include u-bg($blue-warm-vivid-80-t);
   @include u-padding-top(3);
   position: sticky;
+  width: 100%;
   top: 0;
   z-index: 99;
   + main {


### PR DESCRIPTION
## What does this change?
- Checks for browser support of scrolling behavior before applying smoothscroll (and in the process overriding anchor link default actions).
- Applies `position: fixed` to the header if `position: sticky` is unavailable

Known bugs: if the header must use `position: fixed`, the header will cover up the headings of the section. So clicking `Primary issue` in the progress bar will scroll the page down to the right questions, but the `Primary issue` header will be hidden under the sticky bar. Working on a fix for this but unsure if it needs to go in this release.