### PR TITLE
Deploy translation

### DIFF
--- a/apt.yml
+++ b/apt.yml
@@ -1,3 +1,3 @@
 ---
 packages:
-    - install autopoint
+    - gettext

--- a/apt.yml
+++ b/apt.yml
@@ -1,0 +1,3 @@
+---
+packages:
+    - install autopoint

--- a/manifest_dev.yaml
+++ b/manifest_dev.yaml
@@ -8,6 +8,7 @@ applications:
   env:
     ENV: DEVELOP
   buildpacks:
+  - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack
   services:
   - crt-db

--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -12,6 +12,7 @@ applications:
     AUTH_RELYING_PARTY_ID: "crt-portal-django-prod.app.cloud.gov"
     AUTH_AUDIENCE: "microsoft:identityserver:crt-portal-django-prod.app.cloud.gov"
   buildpacks:
+  - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack
   services:
   - crt-db

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -11,6 +11,7 @@ applications:
     AUTH_RELYING_PARTY_ID: "crt-portal-django-stage.app.cloud.gov"
     AUTH_AUDIENCE: "microsoft:identityserver:crt-portal-django-stage.app.cloud.gov"
   buildpacks:
+  - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack
   services:
   - crt-db


### PR DESCRIPTION
Adds gettext to our cloud.gov deploy. We couldn't deploy to cloud.gov with the current develop branch because the new messaging step needed gettext.

Confirmed it works by manually deploying with the manifest on dev - https://crt-portal-django-dev.app.cloud.gov/report/
