### PR TITLE
fix missing asterisks for date card

### DIFF
--- a/crt_portal/cts_forms/templates/forms/question_cards/date.html
+++ b/crt_portal/cts_forms/templates/forms/question_cards/date.html
@@ -13,5 +13,5 @@
   </p>
   {% endif %}
 
- {% include 'forms/snippets/date_components.html' with required=True %}
+ {% include 'forms/snippets/date_components.html' with required=required %}
 </fieldset>

--- a/crt_portal/cts_forms/templates/forms/question_cards/date.html
+++ b/crt_portal/cts_forms/templates/forms/question_cards/date.html
@@ -13,5 +13,5 @@
   </p>
   {% endif %}
 
- {% include 'forms/snippets/date_components.html' %}
+ {% include 'forms/snippets/date_components.html' with required=True %}
 </fieldset>

--- a/crt_portal/cts_forms/templates/forms/report_date.html
+++ b/crt_portal/cts_forms/templates/forms/report_date.html
@@ -5,7 +5,7 @@
   <div class="crt-portal-card__content crt-portal-card__content--lg">
     {{ block.super }}
 
-    {% include "forms/question_cards/date.html" with question=form.date_question month=form.last_incident_month day=form.last_incident_day year=form.last_incident_year help_text=form.help_text %}
+    {% include "forms/question_cards/date.html" with required=True question=form.date_question month=form.last_incident_month day=form.last_incident_day year=form.last_incident_year help_text=form.help_text %}
 
   </div>
 </div>


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/494)

## What does this change?

Fixes asterisk in date field. 

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
