### PR TITLE
Revert "styling: fix padding"

### DIFF
--- a/crt_portal/static/sass/custom/card.scss
+++ b/crt_portal/static/sass/custom/card.scss
@@ -29,9 +29,8 @@
 
   &__content {
     @include u-margin-bottom(1);
-    @include u-padding-x(7);
-    @include u-padding-bottom(6);
-    @include u-padding-top(5);
+    @include u-padding-y(1.5);
+    @include u-padding-x(3);
 
     &--sm {
       @include u-padding-top(3);


### PR DESCRIPTION
This reverts commit 712b63e831fddf5232d98b3b2a2256b2bd3dd01e.

[Link to ZenHub issue.](link-goes-here)

## What does this change?

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
