### PR TITLE
hotfix: fix mobile gap CSS issue

### DIFF
--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -160,6 +160,8 @@ $arrow-height: 24px;
 
   @include at-media-max(mobile-lg) {
     background-image: url(../../img/landing-page-hero-mobile.png);
+    background-size: cover; // avoid unsightly mobile gap
+    background-color: #436eac;
     min-height: 600px;
     color: color('white');
     .h1__display {


### PR DESCRIPTION
[Link to Github issue.](https://github.com/18F/crt-portal/issues/559#issuecomment-644255865)

## What does this change?

Fixes unsightly gap when mobile view is <400px.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
