### PR TITLE
Render detailed invalid phone error message

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -16,6 +16,7 @@ from django.utils.translation import gettext_lazy as _
 from .model_variables import (COMMERCIAL_OR_PUBLIC_ERROR,
                               COMMERCIAL_OR_PUBLIC_PLACE_CHOICES,
                               COMMERCIAL_OR_PUBLIC_PLACE_HELP_TEXT,
+                              CONTACT_PHONE_INVALID_MESSAGE,
                               CORRECTIONAL_FACILITY_LOCATION_CHOICES,
                               CORRECTIONAL_FACILITY_LOCATION_TYPE_CHOICES,
                               DATE_ERRORS, DISTRICT_CHOICES,
@@ -116,7 +117,7 @@ class Contact(ModelForm):
             'contact_phone': TextInput(attrs={
                 'class': 'usa-input',
                 'pattern': phone_validation_regex,
-                'title': _('If you submit a phone number, please make sure to include between 7 and 15 digits. The characters "+", ")", "(", "-", and "." are allowed. Please include country code if entering an international phone number.')
+                'title': CONTACT_PHONE_INVALID_MESSAGE
             }),
             'contact_address_line_1': TextInput(attrs={
                 'class': 'usa-input',
@@ -140,6 +141,8 @@ class Contact(ModelForm):
         self.fields['contact_last_name'].label = CONTACT_QUESTIONS['contact_last_name']
         self.fields['contact_email'].label = CONTACT_QUESTIONS['contact_email']
         self.fields['contact_phone'].label = CONTACT_QUESTIONS['contact_phone']
+        self.fields['contact_phone'].error_messages = {'invalid': CONTACT_PHONE_INVALID_MESSAGE}
+
         self.fields['contact_address_line_1'].label = CONTACT_QUESTIONS['contact_address_line_1']
         self.fields['contact_address_line_2'].label = CONTACT_QUESTIONS['contact_address_line_2']
         self.fields['contact_city'].label = CONTACT_QUESTIONS['contact_city']
@@ -1120,7 +1123,7 @@ class ContactEditForm(ModelForm, ActivityStreamUpdater):
             'contact_phone': TextInput(attrs={
                 'class': 'usa-input',
                 'pattern': phone_validation_regex,
-                'title': _('If you submit a phone number, please make sure to include between 7 and 15 digits. The characters "+", ")", "(", "-", and "." are allowed. Please include country code if entering an international phone number.')
+                'title': CONTACT_PHONE_INVALID_MESSAGE
             }),
             'contact_address_line_1': TextInput(attrs={
                 'class': 'usa-input',
@@ -1135,6 +1138,11 @@ class ContactEditForm(ModelForm, ActivityStreamUpdater):
                 'class': 'usa-input',
             }),
         }
+
+    def __init__(self, *args, **kwargs):
+        ModelForm.__init__(self, *args, **kwargs)
+
+        self.fields['contact_phone'].error_messages = {'invalid': CONTACT_PHONE_INVALID_MESSAGE}
 
     def success_message(self):
         return self.SUCCESS_MESSAGE

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -348,3 +348,5 @@ STATUTE_CHOICES = (
 )
 
 PUBLIC_USER = 'public user'
+
+CONTACT_PHONE_INVALID_MESSAGE = _('If you submit a phone number, please make sure to include between 7 and 15 digits. The characters "+", ")", "(", "-", and "." are allowed. Please include country code if entering an international phone number.')

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -10,6 +10,7 @@ from django.utils.functional import cached_property
 
 from .managers import ActiveProtectedClassChoiceManager
 from .model_variables import (COMMERCIAL_OR_PUBLIC_PLACE_CHOICES,
+                              CONTACT_PHONE_INVALID_MESSAGE,
                               CORRECTIONAL_FACILITY_LOCATION_CHOICES,
                               CORRECTIONAL_FACILITY_LOCATION_TYPE_CHOICES,
                               DATE_ERRORS, DISTRICT_CHOICES, ELECTION_CHOICES,
@@ -82,7 +83,7 @@ class Report(models.Model):
     contact_last_name = models.CharField(max_length=225, null=True, blank=True)
     contact_email = models.EmailField(null=True, blank=True)
     contact_phone = models.CharField(
-        validators=[RegexValidator(phone_validation_regex)],
+        validators=[RegexValidator(phone_validation_regex, message=CONTACT_PHONE_INVALID_MESSAGE)],
         max_length=225,
         null=True,
         blank=True

--- a/crt_portal/cts_forms/tests/tests.py
+++ b/crt_portal/cts_forms/tests/tests.py
@@ -9,10 +9,11 @@ from django.test.client import Client
 from django.urls import reverse
 from testfixtures import LogCapture
 
-from ..forms import (CommercialPublicLocation, Contact, Details,
-                     EducationLocation, LocationForm, PoliceLocation,
-                     PrimaryReason, ProForm, ProtectedClassForm, When, ComplaintActions)
-from ..model_variables import (HATE_CRIMES_TRAFFICKING_MODEL_CHOICES,
+from ..forms import (CommercialPublicLocation, ComplaintActions, Contact,
+                     Details, EducationLocation, LocationForm, PoliceLocation,
+                     PrimaryReason, ProForm, ProtectedClassForm, When)
+from ..model_variables import (CONTACT_PHONE_INVALID_MESSAGE,
+                               HATE_CRIMES_TRAFFICKING_MODEL_CHOICES,
                                PRIMARY_COMPLAINT_CHOICES,
                                PRIMARY_COMPLAINT_ERROR, PROTECTED_CLASS_ERROR,
                                PROTECTED_MODEL_CHOICES, SERVICEMEMBER_ERROR,
@@ -801,7 +802,7 @@ class ContactValidationTests(TestCase):
         self.assertFalse(form.is_valid())
         self.assertEquals(
             form.errors,
-            {'contact_phone': ['Enter a valid value.']}
+            {'contact_phone': [CONTACT_PHONE_INVALID_MESSAGE]}
         )
 
     def test_phone_too_short(self):
@@ -814,7 +815,7 @@ class ContactValidationTests(TestCase):
             phone.full_clean()
         except ValidationError as err:
             phone_error_message = err.message_dict['contact_phone']
-            self.assertTrue(phone_error_message == ['Enter a valid value.'])
+            self.assertTrue(phone_error_message == [CONTACT_PHONE_INVALID_MESSAGE])
 
     def test_international_phone(self):
         phone = Report(


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/505)

## What does this change?
Renders detailed phone number error when validation fails

## Screenshots (for front-end PR):

<img width="336" alt="Screen Shot 2020-05-18 at 10 27 49 PM" src="https://user-images.githubusercontent.com/3485564/82277824-d780c880-9956-11ea-8cc2-95738007cf66.png">

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
