### PR TITLE
remove election location questions

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -348,15 +348,6 @@ class ElectionLocation(LocationForm):
 
     def __init__(self, *args, **kwargs):
         LocationForm.__init__(self, *args, **kwargs)
-        self.question_groups = [
-            QuestionGroup(
-                self,
-                ('election_details',),
-                group_name=ELECTION_QUESTION,
-                optional=False
-
-            )
-        ] + self.question_groups
 
         self.fields['election_details'] = TypedChoiceField(
             choices=ELECTION_CHOICES,


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/345)

## What does this change?

- Removes election location from forms. 

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
