### PR TITLE
Fix for review card buttons on mobile breaking back/next

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_data.html
+++ b/crt_portal/cts_forms/templates/forms/report_data.html
@@ -1,7 +1,9 @@
 {% load i18n %}
 <div class="crt-portal-card">
     <div class="crt-portal-card__content margin-bottom-3">
+      <div class="button--review">
         {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.0 step_value=0 %}
+      </div>
 
         <h2 class="h1 margin-top-0 margin-bottom-0">{{ordered_step_names.0}}</h2>
 
@@ -33,7 +35,9 @@
 
 <div class="crt-portal-card">
   <div class="crt-portal-card__content margin-bottom-3">
+    <div class="button--review">
     {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.1 step_value=1 %}
+    </div>
 
     <h2 class="h1 margin-top-0">{{ordered_step_names.1}}</h2>
 
@@ -51,6 +55,7 @@
   <div class="crt-portal-card__content margin-bottom-3">
     {# buttons to the right form page based on data present #}
 
+    <div class="button--review">
     {% if report.election_details %}
       {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.2 step_value=3 %}
 
@@ -68,8 +73,8 @@
 
     {% else %}
       {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.2 step_value=2 %}
-    {% endif %}
-
+  {% endif %}
+  </div>
 
     <h2 class="h1 margin-top-0">{{ ordered_step_names.2 }}</h2>
 
@@ -122,7 +127,9 @@
 
 <div class="crt-portal-card">
     <div class="crt-portal-card__content margin-bottom-3">
+      <div class="button--review">
         {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.3 step_value=9 %}
+      </div>
 
         <h2 class="h1 margin-top-0">{{ ordered_step_names.3 }}</h2>
 
@@ -145,8 +152,9 @@
 
 <div class="crt-portal-card">
     <div class="crt-portal-card__content margin-bottom-3">
+      <div class="button--review">
         {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.4 step_value=10 %}
-
+      </div>
         <h2 class="h1 margin-top-0">{{ ordered_step_names.4 }}</h2>
 
         <h3 class="crt-portal-card__subheader">{{ question.date.date_title }}</h3>
@@ -156,8 +164,9 @@
 
 <div class="crt-portal-card">
     <div class="crt-portal-card__content margin-bottom-3">
+      <div class="button--review">
         {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.5 step_value=11 %}
-
+      </div>
         <h2 class="h1 margin-top-0">{{ ordered_step_names.5 }}</h2>
 
         <h3 class="crt-portal-card__subheader">{{ question.summary }}</h3>

--- a/crt_portal/static/sass/custom/buttons.scss
+++ b/crt_portal/static/sass/custom/buttons.scss
@@ -40,7 +40,7 @@ button#login {
     position: relative; // won't change display of card but will allow absolute positioning of button
     padding-bottom: units($spacer-6x); // to accommodate button
   }
-  button[name='wizard_goto_step'] {
+  .button--review {
     position: absolute;
     width: 88%;
     bottom: units($spacer-3x);


### PR DESCRIPTION
## What does this change?
- give the buttons on the report_data page a class so they're the only buttons targeted by the mobile rule

## Screenshots (for front-end PR):
<img width="434" alt="Screen Shot 2020-06-10 at 6 18 24 PM" src="https://user-images.githubusercontent.com/509309/84331231-e5390080-ab46-11ea-8be3-af10f768988f.png">
<img width="418" alt="Screen Shot 2020-06-10 at 6 18 16 PM" src="https://user-images.githubusercontent.com/509309/84331233-e5d19700-ab46-11ea-8a64-c3a3f884ec89.png">

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
