### PR TITLE
Footer tweaks

### DIFF
--- a/crt_portal/cts_forms/templates/partials/footer.html
+++ b/crt_portal/cts_forms/templates/partials/footer.html
@@ -19,7 +19,6 @@
             <p>U.S. Department of Justice</p>
             <p>Civil Rights Division</p>
             <p>950 Pennsylvania Avenue, NW</p>
-            <p>Office of the Assistant Attorney General</p>
             <p>Washington, D.C. 20530-0001</p>
           </div>
         </div>
@@ -29,12 +28,11 @@
             <img src="{% static "img/phone.svg" %}" alt="phone" class="icon">
           </div>
           <div class="usa-footer__links">
-            <a href="tel:202-514-4609">(202) 514-4609</a>
+            <a href="tel:202-514-3847">(202) 514-3847</a>
             <p>Telephone Device for the Deaf</p>
             <p>(TTY) <a href="tel:202-514-0716">(202) 514-0716</a></p>
           </div>
         </div>
-
 
         <div class="usa-footer__section">
           <div class="usa-footer__icon display-flex">

--- a/crt_portal/cts_forms/templates/partials/policy.html
+++ b/crt_portal/cts_forms/templates/partials/policy.html
@@ -10,7 +10,7 @@
       </div>
 
       <div class="grid-row grid-gap">
-        <div class="grid-col-12 usa-footer__links" style="font-size: 14px">
+        <div class="grid-col-9 usa-footer__links" style="font-size: 14px">
           <p style="margin-bottom: 1em">
             The purpose of this form is to allow the public to submit Civil Rights complaints to the Department of Justice, thereby allowing us to enforce over thirty civil rights statutes within our authority. <a style="color: white; text-transform: none" href="https://www.justice.gov/crt/privacy-policy">These statutes</a> authorize us to collect this information.  You should know that any information you provide through this form is voluntary, yet failure to provide some of the information might limit the Department’s ability to pursue your claim. We may use this information for certain routine uses, including sharing this information under certain circumstances with:
             <ul>
@@ -18,9 +18,10 @@
               <li>a court, magistrate, or administrative tribunal, as well as opposing counsel during settlement negotiations and/or litigation;</li>
               <li>Members of Congress;</li>
               <li>Federal, state, or local law enforcement agencies.</li>
-              <li>You can find our complete Privacy Policy <a style="color: white; text-transform: none" href="https://www.justice.gov/crt/privacy-policy">here</a>.</li>
             </ul>
           </p>
+
+          <p style="margin-bottom: 2em">You can find our complete Privacy Policy <a style="color: white; text-transform: none" href="https://www.justice.gov/crt/privacy-policy">here</a>.</p>
         </div>
       </div>
 

--- a/crt_portal/static/sass/custom/footer.scss
+++ b/crt_portal/static/sass/custom/footer.scss
@@ -69,6 +69,7 @@ footer {
 }
 
 .usa-footer__links {
+  font-size: 14px;
   display: flex;
   flex-direction: column;
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/509)

## What does this change?

- Footer contact details edited
- Footer font size is now 14px
- Privacy policy link moved out of list

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
