### PR TITLE
Remove hatecrime help text from review page

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_data.html
+++ b/crt_portal/cts_forms/templates/forms/report_data.html
@@ -41,7 +41,6 @@
     <p>{{ report.get_primary_complaint_display }}</p>
 
     <h3 class="border-bottom border-base-lighter padding-bottom-05">{{ question.hatecrime_title }}</h3>
-    <h4>{{ question.hatecrime }}</h4>
     {% if report.id %}
       {% for crime in report.hatecrimes_trafficking.all %}
         <p>{{crime}}</p>


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/526)

## What does this change?
Removes `<h4>` rendered help-text for hatecrime fields on report review step.

## Screenshots (for front-end PR):
<img width="547" alt="Screen Shot 2020-05-19 at 2 21 42 PM" src="https://user-images.githubusercontent.com/3485564/82363693-2cb2ed80-99dc-11ea-9566-635dbde24f8c.png">

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
