### PR TITLE
Broaden anchor tags in privacy policy footer

### DIFF
--- a/crt_portal/cts_forms/templates/partials/policy.html
+++ b/crt_portal/cts_forms/templates/partials/policy.html
@@ -12,7 +12,7 @@
       <div class="grid-row grid-gap">
         <div class="grid-col-9 usa-footer__links" style="font-size: 14px">
           <p style="margin-bottom: 1em">
-            The purpose of this form is to allow the public to submit civil rights complaints to the Department of Justice, thereby allowing us to enforce over thirty civil rights statutes within our authority. <a style="color: white; text-transform: none" href="https://www.justice.gov/crt/privacy-policy">These statutes</a> authorize us to collect this information.  You should know that any information you provide through this form is voluntary, yet failure to provide some of the information might limit the Department’s ability to pursue your claim. We may use this information for certain routine uses, including sharing this information under certain circumstances with:
+            The purpose of this form is to allow the public to submit civil rights complaints to the Department of Justice, thereby allowing us to enforce over thirty <a style="color: white; text-transform: none" href="https://www.justice.gov/crt/privacy-policy">civil rights statutes</a> within our authority.  These statutes authorize us to collect this information.  You should know that any information you provide through this form is voluntary, yet failure to provide some of the information might limit the Department’s ability to pursue your claim. We may use this information for certain routine uses, including sharing this information under certain circumstances with:
             <ul>
               <li>contractors who work with us, if they need it to perform a contract;</li>
               <li>a court, magistrate, or administrative tribunal, as well as opposing counsel during settlement negotiations and/or litigation;</li>
@@ -21,7 +21,7 @@
             </ul>
           </p>
 
-          <p style="margin-bottom: 2em">You can find our complete Privacy Policy <a style="color: white; text-transform: none" href="https://www.justice.gov/crt/privacy-policy">here</a>.</p>
+          <p style="margin-bottom: 2em">You can find our complete <a style="color: white; text-transform: none" href="https://www.justice.gov/crt/privacy-policy">Privacy Policy here</a>.</p>
         </div>
       </div>
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/524)

## What does this change?

Shifts anchor tags in privacy policy to include more descriptive text.

## Screenshots (for front-end PR):
<img width="608" alt="Screen Shot 2020-05-19 at 2 12 32 PM" src="https://user-images.githubusercontent.com/3485564/82362749-cda0a900-99da-11ea-8cd2-b4810b76a246.png">

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
