### PR TITLE
Error summaries

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -482,7 +482,7 @@ class PoliceLocation(LocationForm):
             choices=CORRECTIONAL_FACILITY_LOCATION_TYPE_CHOICES,
             widget=UsaRadioSelect,
             required=False,
-            label=''
+            label=POLICE_QUESTIONS['correctional_facility_type']
         )
         self.fields['correctional_facility_type'].widget.attrs['class'] = 'margin-bottom-0 padding-bottom-0 padding-left-1'
         self.fields['correctional_facility_type'].help_text = POLICE_QUESTIONS['correctional_facility_type']

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -336,7 +336,8 @@ class LocationForm(ModelForm):
                 ('location_name', 'location_address_line_1', 'location_address_line_2'),
                 group_name=LOCATION_QUESTIONS['location_title'],
                 optional=True,  # a11y: only some fields here are required
-                ally_id='location-help-text'
+                ally_id='location-help-text',
+                extra_validation_fields=('location_city_town', 'location_state')
             ),
         ]
         self.page_note = _('Please tell us the city, state, and name of the location where this incident took place. This ensures your report is reviewed by the right people within the Civil Rights Division.')

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -529,7 +529,8 @@ class ProtectedClassForm(ModelForm):
         self.fields['protected_class'] = ModelMultipleChoiceField(
             error_messages={'required': PROTECTED_CLASS_ERROR},
             required=True,
-            label="",
+            label=PROTECTED_CLASS_QUESTION,
+            help_text=_('There are federal and state laws that protect people from discrimination based on their personal characteristics. Here is a list of the most common characteristics that are legally protected. Select any that apply to your incident.'),
             queryset=ProtectedClass.active_choices.all().order_by('form_order'),
             widget=UsaCheckboxSelectMultiple(attrs={
                 'aria-describedby': 'protected-class-help-text'
@@ -540,17 +541,6 @@ class ProtectedClassForm(ModelForm):
         self.fields['other_class'].widget = TextInput(
             attrs={'class': 'usa-input word-count-10'}
         )
-
-        self.question_groups = [
-            QuestionGroup(
-                self,
-                ('protected_class',),
-                group_name=PROTECTED_CLASS_QUESTION,
-                help_text=_('There are federal and state laws that protect people from discrimination based on their personal characteristics. Here is a list of the most common characteristics that are legally protected. Select any that apply to your incident.'),
-                optional=False,
-                ally_id="protected-class-help-text"
-            )
-        ]
 
 
 def date_cleaner(self, cleaned_data):

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -342,6 +342,31 @@ class LocationForm(ModelForm):
         ]
         self.page_note = _('Please tell us the city, state, and name of the location where this incident took place. This ensures your report is reviewed by the right people within the Civil Rights Division.')
 
+    def summary_error_questions(self):
+        """
+        Return a list of questions which contain fields with errors
+
+        First check all defined question groups
+        Then check any fields defined outside of questions groups
+        that have not already been evaluated as part of a question group
+        """
+        questions = []
+        checked_fields = set()
+
+        for group in self.question_groups:
+            if group.errors():
+                questions.append(group.group_name)
+            [checked_fields.add(field) for field in group.fields]
+            if group.extra_validation_fields:
+                [checked_fields.add(field) for field in group.extra_validation_fields]
+
+        for field in self.fields:
+            if field not in checked_fields and self[field].errors:
+                questions.append(self[field].label)
+                checked_fields.add(field)
+
+        return questions
+
 
 class ElectionLocation(LocationForm):
     pass

--- a/crt_portal/cts_forms/question_group.py
+++ b/crt_portal/cts_forms/question_group.py
@@ -5,7 +5,18 @@ from django.forms.forms import BoundField
 
 
 class QuestionGroup(object):
-    def __init__(self, form, fields, group_name='', help_text='', ally_id='', optional=True, label_cls=None, help_cls=None):
+    def __init__(
+        self,
+        form,
+        fields,
+        group_name="",
+        help_text="",
+        ally_id="",
+        optional=True,
+        label_cls=None,
+        help_cls=None,
+        extra_validation_fields=None
+    ):
         self.form = form
         self.fields = fields
         self.group_name = group_name
@@ -14,8 +25,23 @@ class QuestionGroup(object):
         self.ally_id = ally_id
         self.label_cls = label_cls
         self.help_cls = help_cls
+        self.extra_validation_fields = extra_validation_fields
 
     def __iter__(self):
         for name in self.fields:
             field = self.form.fields[name]
             yield BoundField(self.form, field, name)
+
+    def errors(self):
+        """Return field errors contained within this QuestionGroup"""
+        errors = []
+        if self.extra_validation_fields:
+            fields_to_check = self.fields + self.extra_validation_fields
+        else:
+            fields_to_check = self.fields
+
+        for f in fields_to_check:
+            field_errors = self.form[f].errors
+            if field_errors:
+                errors += field_errors
+        return errors

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -57,7 +57,11 @@
                 {% plural %}
                   {{counter}} errors found
                 {% endblocktrans %}
+
+                {% block extra_errors %}
+                {% endblock extra_errors %}
               </section>
+
             {% endif %}
             <h2 class="margin-0">{{ current_step_title }}</h2>
             {% if form.page_note %}

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -59,6 +59,13 @@
                 {% endblocktrans %}
 
                 {% block extra_errors %}
+                  <ul class="error-summary">
+                    {% for field in form %}
+                      {% if field.errors %}
+                        <li>{{field.label}}</li>
+                      {% endif %}
+                    {% endfor %}
+                  </ul>
                 {% endblock extra_errors %}
               </section>
 

--- a/crt_portal/cts_forms/templates/forms/report_class.html
+++ b/crt_portal/cts_forms/templates/forms/report_class.html
@@ -1,12 +1,36 @@
 {% extends "forms/report_base.html" %}
+{% load i18n %}
 {% load static %}
+
+{% block extra_errors %}
+  <ul>
+    {% for field in form %}
+      {% if field.errors %}
+        {{field.label}}
+      {% endif %}
+    {% endfor %}
+  </ul>
+{% endblock %}
+
 {% block form_questions %}
   <div class="crt-portal-card crt-portal-card">
     <div class="crt-portal-card__content crt-portal-card__content--lg">
       {{ block.super }}
 
       <div data-toggle>
-      {% include 'forms/grouped_questions.html' %}
+        <fieldset class="usa-fieldset">
+          <legend class="em-text question-header">
+            {{form.protected_class.label}}<span class="field-required--group">{% trans "required" %}</span>
+          </legend>
+          <p class="help-text" id="protected-class-help-text">
+            {{form.protected_class.help_text}}
+          </p>
+          {% if form.protected_class.errors %}
+            {% include "forms/snippets/error_alert.html" with errors=form.protected_class.errors %}
+          {% endif %}
+          {{ form.protected_class }}
+        </fieldset>
+
       {% with field=form.other_class %}
         <div class='other-class-option' class="padding-left-4">
           <div>

--- a/crt_portal/cts_forms/templates/forms/report_class.html
+++ b/crt_portal/cts_forms/templates/forms/report_class.html
@@ -2,15 +2,6 @@
 {% load i18n %}
 {% load static %}
 
-{% block extra_errors %}
-  <ul>
-    {% for field in form %}
-      {% if field.errors %}
-        {{field.label}}
-      {% endif %}
-    {% endfor %}
-  </ul>
-{% endblock %}
 
 {% block form_questions %}
   <div class="crt-portal-card crt-portal-card">

--- a/crt_portal/cts_forms/templates/forms/report_date.html
+++ b/crt_portal/cts_forms/templates/forms/report_date.html
@@ -1,5 +1,11 @@
 {% extends "forms/report_base.html" %}
 
+{% block extra_errors %}
+  <ul>
+      <li>{{form.date_question}}</li>
+  </ul>
+{% endblock %}
+
 {% block form_questions %}
 <div class="crt-portal-card">
   <div class="crt-portal-card__content crt-portal-card__content--lg">

--- a/crt_portal/cts_forms/templates/forms/report_location.html
+++ b/crt_portal/cts_forms/templates/forms/report_location.html
@@ -2,6 +2,17 @@
 {% load static %}
 {% load i18n %}
 
+
+{% block extra_errors %}
+  <ul class="error-summary">
+  {% for question_group in form.question_groups %}
+    {% if question_group.errors %}
+      <li>{{question_group.group_name}}</li>
+    {% endif %}
+  {% endfor %}
+  </ul>
+{% endblock %}
+
 {% block form_questions %}
   <div class="crt-portal-card">
     <div class="crt-portal-card__content crt-portal-card__content--lg">

--- a/crt_portal/cts_forms/templates/forms/report_location.html
+++ b/crt_portal/cts_forms/templates/forms/report_location.html
@@ -5,10 +5,8 @@
 
 {% block extra_errors %}
   <ul class="error-summary">
-  {% for question_group in form.question_groups %}
-    {% if question_group.errors %}
-      <li>{{question_group.group_name}}</li>
-    {% endif %}
+  {% for question in form.summary_error_questions %}
+      <li>{{question}}</li>
   {% endfor %}
   </ul>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
+++ b/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
@@ -1,8 +1,17 @@
 {% extends "forms/report_base.html" %}
 {% load static %}
 {% load i18n %}
+
+{% block extra_errors %}
+  <ul>
+    {% for field in form %}
+      <li>{{field.label}}</li>
+    {% endfor %}
+  </ul>
+{% endblock %}
+
 {% block form_questions %}
-{% with primary_complaint_field=wizard.form.primary_complaint %}
+  {% with primary_complaint_field=wizard.form.primary_complaint %}
     <div class="crt-portal-card">
       <div class="crt-portal-card__content crt-portal-card__content--lg">
         {{ block.super }}
@@ -21,15 +30,16 @@
         </div>
       </div>
     </div>
+
+    {% if primary_complaint_field.errors %}
+      {% include "forms/snippets/error_alert.html" with errors=primary_complaint_field.errors %}
+    {% endif %}
     <div role="group" aria-labelledby="primary-complaint-help-text" class="question_primary_complaint margin-top-3">
       {{ primary_complaint_field|withInputError }}
-
-      {% if primary_complaint_field.errors %}
-        {% include "forms/snippets/error_alert.html" with errors=primary_complaint_field.errors %}
-      {% endif %}
     </div>
   {% endwith %}
 {% endblock %}
+
 {% block page_js %}
   {{ block.super }}
   <script src="{% static 'js/primary_complaint.js' %}"></script>

--- a/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
+++ b/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
@@ -2,14 +2,6 @@
 {% load static %}
 {% load i18n %}
 
-{% block extra_errors %}
-  <ul>
-    {% for field in form %}
-      <li>{{field.label}}</li>
-    {% endfor %}
-  </ul>
-{% endblock %}
-
 {% block form_questions %}
   {% with primary_complaint_field=wizard.form.primary_complaint %}
     <div class="crt-portal-card">

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -416,3 +416,14 @@ select.usa-input--error {
     margin-right: 1rem;
   }
 }
+
+#page-errors {
+  .error-summary {
+  margin-block-start: 0px;
+    li {
+      font-weight: normal;
+      margin-bottom: 0px;
+      margin-top: 0px;
+    }
+  }
+}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/500)

## What does this change?

Renders question/group label as part of error summary when a step fails form validation.

For `Primary Concern` also renders full error text below question as opposed to at the bottom of the input element.

### Implementation note
The location page took longer than expected and required both a new function,  `LocationForm.summary_error_questions`, and updates to `QuestionGroup.` This stems from the difference in the way fields are defined within `LocationForm` variants used to accommodate different primary concerns. 

### Step 1
<img width="525" alt="Screen Shot 2020-05-18 at 9 54 59 PM" src="https://user-images.githubusercontent.com/3485564/82276080-44de2a80-9952-11ea-9e85-9d47bbc990a7.png">

### Primary Concern
<img width="572" alt="Screen Shot 2020-05-18 at 9 55 10 PM" src="https://user-images.githubusercontent.com/3485564/82276083-46a7ee00-9952-11ea-9074-e1433c848b15.png">

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
