### PR TITLE
Don't show details qx for election primary concern

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1151,7 +1151,7 @@ class ReportEditForm(ProForm, ActivityStreamUpdater):
         """
         Extend ProForm to capture field definitions from component forms, excluding those which should not be editable here
         """
-        exclude = ['intake_format', 'violation_summary', 'contact_first_name', 'contact_last_name',
+        exclude = ['intake_format', 'violation_summary', 'contact_first_name', 'contact_last_name', 'election_details',
                    'contact_email', 'contact_phone', 'contact_address_line_1', 'contact_address_line_2', 'contact_state',
                    'contact_city', 'contact_zip', 'crt_reciept_day', 'crt_reciept_month', 'crt_reciept_year']
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -18,7 +18,7 @@ from .model_variables import (COMMERCIAL_OR_PUBLIC_ERROR,
                               COMMERCIAL_OR_PUBLIC_PLACE_HELP_TEXT,
                               CORRECTIONAL_FACILITY_LOCATION_CHOICES,
                               CORRECTIONAL_FACILITY_LOCATION_TYPE_CHOICES,
-                              DATE_ERRORS, DISTRICT_CHOICES, ELECTION_CHOICES,
+                              DATE_ERRORS, DISTRICT_CHOICES,
                               EMPLOYER_SIZE_CHOICES, EMPLOYER_SIZE_ERROR,
                               EMPTY_CHOICE, INCIDENT_DATE_HELPTEXT,
                               POLICE_LOCATION_ERRORS,
@@ -32,8 +32,7 @@ from .model_variables import (COMMERCIAL_OR_PUBLIC_ERROR,
                               SECTION_CHOICES, SERVICEMEMBER_CHOICES,
                               SERVICEMEMBER_ERROR, STATES_AND_TERRITORIES,
                               STATUS_CHOICES, STATUTE_CHOICES,
-                              VIOLATION_SUMMARY_ERROR, VOTING_ERROR,
-                              WHERE_ERRORS)
+                              VIOLATION_SUMMARY_ERROR, WHERE_ERRORS)
 from .models import (CommentAndSummary, HateCrimesandTrafficking,
                      ProtectedClass, Report)
 from .phone_regex import phone_validation_regex
@@ -340,31 +339,7 @@ class LocationForm(ModelForm):
 
 
 class ElectionLocation(LocationForm):
-    class Meta:
-        model = Report
-        election_fields = ['election_details']
-        fields = LocationForm.Meta.fields + election_fields
-        widgets = LocationForm.Meta.widgets
-
-    def __init__(self, *args, **kwargs):
-        LocationForm.__init__(self, *args, **kwargs)
-
-        self.fields['election_details'] = TypedChoiceField(
-            choices=ELECTION_CHOICES,
-            empty_value=None,
-            widget=UsaRadioSelect(attrs={
-                'help_text': {
-                    'federal': _('Presidential or congressional'),
-                    'state_local': _('Governor, state legislation, city position (mayor, council, local board)'),
-                    'both': _('Federal & State/local')
-                }
-            }),
-            required=True,
-            error_messages={
-                'required': VOTING_ERROR
-            },
-            label=''
-        )
+    pass
 
 
 class WorkplaceLocation(LocationForm):
@@ -703,7 +678,6 @@ class ProForm(
             HateCrimesTrafficking.Meta.fields +\
             ['location_name', 'location_address_line_1', 'location_address_line_2',
                 'location_city_town', 'location_state'] +\
-            ElectionLocation.Meta.election_fields +\
             WorkplaceLocation.Meta.workplace_fields +\
             CommercialPublicLocation.Meta.commercial_fields +\
             PoliceLocation.Meta.police_fields +\
@@ -834,12 +808,6 @@ class ProForm(
         )
         self.fields['public_or_private_school'] = TypedChoiceField(
             choices=PUBLIC_OR_PRIVATE_SCHOOL_CHOICES,
-            empty_value=None,
-            widget=UsaRadioSelect,
-            required=False,
-        )
-        self.fields['election_details'] = TypedChoiceField(
-            choices=ELECTION_CHOICES,
             empty_value=None,
             widget=UsaRadioSelect,
             required=False,
@@ -1218,7 +1186,6 @@ class ReportEditForm(ProForm, ActivityStreamUpdater):
         self._set_to_select_widget('public_or_private_school')
         self._set_to_select_widget('public_or_private_employer')
         self._set_to_select_widget('employer_size')
-        self._set_to_select_widget('election_details')
         self._set_to_select_widget('inside_correctional_facility')
         self._set_to_select_widget('correctional_facility_type')
         self._set_to_select_widget('commercial_or_public_place')

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -72,7 +72,6 @@ class JudicialDistrict(models.Model):
 class Report(models.Model):
     PRIMARY_COMPLAINT_DEPENDENT_FIELDS = {
         'workplace': ['public_or_private_employer', 'employer_size'],
-        'voting': ['election_details'],
         'education': ['public_or_private_school'],
         'police': ['inside_correctional_facility', 'correctional_facility_type'],
         'commercial_or_public': ['commercial_or_public_place', 'other_commercial_or_public_place']

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -103,8 +103,6 @@
             {% endif %}
           </div>
           <div class="details-edit {% if not details_form.errors %}display-none{% endif %}">
-            {% include 'forms/complaint_view/show/details_edit_select.html' with field=details_form.election_details hidden=True %}
-
             {% include 'forms/complaint_view/show/details_edit_select.html' with field=details_form.commercial_or_public_place hidden=True %}
             {% include 'forms/complaint_view/show/details_edit_select.html' with field=details_form.other_commercial_or_public_place hidden=True %}
 

--- a/crt_portal/static/js/edit_details.js
+++ b/crt_portal/static/js/edit_details.js
@@ -106,7 +106,6 @@
     var allOptionalFields = [
       'public_or_private_employer',
       'employer_size',
-      'election_details',
       'public_or_private_school',
       'inside_correctional_facility',
       'correctional_facility_type',
@@ -116,7 +115,6 @@
 
     var followupMapping = {
       workplace: ['public_or_private_employer', 'employer_size'],
-      voting: ['election_details'],
       education: ['public_or_private_school'],
       police: ['inside_correctional_facility', 'correctional_facility_type'],
       commercial_or_public: ['commercial_or_public_place', 'other_commercial_or_public_place']


### PR DESCRIPTION
[Hide voting follow up question on public form #508](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/508)

#What does this change?

Removes customized follow-up Location form for election primary concerns but leaves class itself and other pieces intact.

If `election_details` is to be removed entirely we should follow-up by removing it from the views, form wizard routing, etc.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
