### PR TITLE
Complaint record styling

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -32,7 +32,7 @@
   <tr>
     <th>Primary issue</th>
     <td>
-      <strong>{{primary_complaint.0}}</strong>
+      {{primary_complaint.0}}
     </td>
   <tr>
     <th>Hate crime</th>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -61,7 +61,7 @@
         {% include 'partials/messages.html' %}
       </div>
     </div>
-    <div class="grid-row grid-gap-lg">
+    <div class="grid-row grid-gap-5">
       <div class="tablet:grid-col-4 grid-offset-1">
         {% include 'forms/complaint_view/show/actions.html' with title="Actions" icon="img/intake-icons/ic_check-circle.svg" %}
         <div class="activity-stream">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -61,7 +61,7 @@
         {% include 'partials/messages.html' %}
       </div>
     </div>
-    <div class="grid-row grid-gap-5">
+    <div class="grid-row grid-gap-4">
       <div class="tablet:grid-col-4 grid-offset-1">
         {% include 'forms/complaint_view/show/actions.html' with title="Actions" icon="img/intake-icons/ic_check-circle.svg" %}
         <div class="activity-stream">

--- a/crt_portal/static/sass/custom/card.scss
+++ b/crt_portal/static/sass/custom/card.scss
@@ -2,7 +2,7 @@
   @include u-radius('lg');
   background-color: $white;
   box-shadow: 0 1px 6px 2px rgba(0, 0, 0, 0.14);
-  margin: 24px 0;
+  margin: 2.5rem 0;
 
   // provides styled for a hoverable card, use in primary issue page
   &.crt-hover-card {

--- a/crt_portal/static/sass/custom/card.scss
+++ b/crt_portal/static/sass/custom/card.scss
@@ -2,7 +2,7 @@
   @include u-radius('lg');
   background-color: $white;
   box-shadow: 0 1px 6px 2px rgba(0, 0, 0, 0.14);
-  margin: 2.5rem 0;
+  margin: 24px 0;
 
   // provides styled for a hoverable card, use in primary issue page
   &.crt-hover-card {


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/426)

## What does this change?

On crt form: adjust card spacing to be ~2.5 rem all around~ 1.5em/24px between stacked cards;  32px gutter; de emphasize primary complaint text