### PR TITLE
Update complaint summary within details edit form

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1324,3 +1324,4 @@ class ReportEditForm(ProForm, ActivityStreamUpdater):
                 report.internal_comments.add(summary)
             self.summary_created = created
             self.summary = summary
+        return report

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1301,7 +1301,7 @@ class ReportEditForm(ProForm, ActivityStreamUpdater):
         super().update_activity_stream(user)
         if 'summary' in self.changed_data:
             action.send(
-                self.request.user,
+                user,
                 verb='Added summary: ' if self.summary_created else 'Updated summary: ',
                 description=self.summary.note,
                 target=self.instance

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1,14 +1,16 @@
 import logging
 from datetime import datetime
 
+from actstream import action
 from django.contrib.auth import get_user_model
 from django.core.validators import ValidationError
-from django.utils.functional import cached_property
-
 from django.forms import (BooleanField, CharField, CheckboxInput, ChoiceField,
-                          EmailInput, ModelChoiceField, ModelForm,
-                          ModelMultipleChoiceField, Select, SelectMultiple,
-                          Textarea, TextInput, TypedChoiceField, MultipleHiddenInput)
+                          EmailInput, HiddenInput, IntegerField,
+                          ModelChoiceField, ModelForm,
+                          ModelMultipleChoiceField, MultipleHiddenInput,
+                          Select, SelectMultiple, Textarea, TextInput,
+                          TypedChoiceField)
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from .model_variables import (COMMERCIAL_OR_PUBLIC_ERROR,
@@ -80,7 +82,6 @@ class ActivityStreamUpdater(object):
 
     def update_activity_stream(self, user):
         """Send all actions to activity stream"""
-        from actstream import action
         for verb, description in self.get_actions():
             action.send(
                 user,
@@ -1074,7 +1075,6 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
 
     def update_activity_stream(self, user):
         """Send all actions to activity stream"""
-        from actstream import action
         for verb, description in self.get_actions():
             action.send(
                 user,
@@ -1098,7 +1098,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
 class CommentActions(ModelForm):
     class Meta:
         model = CommentAndSummary
-        fields = ['note', 'is_summary']
+        fields = ['note']
 
     def __init__(self, *args, **kwargs):
         ModelForm.__init__(self, *args, **kwargs)
@@ -1109,28 +1109,14 @@ class CommentActions(ModelForm):
             },
         )
         self.fields['note'].label = 'New comment'
-        self.fields['is_summary'] = CharField()
 
     def update_activity_stream(self, user, report, verb):
         """Send all actions to activity stream"""
-        from actstream import action
         action.send(
             user,
             verb=verb,
             description=self.instance.note,
             target=report
-        )
-
-
-class SummaryField(CommentActions):
-    """Need to override the html id since it is on the same page as the comment form"""
-    def __init__(self, *args, **kwargs):
-        CommentActions.__init__(self, *args, **kwargs)
-        self.fields['note'].widget = Textarea(
-            attrs={
-                'class': 'usa-textarea',
-                'id': 'id_note-summary',
-            },
         )
 
 
@@ -1198,6 +1184,10 @@ class ReportEditForm(ProForm, ActivityStreamUpdater):
     hatecrime = BooleanField(required=False, widget=CheckboxInput(attrs={'class': 'usa-checkbox__input'}))
     trafficking = BooleanField(required=False, widget=CheckboxInput(attrs={'class': 'usa-checkbox__input'}))
 
+    # Summary fields
+    summary = CharField(required=False, strip=True, widget=Textarea(attrs={'class': 'usa-textarea'}))
+    summary_id = IntegerField(required=False, widget=HiddenInput())
+
     class Meta(ProForm.Meta):
         """
         Extend ProForm to capture field definitions from component forms, excluding those which should not be editable here
@@ -1250,6 +1240,12 @@ class ReportEditForm(ProForm, ActivityStreamUpdater):
         self.fields['last_incident_month'].widget.required = False
         self.fields['last_incident_year'].widget.required = False
 
+        # Summary fields
+        summary = self.instance.get_summary
+        if summary:
+            self.fields['summary'].initial = summary.note
+            self.fields['summary_id'].initial = summary.pk
+
     @cached_property
     def changed_data(self):
         changed_data = super().changed_data
@@ -1299,3 +1295,32 @@ class ReportEditForm(ProForm, ActivityStreamUpdater):
         cleaned_data['hatecrimes_trafficking'] = crimes
 
         return self.clean_dependent_fields(cleaned_data)
+
+    def update_activity_stream(self, user):
+        """Generate activity log entry for summary if it was updated"""
+        super().update_activity_stream(user)
+        if 'summary' in self.changed_data:
+            action.send(
+                self.request.user,
+                verb='Added summary: ' if self.summary_created else 'Updated summary: ',
+                description=self.summary.note,
+                target=self.instance
+            )
+
+    def save(self, user=None, commit=True):
+        """
+        If `summary` has changed, update or create the necessary CommentAndSummary
+        """
+        report = super().save(commit=True)
+        if 'summary' in self.changed_data:
+            summary_id = self.cleaned_data.get('summary_id')
+            summary = self.cleaned_data.get('summary')
+            summary_data = {'note': summary, 'author': user, 'is_summary': True}
+            if summary_id:
+                summary, created = CommentAndSummary.objects.update_or_create(id=summary_id, defaults=summary_data)
+            else:
+                summary = CommentAndSummary.objects.create(**summary_data)
+                created = True
+                report.internal_comments.add(summary)
+            self.summary_created = created
+            self.summary = summary

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -14,26 +14,30 @@
 {% endblock %}
 
 {% block card_content %}
+<form id="details-edit-form" class="usa-form " method="post" novalidate>
+
 <div class="blue-background usa-prose">
-  <div id="current-summary">
+  <div id="current-summary" class="details">
     {% if summary %}
     <label class="bold backend-blue" for="current-summary-text">
       Summary
     </label>
-    <button aria-label="edit summary" class="usa-button usa-button--unstyled button--edit" type="button">Edit</button>
-    <div id="current-summary-text">
+    <div id="current-summary-text" >
       {{ summary.note | linebreaks }}
     </div>
     {% endif %}
   </div>
 
-  <div class="edit-summary">
-    {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="summary" is_summary=True button_text='Save' button_aria_label='save summary' show_cancel='true' label='Summary' comment=summary comment_box=comment_box %}
+  <div id="report-summary" class="details-edit {% if summary %}display-none{% else %}always-display{% endif %}">
+    <label for="{{details_form.summary.id_for_label}}" class="bold backend-blue">
+      {{details_form.summary.label}}
+    </label>
+    {{details_form.summary}}
+    {{details_form.summary_id}}
   </div>
 </div>
 
 <div class="report-details">
-  <form id="details-edit-form" class="usa-form " method="post" novalidate>
     {% csrf_token %}
     {{details_form.hatecrimes_trafficking}}
     <table class="usa-table usa-table--borderless complaint-card-table">
@@ -186,8 +190,8 @@
       </tr>
       </tr>
     </table>
-    <button aria-label="update contact details"
-            class="usa-button {% if not details_form.errors %}display-none{% endif %}"
+    <button aria-label="update complaint details"
+            class="usa-button {% if not details_form.errors and summary %}display-none{% endif %} {% if not summary %}always-display{% endif %}"
             disabled
             type="submit"
             name="type" value="{{details_form.CONTEXT_KEY}}">
@@ -198,6 +202,7 @@
             type="button">
             Cancel
     </button>
-  </form>
   </div>
+</form>
+
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -76,7 +76,7 @@
       <div class="tablet:grid-col-6">
         {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}
 
-        {% include 'forms/complaint_view/show/complaint_details.html' with data=data primary_complaint=primary_complaint summary=summary comment_box=summary_box.note %}
+        {% include 'forms/complaint_view/show/complaint_details.html' with data=data primary_complaint=primary_complaint summary=summary %}
 
         {% include 'forms/complaint_view/show/description.html' with description=data.violation_summary %}
       </div>
@@ -87,7 +87,6 @@
 
 {% block page_js %}
 {{ block.super }}
-<script src="{% static 'js/show_hide_narrative_summary.js' %}"></script>
 <script src="{% static 'js/edit_contact_info.js' %}"></script>
 <script src="{% static 'js/edit_details.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/accessible-autocomplete.min.js' %}"></script>

--- a/crt_portal/static/js/edit_details.js
+++ b/crt_portal/static/js/edit_details.js
@@ -27,7 +27,12 @@
     var showThese = document.querySelectorAll('.details');
 
     for (var i = 0; i < hideThese.length; i++) {
-      hideThese[i].classList.add('display-none');
+      // This allows us to conditionally prevent hiding of elements
+      // Such as the complaint summary field when there is none existing
+      var element = hideThese[i];
+      if (!element.classList.contains('always-display')) {
+        element.classList.add('display-none');
+      }
     }
 
     for (var i = 0; i < showThese.length; i++) {
@@ -37,7 +42,10 @@
     // Hide Buttons
     var buttons = detailsForm.getElementsByTagName('button');
     for (var i = 0; i < buttons.length; i++) {
-      buttons[i].classList.add('display-none');
+      var element = buttons[i];
+      if (!element.classList.contains('always-display')) {
+        element.classList.add('display-none');
+      }
     }
   }
 
@@ -78,7 +86,7 @@
     // Generate listenable events for all form inputs, using `change` for IE11 support
     for (var i = 0; i < form.elements.length; i++) {
       var field = form.elements[i];
-      if (field.nodeName == 'INPUT') {
+      if (field.nodeName == 'INPUT' || field.nodeName == 'TEXTAREA') {
         field.addEventListener('input', setButtonDisabled);
       } else if (field.nodeName == 'SELECT') {
         field.addEventListener('change', setButtonDisabled);
@@ -143,7 +151,7 @@
   var detailsForm = document.getElementById('details-edit-form');
   var saveButton = detailsForm.getElementsByTagName('button')[0];
   var cancelButton = detailsForm.getElementsByClassName('button--cancel')[0];
-  var primaryIssues = document.querySelector('#id_primary_complaint');
+  var primaryIssues = document.getElementById('id_primary_complaint');
 
   // add listeners
   primaryIssues.addEventListener('change', toggleFollowUpQuestions);


### PR DESCRIPTION
Follow-up to [Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/465)

## What does this change?

Moves creation/modification of complaint summaries to the `DetailsEditForm`
and `ShowView`.

With no existing summary, submission of the form w/ `summary` data will create a new `CommentAndSummary` object w/ `is_summary=True`. Later modifications to the summary field here are effected on the backend by updating this existing `CommentAndSummaryInstance`

Creation and update actions are entered into the activity log. 

For reports with no existing summary, we _always_ render the `Submit` button. At the moment there's no `cancel` button rendered until a user activates the `edit` button, it felt strange to display when it effected no change visual or otherwise on click.

### Implementation note
This replaces the previous summary form functionality including the expansion of the input/container to fit the contents. 



## Screenshots (for front-end PR):
### No existing summary state on page load
![Screen Shot 2020-05-12 at 11 06 44 PM](https://user-images.githubusercontent.com/3485564/81767086-8a5bad00-94a5-11ea-9521-c11b9969be62.png)

### No existing summary state on summary text entered
![Screen Shot 2020-05-12 at 11 10 32 PM](https://user-images.githubusercontent.com/3485564/81767205-d27acf80-94a5-11ea-9877-f87888540dca.png)


### Existing summary state on page load
![Screen Shot 2020-05-12 at 11 07 48 PM](https://user-images.githubusercontent.com/3485564/81767107-9a738c80-94a5-11ea-9afe-26d1b602262d.png)

### Existing summary state on edit button click
![Screen Shot 2020-05-12 at 11 08 14 PM](https://user-images.githubusercontent.com/3485564/81767131-a8291200-94a5-11ea-889d-38fc9ec2b186.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
