### PR TITLE
Add bubbles back

### DIFF
--- a/crt_portal/static/sass/custom/progress.scss
+++ b/crt_portal/static/sass/custom/progress.scss
@@ -70,15 +70,15 @@ ol.steps {
     }
   }
 
-  .step a::before,
-  .step a::after {
+  .step::before,
+  .step::after {
     display: block;
     font-size: $counter-font-size;
     box-sizing: border-box;
   }
 
   // circle
-  .step a::before {
+  .step::before {
     border-radius: 50%;
     text-decoration: none;
 
@@ -103,7 +103,7 @@ ol.steps {
     &.step {
       font-weight: bold;
 
-      a::before {
+      &::before {
         background-color: $visited !important;
         box-shadow: inset 0 0 0 $circle-border-width $visited;
       }
@@ -112,7 +112,7 @@ ol.steps {
 
   // unfinished milestone
   li.current {
-    ~ li.step a::before {
+    ~ li.step::before {
       color: white;
       background-color: $blue-warm-vivid-80;
       box-shadow: inset 0 0 0 $circle-border-width $outline;

--- a/crt_portal/static/sass/custom/progress.scss
+++ b/crt_portal/static/sass/custom/progress.scss
@@ -67,6 +67,8 @@ ol.steps {
 
     a {
       display: block;
+      margin-top: -($circle-diameter + 6.5px); // 6.5px == size of 0.5em bottom margin on step circle
+      padding-top: $circle-diameter + 6.5px;
     }
   }
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/484)

## What does this change?
Adds back the numbered bubbles *and* maintains the big click targets.

## Screenshots (for front-end PR):
Public facing:
<img width="897" alt="Screen Shot 2020-05-07 at 10 39 36 PM" src="https://user-images.githubusercontent.com/509309/81371065-0fb11d00-90b4-11ea-86d0-6ac864a0f281.png">

Proform (focus ring around "Contact" is just for the screenshot, to show the click target size):
<img width="1440" alt="Screen Shot 2020-05-07 at 10 43 01 PM" src="https://user-images.githubusercontent.com/509309/81371094-2192c000-90b4-11ea-8107-e26d91857a22.png">

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
