### PR TITLE
mobile: confirmation number tweak

### DIFF
--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -36,10 +36,14 @@
       <div class="crt-success-card__content">
           <h3 class="intake-section-title">{% trans "Please save your record number for tracking." %}</h3>
           <p>{% trans "If you want a copy of this report for your personal records, save or print a copy of this page." %}</p>
-          <div class='record-number-wrapper'>
-            <div id="paper-icon-wrapper" class="margin-right-1"><img src="{% static 'img/ic_paper.svg' %}" alt="paper" /></div>
-            {% trans "Your record number is:" %}
-            <span class="record-number margin-left-1">{{report.public_id}}</span>
+          <div class="record-number-wrapper">
+            <div class="record-number-note">
+              <div id="paper-icon-wrapper" class="margin-right-1"><img src="{% static 'img/ic_paper.svg' %}" alt="paper" /></div>
+              {% trans "Your record number is:" %}
+            </div>
+            <div>
+              <span class="record-number margin-left-1">{{report.public_id}}</span>
+            </div>
           </div>
       </div>
     </div>

--- a/crt_portal/static/sass/custom/confirmation.scss
+++ b/crt_portal/static/sass/custom/confirmation.scss
@@ -58,6 +58,12 @@ section hr {
   align-content: center;
   @include flex-container();
 
+  @include at-media-max(mobile-lg) {
+    // break up in two rows for mobile
+    flex-direction: column;
+    align-items: initial;
+  }
+
   #paper-icon-wrapper {
     @include flex-container();
     justify-content: center;
@@ -65,6 +71,14 @@ section hr {
     height: 25px;
     width: 25px;
     border-radius: 2rem;
+  }
+
+  .record-number-note {
+    display: flex;
+    align-items: center;
+    @include at-media-max(mobile-lg) {
+      margin-bottom: 0.5rem;
+    }
   }
 
   .record-number {

--- a/crt_portal/static/sass/custom/confirmation.scss
+++ b/crt_portal/static/sass/custom/confirmation.scss
@@ -27,6 +27,7 @@
     @include u-bg($blue-warm-5-t);
     justify-content: center;
     align-content: center;
+    padding: 0 1rem;
 
     .icon {
       margin-right: 10px;


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/559)

## What does this change?

On mobile, confirmation number is broken and not easy to scan/copy. This PR fixes this (see screenshots below)

## Screenshots (for front-end PR):

![2020-06-01_12-03](https://user-images.githubusercontent.com/3013175/83444901-ed839400-a400-11ea-8c17-e0dda8f71e5c.png)

![2020-06-01_11-46](https://user-images.githubusercontent.com/3013175/83442801-9e882f80-a3fd-11ea-9d75-68e0ac1297b6.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
