### PR TITLE
Remove extra quote mark at end of sentence

### DIFF
--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -130,7 +130,7 @@
             </h3>
           </div>
           <div class='confirmation-content padding-left-5'>
-            {% trans "Legal aid offices or members of lawyer associations in your state may be able to help you with your issue." %}"
+            {% trans "Legal aid offices or members of lawyer associations in your state may be able to help you with your issue." %}
             <ul class="confirmation-list">
               <li>
                 {% trans 'American Bar Association, visit <a href="http://www.findlegalhelp.org">www.findlegalhelp.org</a> or call <a href="tel:800-285-2221">(800) 285-2221</a>' %}


### PR DESCRIPTION
Random quote task from: [Copy edits before 6/2 #523](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/523)

## What does this change?
Sentence has extra quote mark at the end: `Legal aid offices or members of lawyer associations in your state may be able to help you with your issue."`

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
