### PR TITLE
location details page: remove required label.

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -315,7 +315,7 @@ class LocationForm(ModelForm):
                 self,
                 ('location_name', 'location_address_line_1', 'location_address_line_2'),
                 group_name=LOCATION_QUESTIONS['location_title'],
-                optional=False,
+                optional=True,  # a11y: only some fields here are required
                 ally_id='location-help-text'
             ),
         ]


### PR DESCRIPTION
Tweak for [this zenhub issue](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/319)

## What does this change?

Quick fix for https://github.com/18F/crt-portal/issues/319#issuecomment-626786167 -- remove `required` label from location section.