### PR TITLE
Review page spacing fixes redux

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_data.html
+++ b/crt_portal/cts_forms/templates/forms/report_data.html
@@ -6,7 +6,7 @@
         <h2 class="margin-top-0">{{ordered_step_names.0}}</h2>
 
         <div class="question">
-            <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.contact.contact_name_title }}</h3>
+          <h3 class="border-bottom border-base-lighter padding-bottom-05 margin-bottom-0 margin-top-3">{{ question.contact.contact_name_title }}</h3>
             <h4>{% trans "Your name" %}</h4>
             <p>{{ report.contact_first_name|default:"-" }} {{ report.contact_last_name|default:"-" }}</p>
         </div>

--- a/crt_portal/cts_forms/templates/forms/report_data.html
+++ b/crt_portal/cts_forms/templates/forms/report_data.html
@@ -23,7 +23,7 @@
           <h4>{% trans "Address" %}</h4>
           <p>{{ report.contact_address_line_1|default:"-" }}</p>
           <p>{{ report.contact_address_line_2|default:"-" }}</p>
-          <p>{{ report.contact_city|default:"-" }} {{ report.get_contact_state_display|default:"-" }} {{ report.contact_zip|default:"-" }}</p>
+          <p>{{ report.contact_city|default:"-" }}, {{ report.get_contact_state_display|default:"-" }} {{ report.contact_zip|default:"-" }}</p>
 
         </div>
         <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.servicemember }}</h3>
@@ -126,7 +126,7 @@
         <h4>{% trans "Address" %}</h4>
         <p>{{ report.location_address_line_1|default:"-" }}</p>
         <p>{{ report.location_address_line_2|default:"-" }}</p>
-        <p>{{ report.location_city_town|default:"-" }} {{ report.get_location_state_display|default:"-"}}</p>
+        <p>{{ report.location_city_town|default:"-" }}, {{ report.get_location_state_display|default:"-"}}</p>
 
     </div>
 </div>

--- a/crt_portal/cts_forms/templates/forms/report_data.html
+++ b/crt_portal/cts_forms/templates/forms/report_data.html
@@ -3,16 +3,16 @@
     <div class="crt-portal-card__content margin-bottom-3">
         {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.0 step_value=0 %}
 
-        <h2 class="margin-top-0">{{ordered_step_names.0}}</h2>
+        <h2 class="margin-top-0 margin-bottom-0">{{ordered_step_names.0}}</h2>
 
         <div class="question">
-          <h3 class="border-bottom border-base-lighter padding-bottom-05 margin-bottom-0 margin-top-3">{{ question.contact.contact_name_title }}</h3>
+          <h3 class="crt-portal-card__subheader">{{ question.contact.contact_name_title }}</h3>
             <h4>{% trans "Your name" %}</h4>
             <p>{{ report.contact_first_name|default:"-" }} {{ report.contact_last_name|default:"-" }}</p>
         </div>
 
         <div class="question">
-          <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.contact.contact_title }}</h3>
+          <h3 class="crt-portal-card__subheader">{{ question.contact.contact_title }}</h3>
 
           <h4>{{ question.contact.contact_email }}</h4>
           <p>{{ report.contact_email|default:"-" }}</p>
@@ -26,7 +26,7 @@
           <p>{{ report.contact_city|default:"-" }}, {{ report.get_contact_state_display|default:"-" }} {{ report.contact_zip|default:"-" }}</p>
 
         </div>
-        <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.servicemember }}</h3>
+        <h3 class="crt-portal-card__subheader">{{ question.servicemember }}</h3>
         <p>{{ report.get_servicemember_display|default:"-" }}</p>
     </div>
 </div>
@@ -37,10 +37,10 @@
 
     <h2 class="margin-top-0">{{ordered_step_names.1}}</h2>
 
-    <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.primary_reason }}</h3>
+    <h3 class="crt-portal-card__subheader">{{ question.primary_reason }}</h3>
     <p>{{ report.get_primary_complaint_display }}</p>
 
-    <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.hatecrime_title }}</h3>
+    <h3 class="crt-portal-card__subheader">{{ question.hatecrime_title }}</h3>
     <h4>{{ question.hatecrime }}</h4>
     {% if report.id %}
       {% for crime in report.hatecrimes_trafficking.all %}
@@ -85,40 +85,40 @@
     <h2 class="margin-top-0">{{ ordered_step_names.2 }}</h2>
 
     {% if report.election_details %}
-      <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.election }}</h3>
+      <h3 class="crt-portal-card__subheader">{{ question.election }}</h3>
       <p>{{ report.get_election_details_display|default:"-" }}</p>
 
     {% elif report.public_or_private_employer %}
-      <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.workplace.public_or_private_employer }}</h3>
+      <h3 class="crt-portal-card__subheader">{{ question.workplace.public_or_private_employer }}</h3>
       <p>{{ report.get_public_or_private_employer_display|default:"-" }}</p>
 
-      <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.workplace.employer_size }}</h3>
+      <h3 class="crt-portal-card__subheader">{{ question.workplace.employer_size }}</h3>
       <p>{{ report.get_employer_size_display|default:"-" }}</p>
 
     {% elif report.inside_correctional_facility %}
-      <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.police.inside_correctional_facility }}</h3>
+      <h3 class="crt-portal-card__subheader">{{ question.police.inside_correctional_facility }}</h3>
       <p>{{ report.get_inside_correctional_facility_display|default:"-" }}</p>
 
       {% if report.correctional_facility_type %}
-        <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.police.correctional_facility_type }}</h3>
+        <h3 class="crt-portal-card__subheader">{{ question.police.correctional_facility_type }}</h3>
         <p>{{ report.get_correctional_facility_type_display|default:"-" }}</p>
       {% endif %}
 
     {% elif report.commercial_or_public_place %}
-      <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.public }}</h3>
+      <h3 class="crt-portal-card__subheader">{{ question.public }}</h3>
       <p>{{ report.get_commercial_or_public_place_display|default:"-" }}</p>
       {% if report.other_commercial_or_public_place %}
-        <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.other_commercial_or_public_place }}</h3>
+        <h3 class="crt-portal-card__subheader">{{ question.other_commercial_or_public_place }}</h3>
         <p>{{ report.get_other_commercial_or_public_place_display|default:"-" }}</p>
       {% endif %}
 
     {% elif report.public_or_private_school %}
-      <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.education }}</h3>
+      <h3 class="crt-portal-card__subheader">{{ question.education }}</h3>
       <p>{{ report.get_public_or_private_school_display|default:"-" }}</p>
 
     {% endif %}
 
-    <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.location.location_title }}</h3>
+    <h3 class="crt-portal-card__subheader">{{ question.location.location_title }}</h3>
 
         <h4>{{ question.location.location_name }}</h4>
         <p>{{ report.location_name|default:"-" }}</p>
@@ -137,7 +137,7 @@
 
         <h2 class="margin-top-0">{{ ordered_step_names.3 }}</h2>
 
-        <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.characteristics }}</h3>
+        <h3 class="crt-portal-card__subheader">{{ question.characteristics }}</h3>
         {% if report.id %}
             {% for characteristic in report.protected_class.all %}
                 <p>{{ characteristic }}</p>
@@ -160,7 +160,7 @@
 
         <h2 class="margin-top-0">{{ ordered_step_names.4 }}</h2>
 
-        <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.date.date_title }}</h3>
+        <h3 class="crt-portal-card__subheader">{{ question.date.date_title }}</h3>
         <p>{{ report.last_incident_month }}/{{ report.last_incident_day|default:"—" }}/{{ report.last_incident_year}}</p>
     </div>
 </div>
@@ -171,7 +171,7 @@
 
         <h2 class="margin-top-0">{{ ordered_step_names.5 }}</h2>
 
-        <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.summary }}</h3>
+        <h3 class="crt-portal-card__subheader">{{ question.summary }}</h3>
         <p>{{ report.violation_summary|linebreaks }}</p>
     </div>
 </div>

--- a/crt_portal/cts_forms/templates/forms/report_review.html
+++ b/crt_portal/cts_forms/templates/forms/report_review.html
@@ -9,7 +9,7 @@
 
         <span class="em-text display-block margin-bottom-1">{% trans "Before you submit your report, please check your responses" %}</span>
 
-        <p class="padding-bottom-2 margin-top-0"><em>{% trans "If you need to make any changes, you can go back and edit the previous pages. Please make sure your information is accurate. This allows us to respond to your report quickly." %}</em></p>
+        <p class="help-text padding-bottom-1">{% trans "If you need to make any changes, you can go back and edit the previous pages. Please make sure your information is accurate. This allows us to respond to your report quickly." %}</p>
 
         <input id="submit-next-top" type="submit" value="{% trans 'Submit report' %}" class="usa-button">
     </div>

--- a/crt_portal/cts_forms/templates/forms/report_review.html
+++ b/crt_portal/cts_forms/templates/forms/report_review.html
@@ -9,7 +9,7 @@
 
         <span class="em-text display-block margin-bottom-1">{% trans "Before you submit your report, please check your responses" %}</span>
 
-        <p class="padding-bottom-2"><em>{% trans "If you need to make any changes, you can go back and edit the previous pages. Please make sure your information is accurate. This allows us to respond to your report quickly." %}</em></p>
+        <p class="padding-bottom-2 margin-top-0"><em>{% trans "If you need to make any changes, you can go back and edit the previous pages. Please make sure your information is accurate. This allows us to respond to your report quickly." %}</em></p>
 
         <input id="submit-next-top" type="submit" value="{% trans 'Submit report' %}" class="usa-button">
     </div>

--- a/crt_portal/static/sass/custom/card.scss
+++ b/crt_portal/static/sass/custom/card.scss
@@ -35,6 +35,10 @@
       @include u-padding-bottom(6);
       @include u-padding-top(5);
     }
+
+    h2 {
+      margin-bottom: 2rem;
+    }
   }
 
   .title {

--- a/crt_portal/static/sass/custom/card.scss
+++ b/crt_portal/static/sass/custom/card.scss
@@ -56,4 +56,11 @@
       margin-top: 0;
     }
   }
+
+  h3.crt-portal-card__subheader {
+    padding-bottom: .25rem;
+    border-bottom: 1px solid $gray-warm-10;
+    margin-top: 1.5rem;
+    margin-bottom: 0;
+  }
 }

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -133,6 +133,7 @@ form#report-form {
   }
 
   .light-button {
+    color: $blue-warm-vivid-80;
     background-color: transparent;
     &:hover {
       background-color: $white;


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/386)

## What does this change?

- Fixes several overlooked issues with review page: 
  - edit button: blue-warm-80v
  - 24px before blue question
  - "review your report" title spacing
  - help text space fixes
  - comma between city/state

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
