### PR TITLE
fix connecting line for spanish

### DIFF
--- a/crt_portal/cts_forms/templates/forms/portal/progress-bar.html
+++ b/crt_portal/cts_forms/templates/forms/portal/progress-bar.html
@@ -31,11 +31,7 @@
           </li>
         {% endfor %}
         </ol>
-      {# need some styling to get the progress bar in the right place for Spanish #}
-      {% get_language_info for LANGUAGE_CODE as lang %}
-      {% if lang.code == 'en' %}
         <div class="connecting-line"></div>
-      {% endif %}
     </div>
   </div>
 </div>

--- a/crt_portal/static/sass/custom/progress.scss
+++ b/crt_portal/static/sass/custom/progress.scss
@@ -43,6 +43,7 @@ ol.steps {
   list-style: none;
   text-align: center;
   counter-reset: milestones; // init counter
+  height: 62px;
 
   // design
   width: $steps-width;


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/520)

## What does this change?

Fixes connection line. Progress bar needs to be a fixed height since the connecting line is relative. 

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
