### PR TITLE
Add footer links 

### DIFF
--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -2004,13 +2004,17 @@ msgstr "Ley de libertad de información (FOIA por sus siglas en inglés)"
 msgid "Accessibility"
 msgstr "Accesibilidad"
 
-#: templates/partials/footer.html:80
+#: templates/partials/footer.html:83
 msgid "Office of Inspector General"
 msgstr "Oficina del Inspector General"
 
-#: templates/partials/footer.html:83
+#: templates/partials/footer.html:86
 msgid "Budget and performance"
 msgstr "Presupuesto y rendimiento"
+
+#: templates/partials/footer.html:89
+msgid "Office of Legal policies and Disclaimers"
+msgstr ""
 
 #: templates/privacy.html:7
 #, fuzzy

--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -2013,8 +2013,8 @@ msgid "Budget and performance"
 msgstr "Presupuesto y rendimiento"
 
 #: templates/partials/footer.html:89
-msgid "Office of Legal policies and Disclaimers"
-msgstr ""
+msgid "Legal policies and Disclaimers"
+msgstr "Politicas Legales y Descargos de Responsabilidades"
 
 #: templates/privacy.html:7
 #, fuzzy

--- a/crt_portal/cts_forms/templates/partials/footer.html
+++ b/crt_portal/cts_forms/templates/partials/footer.html
@@ -70,6 +70,9 @@
           <a href="https://www.justice.gov/accessibility/accessibility-information">
             {% trans "Accessibility" %}
           </a>
+          <a href="https://www.justice.gov">
+            justice.gov
+          </a>
         </div>
 
         <div class="tablet:grid-col-6 grid-col-12 usa-footer__links">
@@ -81,6 +84,9 @@
           </a>
           <a href="https://www.justice.gov/doj/budget-and-performance">
             {% trans "Budget and performance" %}
+          </a>
+          <a href="https://www.justice.gov/legalpolicies">
+            {% trans "Office of Legal policies and Disclaimers" %}
           </a>
           <a href="https://www.usa.gov/">
             USA.gov

--- a/crt_portal/cts_forms/templates/partials/footer.html
+++ b/crt_portal/cts_forms/templates/partials/footer.html
@@ -86,7 +86,7 @@
             {% trans "Budget and performance" %}
           </a>
           <a href="https://www.justice.gov/legalpolicies">
-            {% trans "Office of Legal policies and Disclaimers" %}
+            {% trans "Legal policies and Disclaimers" %}
           </a>
           <a href="https://www.usa.gov/">
             USA.gov


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/535)

## What does this change?
Including links to justice.gov and office of legal policies and disclaimers in footer.

Includes updated messages file.

## Screenshots (for front-end PR):
<img width="1102" alt="Screen Shot 2020-05-26 at 8 13 11 PM" src="https://user-images.githubusercontent.com/3485564/82962146-5c8a6400-9f8d-11ea-954c-3f557e081b4c.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
