### PR TITLE
Add toll-free number to footer

### DIFF
--- a/crt_portal/cts_forms/templates/partials/footer.html
+++ b/crt_portal/cts_forms/templates/partials/footer.html
@@ -28,9 +28,10 @@
             <img src="{% static "img/phone.svg" %}" alt="phone" class="icon">
           </div>
           <div id="phone-footer" class="usa-footer__links">
-            <a href="tel:202-514-3847">(202) 514-3847</a>
+            <p><a href="tel:202-514-3847">(202) 514-3847</a></p>
+            <p><a href="tel:1-855-856-1247">1-855-856-1247</a> {% trans '(toll-free)' %}</p>
             <p>{% trans 'Telephone Device for the Deaf' %}</p>
-            <p>{% trans '(TTY)' %}<a href="tel:202-514-0716">(202) 514-0716</a></p>
+            <p>{% trans '(TTY)' %} <a href="tel:202-514-0716">(202) 514-0716</a></p>
           </div>
         </div>
 


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?
Adds toll-free number to footer throughout site

TODO: Need translations for `(toll-free)`
## Screenshots (for front-end PR):
![Screen Shot 2020-06-11 at 8 55 30 AM](https://user-images.githubusercontent.com/3485564/84387756-81075280-abc1-11ea-8dfd-64602db6d3a1.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
