### PR TITLE
Fix dev regressions

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -21,7 +21,7 @@
 
 {% block page_header %}
   {% trans "Contact the Department of Justice to report a civil rights concern" as intro_text %}
-  {% include 'forms/portal/header.html' with intro_text=intro_text %} %}
+  {% include 'forms/portal/header.html' with intro_text=intro_text %}
 {% endblock %}
 
 {% block content %}

--- a/crt_portal/static/sass/custom/buttons.scss
+++ b/crt_portal/static/sass/custom/buttons.scss
@@ -4,6 +4,7 @@ button,
 }
 
 .button--edit {
+  background-color: transparent;
   @include u-font-size('body', 'sm');
   float: right;
   &:before {
@@ -18,6 +19,7 @@ button,
 }
 
 .button--cancel {
+  background-color: transparent;
   @include u-color('secondary-dark');
   margin-left: 0.5rem;
   &:hover,

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -95,6 +95,10 @@ form#report-form {
       margin-top: 1.5rem;
     }
 
+    &:last-of-type:not(:only-of-type) {
+      margin-top: 2.5rem;
+    }
+
     ul {
       margin-bottom: 0;
     }

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -115,6 +115,7 @@ form#report-form {
   }
 
   .light-button {
+    background-color: transparent;
     &:hover {
       background-color: $white;
     }


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/473)

## What does this change?

Fixes dev regressions with: button colors, form fieldset spacing, and removes a stray closing template tag.