### PR TITLE
preserving the query of a user on a page

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -39,6 +39,7 @@
 
 <div class="report-details">
     {% csrf_token %}
+    <input type="hidden" value="{{ return_url_args }}" name="next" id="next-{{ id_name }}" />
     <table class="usa-table usa-table--borderless complaint-card-table">
       <tr>
         <th><label for="{{details_form.primary_complaint.id_for_label}}">Primary issue</label></th>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/contact_edit.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/contact_edit.html
@@ -1,5 +1,6 @@
 <form id="contact-edit-form" class="usa-form {% if not contact_form.errors %}display-none{% endif %}" method="post" novalidate>
     {% csrf_token %}
+    <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
     {% for field in contact_form %}
         {% include "forms/snippets/input.html" with field=field %}
     {% endfor %}

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -37,11 +37,12 @@ class CommentActionTests(TestCase):
         self.response = self.client.post(
             reverse(
                 'crt_forms:save-report-comment',
-                kwargs={'report_id': self.pk}
+                kwargs={'report_id': self.pk},
             ),
             {
                 'is_summary': False,
                 'note': self.note,
+                'next': '?per_page=15',
             },
             follow=True
         )
@@ -49,6 +50,10 @@ class CommentActionTests(TestCase):
     def test_post(self):
         """A logged in user can post a comment"""
         self.assertEquals(self.response.status_code, 200)
+
+    def test_retain_query(self):
+        """if the user came to the page with query parameters, keep them for the back to all button."""
+        self.assertTrue('?per_page=15' in str(self.response.content))
 
     def test_creates_comment(self):
         """A comment is created and associated with the right report"""
@@ -59,7 +64,9 @@ class CommentActionTests(TestCase):
     def test_adds_comment_to_activity(self):
         """The comment shows up in the report's activity log"""
         response = self.client.get(
-            reverse('crt_forms:crt-forms-show', kwargs={'id': self.pk})
+            reverse(
+                'crt_forms:crt-forms-show',
+                kwargs={'id': self.pk}),
         )
         content = str(response.content)
         self.assertTrue(self.note in content)
@@ -70,7 +77,7 @@ class CommentActionTests(TestCase):
         response = self.client.post(
             reverse(
                 'crt_forms:save-report-comment',
-                kwargs={'report_id': self.pk}
+                kwargs={'report_id': self.pk},
             ),
             {
                 'is_summary': False,

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -298,10 +298,9 @@ class ShowView(LoginRequiredMixin, View):
             report.save()
             form.update_activity_stream(request.user)
             messages.add_message(request, messages.SUCCESS, form.success_message())
-            return_url_args = request.GET.get('next', ''),
-
             #  preserve the query that got the user to this page
-            next_page = urllib.parse.quote(request.POST['next'])
+            return_url_args = request.POST.get('next', '')
+            next_page = urllib.parse.quote(return_url_args)
             url = f'{report.get_absolute_url()}?next={next_page}'
             return redirect(url)
         else:
@@ -345,8 +344,10 @@ class SaveCommentView(LoginRequiredMixin, FormView):
             messages.add_message(request, messages.SUCCESS, f'Successfully {verb[:-2].lower()}.')
             comment_form.update_activity_stream(request.user, report, verb)
 
-            next_page = urllib.parse.quote(request.POST['next'])
-            url = f'{report.get_absolute_url()}#status-update?next={next_page}'
+            #  preserve the query that got the user to this page
+            return_url_args = request.POST.get('next', '')
+            next_page = urllib.parse.quote(return_url_args)
+            url = f'{report.get_absolute_url()}?next={next_page}'
             return redirect(url)
         else:
             # TODO handle form validation failures

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -260,9 +260,6 @@ class ShowView(LoginRequiredMixin, View):
             'contact_form': contact_form,
             'details_form': details_form,
         })
-        output.update({
-            'next': request.POST.get('next', ''),
-        })
 
         return render(request, 'forms/complaint_view/show/index.html', output)
 


### PR DESCRIPTION
[CRT user wants to filters to persist after editing#538](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/538)

## What does this change?
The edit forms were not preserving the query. The `next` argument preserves the query that brought the user to the page. That is used to populate the "back to all" button 

## Screenshots (for front-end PR):

## Checklist:
Create a query on the form/view page

- click on a record

Note the next argument in the URL

- edit the Actions
  - the url should not change

- add a comment 
  - the url should not change

- add a summary 
  - the url should not change

- edit a summary 
  - the url should not change

- edit the correspondent info
  - the url should not change

- edit the reported complaint
  - the url should not change

- confirm that the "back to all" button takes you to your original query

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
