### PR TITLE
PII warning banner for non-production sites

### DIFF
--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -25,6 +25,26 @@
       {% include "partials/banner/usa_banner.html" %}
     {% endblock %}
 
+    {% environment as env %}
+    {% if env != "PRODUCTION" %}
+      <div class="crt-header--warning-pii">
+        <div class="grid-container">
+          <div class="grid-row grid-gap">
+            <div class="grid-col-12">
+              <div class="usa-alert usa-alert--warning">
+                <div class="usa-alert__body">
+                  <h1 class="usa-alert__heading">Test site</h1>
+                  <p class="usa-alert__text">
+                    This is a test site. Do not enter PII.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
     {% block page_header %}{% endblock %}
 
     <main id="main-content" {% block main_class %}{% endblock %}>

--- a/crt_portal/static/sass/custom/header.scss
+++ b/crt_portal/static/sass/custom/header.scss
@@ -34,3 +34,9 @@
     max-width: 87rem !important;
   }
 }
+
+.crt-header--warning-pii {
+  width: 100%;
+  background-color: $blue-warm-vivid-80;
+  padding-top: 1rem;
+}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/399)

## What does this change?

Adds a test site warning for non-production sites.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
