### PR TITLE
Remove references to legacy location help text

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -278,23 +278,18 @@ class LocationForm(ModelForm):
 
         widgets = {
             'location_name': TextInput(attrs={
-                'class': 'usa-input',
-                'aria-describedby': 'location-help-text'
+                'class': 'usa-input'
             }),
             'location_address_line_1': TextInput(attrs={
-                'class': 'usa-input',
-                'aria-describedby': 'location-help-text'
+                'class': 'usa-input'
             }),
             'location_address_line_2': TextInput(attrs={
-                'class': 'usa-input',
-                'aria-describedby': 'location-help-text'
+                'class': 'usa-input'
             }),
             'location_city_town': TextInput(attrs={
-                'class': 'usa-input',
-                'aria-describedby': 'location-help-text'
+                'class': 'usa-input'
             }),
             'location_state': Select(attrs={
-                'aria-describedby': 'location-help-text',
                 'class': 'usa-select'
             }),
         }
@@ -319,7 +314,6 @@ class LocationForm(ModelForm):
         self.fields['location_state'] = ChoiceField(
             choices=_add_empty_choice(STATES_AND_TERRITORIES),
             widget=Select(attrs={
-                'aria-describedby': 'location-help-text',
                 'class': 'usa-select'
             }),
             required=True,
@@ -336,7 +330,6 @@ class LocationForm(ModelForm):
                 ('location_name', 'location_address_line_1', 'location_address_line_2'),
                 group_name=LOCATION_QUESTIONS['location_title'],
                 optional=True,  # a11y: only some fields here are required
-                ally_id='location-help-text'
             ),
         ]
         self.page_note = _('Please tell us the city, state, and name of the location where this incident took place. This ensures your report is reviewed by the right people within the Civil Rights Division.')
@@ -493,15 +486,12 @@ class EducationLocation(LocationForm):
                 group_name=EDUCATION_QUESTION,
                 help_text=_('Includes schools, educational programs, or educational activities, like training programs, sports teams, clubs, or other school-sponsored activities'),
                 optional=False,
-                ally_id='education-location-help-text'
             ),
         ] + self.question_groups
 
         self.fields['public_or_private_school'] = TypedChoiceField(
             choices=PUBLIC_OR_PRIVATE_SCHOOL_CHOICES,
-            widget=UsaRadioSelect(attrs={
-                'aria-describedby': 'education-location-help-text'
-            }),
+            widget=UsaRadioSelect(),
             label='',
             required=True,
             error_messages={
@@ -702,23 +692,18 @@ class ProForm(
             # location widgets
             {
                 'location_name': TextInput(attrs={
-                    'class': 'usa-input',
-                    'aria-describedby': 'location-help-text'
+                    'class': 'usa-input'
                 }),
                 'location_address_line_1': TextInput(attrs={
-                    'class': 'usa-input',
-                    'aria-describedby': 'location-help-text'
+                    'class': 'usa-input'
                 }),
                 'location_address_line_2': TextInput(attrs={
-                    'class': 'usa-input',
-                    'aria-describedby': 'location-help-text'
+                    'class': 'usa-input'
                 }),
                 'location_city_town': TextInput(attrs={
-                    'class': 'usa-input',
-                    'aria-describedby': 'location-help-text'
+                    'class': 'usa-input'
                 }),
                 'location_state': Select(attrs={
-                    'aria-describedby': 'location-help-text',
                     'class': 'usa-select'
                 }),
             },


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/443)

## What does this change?
`location-help-text` and it's variants no longer exist removing vestigial references to them throughout `forms.py`

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
