### PR TITLE
Trend tracking protype

### DIFF
--- a/crt_portal/cts_forms/migrations/0073_make_trend_view.py
+++ b/crt_portal/cts_forms/migrations/0073_make_trend_view.py
@@ -1,0 +1,108 @@
+from django.db import connection
+from django.db import migrations
+
+
+# Dictionary is used to find common stop words without returing stemmed results https://dba.stackexchange.com/questions/145016/finding-the-most-commonly-used-non-stop-words-in-a-column
+sql_create_statement = """
+CREATE TEXT SEARCH DICTIONARY english_simple_dict (
+    TEMPLATE = pg_catalog.simple
+  , STOPWORDS = english
+);
+
+CREATE TEXT SEARCH CONFIGURATION english_simple (COPY = simple);
+ALTER  TEXT SEARCH CONFIGURATION english_simple
+ALTER MAPPING FOR asciiword WITH english_simple_dict;
+
+CREATE VIEW trends AS
+    -- get this week's data
+    (SELECT
+        word,
+        ndoc as document_count,
+        nentry as word_count,
+        date_trunc('week', CURRENT_TIMESTAMP) as start_date,
+        CURRENT_TIMESTAMP as end_date,
+        'this_week' as record_type,
+        row_number() OVER (PARTITION BY true) as id
+    FROM ts_stat($$
+        SELECT to_tsvector('english_simple', violation_summary)
+        FROM cts_forms_report
+        where
+            (create_date >= date_trunc('week', CURRENT_TIMESTAMP))
+    $$)
+    LIMIT  10)
+    UNION
+    -- get last week's data
+    (SELECT
+        word,
+        ndoc as document_count,
+        nentry as word_count,
+        date_trunc('week', CURRENT_TIMESTAMP - interval '1 week') as start_date,
+        date_trunc('week', CURRENT_TIMESTAMP) as end_date,
+        'last_week' as record_type,
+        row_number() OVER (PARTITION BY true) as id
+    FROM ts_stat($$
+        SELECT to_tsvector('english_simple', violation_summary)
+        FROM cts_forms_report
+        WHERE (
+            create_date >= date_trunc('week', CURRENT_TIMESTAMP - interval '1 week') and
+            create_date < date_trunc('week', CURRENT_TIMESTAMP)
+        )
+    $$)
+    ORDER  BY ndoc DESC
+    LIMIT  10)
+    UNION
+    -- get last 4 weeks
+    (SELECT
+        word,
+        ndoc as document_count,
+        nentry as word_count,
+        date_trunc('week', CURRENT_TIMESTAMP - interval '4 week') as start_date,
+        CURRENT_TIMESTAMP as end_date,
+        'four_weeks' as record_type,
+        row_number() OVER (PARTITION BY true) as id
+    FROM ts_stat($$
+        SELECT to_tsvector('english_simple', violation_summary)
+        FROM cts_forms_report
+        WHERE (
+            create_date >= date_trunc('week', CURRENT_TIMESTAMP - interval '4 week') and
+            create_date < date_trunc('week', CURRENT_TIMESTAMP)
+        )
+    $$)
+    ORDER BY ndoc DESC
+    LIMIT  10)
+    UNION
+    -- get this year
+    (SELECT
+        word,
+        ndoc as document_count,
+        nentry as word_count,
+        date_trunc('year', CURRENT_TIMESTAMP) as start_date,
+        CURRENT_TIMESTAMP as end_date,
+        'year' as record_type,
+        row_number() OVER (PARTITION BY true) as id
+    FROM ts_stat($$
+        SELECT to_tsvector('english_simple', violation_summary)
+        FROM cts_forms_report
+        WHERE (create_date >= date_trunc('year', CURRENT_TIMESTAMP))
+    $$)
+    ORDER BY ndoc DESC
+    LIMIT  10)
+    ORDER BY start_date, document_count DESC
+;
+"""
+
+def make_view(apps,schema_editor):
+   with connection.cursor() as cursor:
+      cursor.execute(sql_create_statement)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cts_forms', '0072_contact_phone_message'),
+    ]
+
+    operations = [
+       migrations.RunPython(make_view)
+
+    ]

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -270,3 +270,18 @@ class Report(models.Model):
 
     def get_absolute_url(self):
         return reverse('crt_forms:crt-forms-show', kwargs={"id": self.id})
+
+
+class Trends(models.Model):
+    """see the top 10 non-stop words from violation summary """
+    word = models.TextField()
+    document_count = models.IntegerField()
+    word_count = models.IntegerField()
+    start_date = models.DateTimeField()
+    end_date = models.DateTimeField()
+    record_type = models.TextField()
+
+    class Meta:
+        """This model is tied to a view created from migration 73"""
+        managed = False
+        db_table = 'trends'

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -16,7 +16,7 @@
     <div class="grid-row margin-bottom-1">
       <div class="tablet:grid-col-4 grid-offset-1 padding-left-05">
         <div class="display-flex">
-          <a class="outline-button outline-button--dark" href="/form/view{{ return_url_args }}">
+          <a class="outline-button outline-button--dark" href="{% url 'crt_forms:crt-forms-index' %}{{ return_url_args }}">
             <img src="{% static "img/intake-icons/ic_arrow_forward.svg" %}" alt="back arrow" class="icon">
             Back to all
           </a>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/trends.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/trends.html
@@ -37,6 +37,7 @@
         <h3>Methodology</h3>
         <p>Document count is the number of complaints that the word appears in. Word count is the total number of times that word appears.</p>
         <p>The data is based on creation dates. Time periods start on Sunday, except for year. The cutoff is midnight GMT.</p>
+        <p>There my be variations in the document count and search results. For the search, results will be shown for variations on a word, so "pet" and "pets" will show up on the view all table if you search for "pet" or "pets" in the description. The counts on this page are using exact word matches, so "pet" and "pets" will be counted separately. Capitalization is not a factor when searching or counting so searching "Pet" will not be different than "pet". The counts for this page are also optimized for English characters.</p>
       </div>
     </div>
   </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/trends.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/trends.html
@@ -1,0 +1,40 @@
+{% extends "forms/complaint_view/intake_base.html" %}
+
+{%block content %}
+<div class="complaint-show-body">
+  <div class="grid-container">
+    <div class="display-flex flex-align-center details-id">
+      <h2 class="margin-right-205 margin-top-0 margin-bottom-0 backend-blue">
+        Trends
+      </h2>
+    </div>
+    <div class="crt-portal-card">
+      <div class="crt-portal-card__content">
+        <h2>This week</h2>
+        {% include 'forms/snippets/trend_table.html' with trend=this_week label='Top words for this week' date_id="#week-start" %}
+      </div>
+    </div>
+    <div class="crt-portal-card">
+      <div class="crt-portal-card__content">
+        <h2>Last week</h2>
+        {% include 'forms/snippets/trend_table.html' with trend=last_week label='Top words for last week' date_id="#last-week-start"%}
+      </div>
+    </div>
+    <div class="crt-portal-card">
+      <div class="crt-portal-card__content">
+        <h2>Past four weeks</h2>
+        {% include 'forms/snippets/trend_table.html' with trend=four_weeks label='Top words for the past four weeks' date_id="#four-weeks-start"%}
+      </div>
+    </div>
+    <div class="crt-portal-card">
+      <div class="crt-portal-card__content">
+        <h2>This year</h2>
+        {% include 'forms/snippets/trend_table.html' with trend=year label='Top words for this year' date_id="year-start"%}
+
+        <p>Document count is the number of complaints that the word appears in. Word count is the total number of times that word appears.</p>
+        <p>The data is based on creation dates. Time periods start on Sunday, except for year. The cutoff is midnight GMT.</p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/trends.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/trends.html
@@ -30,7 +30,11 @@
       <div class="crt-portal-card__content">
         <h2>This year</h2>
         {% include 'forms/snippets/trend_table.html' with trend=year label='Top words for this year' date_id="year-start"%}
-
+      </div>
+    </div>
+    <div class="crt-portal-card">
+      <div class="crt-portal-card__content">
+        <h3>Methodology</h3>
         <p>Document count is the number of complaints that the word appears in. Word count is the total number of times that word appears.</p>
         <p>The data is based on creation dates. Time periods start on Sunday, except for year. The cutoff is midnight GMT.</p>
       </div>

--- a/crt_portal/cts_forms/templates/forms/snippets/trend_table.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/trend_table.html
@@ -1,0 +1,25 @@
+
+<p id="{{ date_id }}">Start date {{ trend.0.start_date|date:'F j, Y' }}</p>
+<table aria-label="{{ label }}" aria-describedby="{{ date_id }}" class="usa-table usa-table--borderless">
+  <thead>
+    <tr>
+      <th>Word</th>
+      <th>Document count</th>
+      <th>Word count</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for record in trend %}
+      <tr>
+        <td><a aria-label="see matching records" href="{% url 'crt_forms:crt-forms-index' %}?violation_summary={{ record.word }}&create_date_start={{  trend.0.start_date|date:'Ymd' }}
+        {% if date_id == '#last-week-start' %}
+          &create_date_end={{ trend.0.end_date|date:'Ymd' }}
+        {% endif %}">
+          {{ record.word }}
+        </a></td>
+        <td>{{ record.document_count }}</td>
+        <td>{{ record.word_count }}</td>
+      <tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -11,5 +11,5 @@ urlpatterns = [
     path('view/', IndexView, name='crt-forms-index'),
     path('new/', ProFormView.as_view([ProForm]), name='crt-pro-form'),
     path('comment/report/<int:report_id>/', SaveCommentView.as_view(), name='save-report-comment'),
-    path('trends', TrendView.as_view(), name='trends'),
+    path('trends/', TrendView.as_view(), name='trends'),
 ]

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import IndexView, ShowView, ProFormView, SaveCommentView
+from .views import IndexView, ShowView, ProFormView, SaveCommentView, TrendView
 from .forms import ProForm
 
 app_name = 'crt_forms'
@@ -10,5 +10,6 @@ urlpatterns = [
     path('view/<int:id>/', ShowView.as_view(), name='crt-forms-show'),
     path('view/', IndexView, name='crt-forms-index'),
     path('new/', ProFormView.as_view([ProForm]), name='crt-pro-form'),
-    path('comment/report/<int:report_id>/', SaveCommentView.as_view(), name='save-report-comment')
+    path('comment/report/<int:report_id>/', SaveCommentView.as_view(), name='save-report-comment'),
+    path('trends', TrendView.as_view(), name='trends'),
 ]

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -681,7 +681,6 @@ class TrendView(LoginRequiredMixin, TemplateView):
     template_name = "forms/complaint_view/trends.html"
 
     def get_context_data(self, **kwargs):
-        print (Trends.objects.all())
         return {
             'this_week': Trends.objects.filter(record_type='this_week'),
             'last_week': Trends.objects.filter(record_type='last_week'),

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -26,7 +26,7 @@ from .model_variables import (COMMERCIAL_OR_PUBLIC_PLACE_DICT,
                               PRIMARY_COMPLAINT_CHOICES_TO_EXAMPLES,
                               PUBLIC_OR_PRIVATE_EMPLOYER_DICT,
                               PUBLIC_OR_PRIVATE_SCHOOL_DICT)
-from .models import CommentAndSummary, Report
+from .models import CommentAndSummary, Report, Trends
 from .page_through import pagination
 
 SORT_DESC_CHAR = '-'
@@ -675,3 +675,16 @@ class CRTReportWizard(SessionWizardView):
                 'ordered_step_names': self.ORDERED_STEP_NAMES
             },
         )
+
+
+class TrendView(LoginRequiredMixin, TemplateView):
+    template_name = "forms/complaint_view/trends.html"
+
+    def get_context_data(self, **kwargs):
+        print (Trends.objects.all())
+        return {
+            'this_week': Trends.objects.filter(record_type='this_week'),
+            'last_week': Trends.objects.filter(record_type='last_week'),
+            'four_weeks': Trends.objects.filter(record_type='four_weeks'),
+            'year': Trends.objects.filter(record_type='year'),
+        }

--- a/pa11y_scripts/.crt-privacy-policy.json
+++ b/pa11y_scripts/.crt-privacy-policy.json
@@ -1,11 +1,11 @@
 {
-    "urls": [
-      {
-        "url": "http://127.0.0.1:8000/privacy-policy",
-        "actions": [
-          "wait for element #privacy-act-statement to be visible"
-        ],
-        "screenCapture": "pa11y-screenshots/crt-privacy-policy.png"
-      }
-    ]
-  }
+  "urls": [
+    {
+      "url": "http://127.0.0.1:8000/privacy-policy",
+      "actions": [
+        "wait for element #privacy-act-statement to be visible"
+      ],
+      "screenCapture": "pa11y-screenshots/crt-privacy-policy.png"
+    }
+  ]
+}

--- a/pa11y_scripts/.crt-trends.json
+++ b/pa11y_scripts/.crt-trends.json
@@ -1,0 +1,16 @@
+{
+    "urls": [
+        {
+          "useIncognitoBrowserContext": true,
+          "url": "http://127.0.0.1:8000/form/trends/",
+          "actions": [
+            "wait for url to be http://127.0.0.1:8000/accounts/login/?next=/form/trends/",
+            "set field #id_username to pa11y_tester",
+            "set field #id_password to imposing40Karl5monomial",
+            "click #login",
+            "wait for url to be http://127.0.0.1:8000/form/trends/"
+          ],
+          "screenCapture": "pa11y-screenshots/crt-trends.png"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:a11y-view": "pa11y-ci --config pa11y_scripts/.crt-view.json",
     "test:a11y-crt-new": "pa11y-ci --config pa11y_scripts/.crt-new.json",
     "test:a11y-crt-details": "pa11y-ci --config pa11y_scripts/.crt-details.json",
+    "test:a11y-crt-trends": "pa11y-ci --config pa11y_scripts/.crt-trends.json",
     "test:a11y-crt-privacy": "pa11y-ci --config pa11y_scripts/.crt-privacy-policy.json",
     "test:a11y-crt-landing": "pa11y-ci --config pa11y_scripts/.crt-landing.json",
 


### PR DESCRIPTION
This creates a view at /form/trends 

It displays data from a sql view to show the top 10 words for: this week, last week, the past four weeks and year to date.

The table lists the words, document count, word count.
The words link to the matching records.
There is an explanation of the methodology and why search results and document counts might not be the same. 

There is an A11y test but I did not add that as a gate to build the app, since those have been flakey lately.

## Screenshots (for front-end PR):
![crt-trends](https://user-images.githubusercontent.com/4406333/83461445-a2c44500-a41d-11ea-98de-68de4b793808.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
