### PR TITLE
Touchpoints styling

### DIFF
--- a/crt_portal/static/sass/custom/banner.scss
+++ b/crt_portal/static/sass/custom/banner.scss
@@ -6,6 +6,11 @@
   .usa-banner__header-text,
   .usa-media-block__body {
     color: white;
+
+    // Touchpoints footer styling
+    [id=fba-modal-dialog] & {
+     color: #1b1b1b;
+    }
   }
 
   .usa-banner__button, .usa-banner__header-action {

--- a/crt_portal/static/sass/custom/touchpoints.scss
+++ b/crt_portal/static/sass/custom/touchpoints.scss
@@ -1,0 +1,3 @@
+#fba-button {
+        background-color: #00819d;
+}

--- a/crt_portal/static/sass/styles.scss
+++ b/crt_portal/static/sass/styles.scss
@@ -45,3 +45,4 @@
 @import 'custom/confirmation';
 @import 'custom/landing';
 @import 'custom/privacy';
+@import 'custom/touchpoints';


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/552)

## What does this change?
Two styling tweaks to increase contrast among Touchpoints components and tackle conflicts between our styles and those brought along by Touchpoints.

## Screenshots (for front-end PR):
### Darker text color in modal footer
<img width="585" alt="Screen Shot 2020-05-28 at 2 46 35 PM" src="https://user-images.githubusercontent.com/3485564/83182181-f704b780-a0f3-11ea-8b26-2d8568d89e75.png">

### Darker background for access link
<img width="429" alt="Screen Shot 2020-05-28 at 3 00 03 PM" src="https://user-images.githubusercontent.com/3485564/83182206-0126b600-a0f4-11ea-9ab9-8c9cd388d5d9.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
