### PR TITLE
Need to use "stage" that corresponds with the numbered stages

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -5,7 +5,7 @@
 {% block page_title %}
   {% if wizard.steps.step1 and current_step_name %}
     <title>
-        {% blocktrans with stage_number=wizard.steps.step1 current_step_name=current_step_name %}
+        {% blocktrans with stage_number=stage_number current_step_name=current_step_name %}
           Step {{ stage_number }}: {{ current_step_name }} - Contact the Civil Rights Division - Department of Justice
         {% endblocktrans %}
     </title>


### PR DESCRIPTION
[Step (really stage) number in page title and progress bar not matching #534](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/534)

## What does this change?
Need to use the "stage," that corresponds with the numbered stages in the bubbles. Stages can be comprised of multiple wizard steps

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
