### PR TITLE
fix commercial/public "other" toggle

### DIFF
--- a/crt_portal/cts_forms/templates/forms/question_cards/commercial_public_location.html
+++ b/crt_portal/cts_forms/templates/forms/question_cards/commercial_public_location.html
@@ -26,6 +26,6 @@
 {% block page_js %}
 <script src="{% static 'js/other_show_hide.js' %}"></script>
 <script nonce="{{request.csp_nonce}}">
-  window.CRT.otherTextInputToggle('#id_6-commercial_or_public_place .other-class-option');
+  window.CRT.otherTextInputToggle('#id_6-commercial_or_public_place li');
 </script>
 {% endblock %}


### PR DESCRIPTION
No zenhub issue, please let me know if there's one.

## What does this change?

Fixes "Other" toggle in commercial/public. (Protected class toggle continues to work)

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
