### PR TITLE
copy edits

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -886,6 +886,7 @@ class Filters(ModelForm):
     )
     primary_statute = ChoiceField(
         required=False,
+        label=_("Primary classification"),
         choices=_add_empty_choice(STATUTE_CHOICES),
         widget=Select(attrs={
             'name': 'primary_statute',
@@ -938,7 +939,7 @@ class Filters(ModelForm):
             'location_state': 'Incident location state',
             'assigned_to': 'Assignee',
             'public_id': 'Complaint ID',
-            'primary_statute': 'Statute',
+            'primary_statute': 'Primary classification',
             'violation_summary': 'Personal description',
         }
 
@@ -1011,7 +1012,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
         )
         self.fields['primary_statute'] = ChoiceField(
             widget=ComplaintSelect(
-                label='Primary statute',
+                label='Primary classification',
                 attrs={
                     'class': 'text-uppercase crt-dropdown__data',
                 },

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1035,7 +1035,11 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
     def get_actions(self):
         """Parse incoming changed data for activity stream entry"""
         for field in self.changed_data:
-            yield f"{' '.join(field.split('_')).capitalize()}:", f'Updated from "{self.initial[field]}" to "{self.cleaned_data[field]}"'
+            name = ' '.join(field.split('_')).capitalize()
+            # rename primary statute if applicable
+            if field == 'primary_statute':
+                name = 'Primary classification'
+            yield f"{name}:", f'Updated from "{self.initial[field]}" to "{self.cleaned_data[field]}"'
 
     def update_activity_stream(self, user):
         """Send all actions to activity stream"""

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -265,7 +265,6 @@ class Details(ModelForm):
         self.fields['violation_summary'].help_text = SUMMARY_HELPTEXT
         self.fields['violation_summary'].error_messages = {'required': VIOLATION_SUMMARY_ERROR}
         self.fields['violation_summary'].required = True
-        self.page_note = _('Continued')
 
 
 class LocationForm(ModelForm):

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/primary_statute_filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/primary_statute_filter.html
@@ -1,7 +1,7 @@
 {% extends "forms/complaint_view/index/filter.html" %}
 
 {% block controls %}primary-statute{% endblock %}
-{% block label %}Statute{% endblock %}
+{% block label %}Classification{% endblock %}
 {% block id %}primary-statute{% endblock %}
 
 {% block content %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -69,7 +69,7 @@
         </div>
         <div class="crt-portal-card">
           <div class="crt-portal-card__content">
-            {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="comment" is_summary=False  button_text='Send' button_aria_label='send comment' label='New comment' comment_box=comments.note %}
+            {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="comment" is_summary=False button_text='Save' button_aria_label='save comment' label='New comment' comment_box=comments.note %}
           </div>
         </div>
       </div>

--- a/crt_portal/cts_forms/templatetags/get_field_label.py
+++ b/crt_portal/cts_forms/templatetags/get_field_label.py
@@ -12,7 +12,7 @@ variable_rename = {
     'location_state': 'State',
     'assigned_to': 'Assignee',
     'public_id': 'Complaint ID',
-    'primary_statute': 'Statute',
+    'primary_statute': 'Classification',
     'violation_summary': 'Personal description',
 }
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/523)

## What does this change?

- `Statute` -> `Classification` rename 
- Removes stray `Continue` on personal description page
- CRT form:  `Send` -> `Save`

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
