### PR TITLE
confirmation page: external link icons

### DIFF
--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -135,10 +135,10 @@
             {% trans "Legal aid offices or members of lawyer associations in your state may be able to help you with your issue." %}"
             <ul class="confirmation-list">
               <li>
-                {% trans 'American Bar Association, visit <a class="external-link" aria-label="www.findlegalhelp.org" href="http://www.findlegalhelp.org/">www.findlegalhelp.org</a> or call <a href="tel:800-285-2221">(800) 285-2221</a>' %}
+                {% trans 'American Bar Association, visit <a class="external-link--blue" aria-label="www.findlegalhelp.org" href="http://www.findlegalhelp.org/">www.findlegalhelp.org</a> or call <a href="tel:800-285-2221">(800) 285-2221</a>' %}
               </li>
               <li>
-                {% trans 'Legal Service Corporation (or Legal Aid Offices), visit <a aria-label="lsc.gov/find-legal-aid" class="external-link" href="https://lsc.gov/find-legal-aid">lsc.gov/find-legal-aid</a> or call <a href="tel:202-295-1500">(202) 295-1500</a>' %}
+                {% trans 'Legal Service Corporation (or Legal Aid Offices), visit <a aria-label="lsc.gov/find-legal-aid" class="external-link--blue" href="https://lsc.gov/find-legal-aid">lsc.gov/find-legal-aid</a> or call <a href="tel:202-295-1500">(202) 295-1500</a>' %}
               </li>
             </ul>
           </div>
@@ -180,8 +180,7 @@
   {% include "partials/policy.html" %}
 </div>
 {% endblock footer_extra %}
-  
+
 {% block page_js %}
   <script src="https://touchpoints.app.cloud.gov/touchpoints/a24aeb5e/js" async></script>
 {% endblock %}
-  

--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -135,10 +135,10 @@
             {% trans "Legal aid offices or members of lawyer associations in your state may be able to help you with your issue." %}"
             <ul class="confirmation-list">
               <li>
-                {% trans 'American Bar Association, visit <a href="http://www.findlegalhelp.org">www.findlegalhelp.org</a> or call <a href="tel:800-285-2221">(800) 285-2221</a>' %}
+                {% trans 'American Bar Association, visit <a class="external-link" aria-label="www.findlegalhelp.org" href="http://www.findlegalhelp.org/">www.findlegalhelp.org</a> or call <a href="tel:800-285-2221">(800) 285-2221</a>' %}
               </li>
               <li>
-                {% trans 'Legal Service Corporation (or Legal Aid Offices), visit <a href="https://www.lsc.gov/find-legal-aid">www.lsc.gov/find-legal-aid</a> or call <a href="tel:202-295-1500">(202) 295-1500</a>' %}
+                {% trans 'Legal Service Corporation (or Legal Aid Offices), visit <a aria-label="lsc.gov/find-legal-aid" class="external-link" href="https://lsc.gov/find-legal-aid">lsc.gov/find-legal-aid</a> or call <a href="tel:202-295-1500">(202) 295-1500</a>' %}
               </li>
             </ul>
           </div>

--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -135,10 +135,10 @@
             {% trans "Legal aid offices or members of lawyer associations in your state may be able to help you with your issue." %}"
             <ul class="confirmation-list">
               <li>
-                {% trans 'American Bar Association, visit <a class="external-link--blue" aria-label="www.findlegalhelp.org" href="http://www.findlegalhelp.org/">www.findlegalhelp.org</a> or call <a href="tel:800-285-2221">(800) 285-2221</a>' %}
+                {% trans 'American Bar Association, visit <a class="external-link--blue" aria-label="www.findlegalhelp.org" href="http://www.findlegalhelp.org">www.findlegalhelp.org</a> or call <a href="tel:800-285-2221">(800) 285-2221</a>' %}
               </li>
               <li>
-                {% trans 'Legal Service Corporation (or Legal Aid Offices), visit <a aria-label="lsc.gov/find-legal-aid" class="external-link--blue" href="https://lsc.gov/find-legal-aid">lsc.gov/find-legal-aid</a> or call <a href="tel:202-295-1500">(202) 295-1500</a>' %}
+                {% trans 'Legal Service Corporation (or Legal Aid Offices), visit <a aria-label="www.lsc.gov/find-legal-aid" class="external-link--blue" href="https://www.lsc.gov/find-legal-aid">www.lsc.gov/find-legal-aid</a> or call <a href="tel:202-295-1500">(202) 295-1500</a>' %}
               </li>
             </ul>
           </div>

--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -337,7 +337,7 @@
             <h3>{% trans "Need urgent legal help?" %}</h3>
           </div>
           <p class="crt-landing--text">{% trans "Local legal aid offices or lawyers in your area may be able to quickly respond to or help with your concern." %}</p>
-          <p class="crt-landing--text">{% trans 'Contact Legal Service Corporation at <a aria-label="lsc.gov/find-legal-aid" class="external-link--blue" href="https://lsc.gov/find-legal-aid">lsc.gov/find-legal-aid</a> or call <a href="tel:202-295-1500">(202) 295-1500</a>.' %}</p>
+          <p class="crt-landing--text">{% trans 'Contact Legal Service Corporation at <a aria-label="www.lsc.gov/find-legal-aid" class="external-link--blue" href="https://www.lsc.gov/find-legal-aid">lsc.gov/find-legal-aid</a> or call <a href="tel:202-295-1500">(202) 295-1500</a>.' %}</p>
           <p class="crt-landing--text">{% trans 'Or visit <a class="external-link--blue" aria-label="www.findlegalhelp.org" href="http://www.findlegalhelp.org/">www.findlegalhelp.org</a> or call <a href="tel:800-285-2221">(800) 285-2221</a> to find a lawyer through the American Bar Association.' %}</p>
         </div>
       </div>

--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -104,7 +104,7 @@
           </p>
           <p class="crt-landing--emergency_contact">
             <em>
-              {% trans 'If you are reporting misconduct by law enforcement or believe you have experienced a hate crime, please <a aria-label="contact the FBI" class="crt-external--link" href="https://www.fbi.gov/tips">contact the FBI</a>.' %}
+              {% trans 'If you are reporting misconduct by law enforcement or believe you have experienced a hate crime, please <a aria-label="contact the FBI" class="external-link--white" href="https://www.fbi.gov/tips">contact the FBI</a>.' %}
             </em>
           </p>
         </div>
@@ -337,8 +337,8 @@
             <h3>{% trans "Need urgent legal help?" %}</h3>
           </div>
           <p class="crt-landing--text">{% trans "Local legal aid offices or lawyers in your area may be able to quickly respond to or help with your concern." %}</p>
-          <p class="crt-landing--text">{% trans 'Contact Legal Service Corporation at <a aria-label="lsc.gov/find-legal-aid" class="crt-external--link" href="https://lsc.gov/find-legal-aid">lsc.gov/find-legal-aid</a> or call <a href="tel:202-295-1500">(202) 295-1500</a>.' %}</p>
-          <p class="crt-landing--text">{% trans 'Or visit <a class="crt-external--link" aria-label="www.findlegalhelp.org" href="http://www.findlegalhelp.org/">www.findlegalhelp.org</a> or call <a href="tel:800-285-2221">(800) 285-2221</a> to find a lawyer through the American Bar Association.' %}</p>
+          <p class="crt-landing--text">{% trans 'Contact Legal Service Corporation at <a aria-label="lsc.gov/find-legal-aid" class="external-link--blue" href="https://lsc.gov/find-legal-aid">lsc.gov/find-legal-aid</a> or call <a href="tel:202-295-1500">(202) 295-1500</a>.' %}</p>
+          <p class="crt-landing--text">{% trans 'Or visit <a class="external-link--blue" aria-label="www.findlegalhelp.org" href="http://www.findlegalhelp.org/">www.findlegalhelp.org</a> or call <a href="tel:800-285-2221">(800) 285-2221</a> to find a lawyer through the American Bar Association.' %}</p>
         </div>
       </div>
     </div>

--- a/crt_portal/static/sass/custom/confirmation.scss
+++ b/crt_portal/static/sass/custom/confirmation.scss
@@ -161,6 +161,11 @@ section.what-to-expect {
       margin-top: -0.015rem; // Merriweather numerals have a dropped baseline and don't sit in the center of the circle naturally
     }
   }
+
+  .external-link:after {
+    padding-left: 0.25rem;
+    content: url(../../img/ic_external-link-blue.svg);
+  }
 }
 
 section.submission {

--- a/crt_portal/static/sass/custom/confirmation.scss
+++ b/crt_portal/static/sass/custom/confirmation.scss
@@ -161,11 +161,6 @@ section.what-to-expect {
       margin-top: -0.015rem; // Merriweather numerals have a dropped baseline and don't sit in the center of the circle naturally
     }
   }
-
-  .external-link:after {
-    padding-left: 0.25rem;
-    content: url(../../img/ic_external-link-blue.svg);
-  }
 }
 
 section.submission {

--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -222,11 +222,6 @@ $arrow-height: 24px;
       color: white;
       font-weight: bold;
     }
-
-    .crt-external--link:after {
-      padding-left: 0.25rem;
-      content: url(../../img/ic_external-link-white.svg);
-    }
   }
 }
 
@@ -488,11 +483,6 @@ $arrow-height: 24px;
 
   h3 {
     font-size: 1.5rem;
-  }
-
-  .crt-external--link:after {
-    padding-left: 0.25rem;
-    content: url(../../img/ic_external-link-blue.svg);
   }
 }
 

--- a/crt_portal/static/sass/custom/links.scss
+++ b/crt_portal/static/sass/custom/links.scss
@@ -1,0 +1,9 @@
+.external-link--white:after {
+  padding-left: 0.25rem;
+  content: url(../../img/ic_external-link-white.svg);
+}
+
+.external-link--blue:after {
+  padding-left: 0.25rem;
+  content: url(../../img/ic_external-link-blue.svg);
+}

--- a/crt_portal/static/sass/styles.scss
+++ b/crt_portal/static/sass/styles.scss
@@ -46,3 +46,4 @@
 @import 'custom/landing';
 @import 'custom/privacy';
 @import 'custom/touchpoints';
+@import 'custom/links';


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/555)

## What does this change?

- External link icons for confirmation page

## Screenshots (for front-end PR):

![2020-06-01_12-38](https://user-images.githubusercontent.com/3013175/83447174-d9da2c80-a404-11ea-9a90-7e52f055db0f.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
