### PR TITLE
Render dashes for missing date parts on report listView

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -63,7 +63,7 @@
 
         <td>
           <a class="td-link display-block" href="{{datum.url}}">
-            {{ datum.report.last_incident_month }}/{% if datum.report.last_incident_day %}{{datum.report.last_incident_day}}{%else%}-{% endif %}/{{ datum.report.last_incident_year }}
+            {{ datum.report.last_incident_month|default:"-" }}/{{datum.report.last_incident_day|default:"-"}}/{{ datum.report.last_incident_year|default:"-" }}
           </a>
         </td>
       </tr>

--- a/crt_portal/cts_forms/templates/forms/report_data.html
+++ b/crt_portal/cts_forms/templates/forms/report_data.html
@@ -158,7 +158,7 @@
         <h2 class="h1 margin-top-0">{{ ordered_step_names.4 }}</h2>
 
         <h3 class="crt-portal-card__subheader">{{ question.date.date_title }}</h3>
-        <p>{{ report.last_incident_month }}/{{ report.last_incident_day|default:"—" }}/{{ report.last_incident_year}}</p>
+        <p>{{ report.last_incident_month|default:"—" }}/{{ report.last_incident_day|default:"—" }}/{{ report.last_incident_year|default:"—"}}</p>
     </div>
 </div>
 


### PR DESCRIPTION
Continuation of [Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/404)

## What does this change?
Replaces `None` with dashes when rendering Incident Date in the report list view.

## Screenshots (for front-end PR):
![Screen Shot 2020-06-11 at 12 16 32 PM](https://user-images.githubusercontent.com/3485564/84412640-870b2c80-abdd-11ea-83f1-95e7a4d03642.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
