### PR TITLE
Don't read help-text for each input in form group/fieldset

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -515,9 +515,7 @@ class ProtectedClassForm(ModelForm):
         model = Report
         fields = ['protected_class', 'other_class']
         widgets = {
-            'protected_class': UsaCheckboxSelectMultiple(attrs={
-                'aria-describedby': 'protected-class-help-text'
-            }),
+            'protected_class': UsaCheckboxSelectMultiple(),
             'other_class': TextInput(
                 attrs={'class': 'usa-input word-count-10'}
             ),
@@ -531,9 +529,7 @@ class ProtectedClassForm(ModelForm):
             required=True,
             label="",
             queryset=ProtectedClass.active_choices.all().order_by('form_order'),
-            widget=UsaCheckboxSelectMultiple(attrs={
-                'aria-describedby': 'protected-class-help-text'
-            }),
+            widget=UsaCheckboxSelectMultiple(),
         )
         # Translators: This is to explain an "other" choice for personal characteristics
         self.fields['other_class'].help_text = _('Please describe "Other reason"')
@@ -547,9 +543,7 @@ class ProtectedClassForm(ModelForm):
                 ('protected_class',),
                 group_name=PROTECTED_CLASS_QUESTION,
                 help_text=_('There are federal and state laws that protect people from discrimination based on their personal characteristics. Here is a list of the most common characteristics that are legally protected. Select any that apply to your incident.'),
-                optional=False,
-                ally_id="protected-class-help-text"
-            )
+                optional=False)
         ]
 
 

--- a/crt_portal/cts_forms/templates/forms/report_contact_info.html
+++ b/crt_portal/cts_forms/templates/forms/report_contact_info.html
@@ -21,6 +21,7 @@
   </div>
 </div>
 
-{% include "forms/question_cards/single_form.html" with field=form.servicemember %}
-
+  <div role="group" aria-labelledby="servicemember-help-text">
+    {% include "forms/question_cards/single_form.html" with field=form.servicemember ally_id="servicemember-help-text" %}
+  </div>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
+++ b/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
@@ -6,8 +6,8 @@
     <div class="crt-portal-card">
       <div class="crt-portal-card__content crt-portal-card__content--lg">
         {{ block.super }}
-        <div id="primary-complaint-help-text">
-          <p class="em-text">
+        <div>
+          <p id="primary-complaint-help-text" class="em-text" id="primary-complaint-help-text">
             {{ primary_complaint_field.label }}{% if not question_group.optional %}<span class="field-required--group">{% trans "required" %}</span>{% endif %}
           </p>
 


### PR DESCRIPTION
[ZenHub issue 498](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/498)
[ZenHub issue 499](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/499)

## What does this change?
Detaches help text on primary complaint and personal characteristics page from groups/field set questions so they are not read by screen-readers on _every_ option.

Tested on safari with voiceover, I'm still hearing the legend on personal characteristics read twice but I think that's a quirk of safari+VO, digging a bit deeper to confirm.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
