### PR TITLE
footer attribution

### DIFF
--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -362,6 +362,27 @@
 
 {% endblock %}
 
+{% block footer_extra %}
+  <div class="usa-footer__attribution">
+    <div class="grid-container">
+      <div class="grid-row">
+        <div class="grid-col-12">
+          <div class="usa-footer__logo-subheading">
+            {% trans 'Image attributions' %}
+          </div>
+          <div class="usa-footer__attribution-names">
+            <p>Unsplash: Jacob Le, Paul Stickman, Andre Hunter, Sobhan Joodi, Library of Congress</p>
+            <p>Pexels: Akela Photography, Nicholas Swatz, Asad Photo, Cottonbro</p>
+            <p>Flickr: Kelly Johnson Revolutionary Photography, The U.S. National Archives</p>
+            <p>Wikimedia Commons Public Domain</p>
+            <p>Cover art by Aviva Oskow</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock footer_extra %}
+
 {% block page_js %}
   <script nonce="{{ request.csp_nonce }}">
    var examples = document.getElementById("crt-landing--examples");

--- a/crt_portal/cts_forms/templates/partials/footer.html
+++ b/crt_portal/cts_forms/templates/partials/footer.html
@@ -104,22 +104,5 @@
         </div>
       </div>
     </div>
-
-    <div class="grid-row grid-gap">
-      <div class="grid-col-12 usa-footer__attribution">
-        <div class="usa-footer__logo-subheading">
-          {% trans 'Photo attributions' %}
-        </div>
-        <div class="usa-footer__separator"></div>
-        <div class="usa-footer__attribution-names">
-          <p>Unsplash: Jacob Le, Paul Stickman, Andre Hunter, Sobhan Joodi, Library of Congress</p>
-          <p>Pexels: Akela Photography, Nicholas Swatz, Asad Photo, Cottonbro</p>
-          <p>Flickr: Kelly Johnson Revolutionary Photography, The U.S. National Archives</p>
-          <p>Wikimedia Commons Public Domain</p>
-          <p>Cover art by Aviva Oskow</p>
-        </div>
-      </div>
-    </div>
-
   </div>
 </div>

--- a/crt_portal/cts_forms/templates/partials/footer.html
+++ b/crt_portal/cts_forms/templates/partials/footer.html
@@ -103,7 +103,23 @@
           </a>
         </div>
       </div>
-
     </div>
+
+    <div class="grid-row grid-gap">
+      <div class="grid-col-12 usa-footer__attribution">
+        <div class="usa-footer__logo-subheading">
+          {% trans 'Photo attributions' %}
+        </div>
+        <div class="usa-footer__separator"></div>
+        <div class="usa-footer__attribution-names">
+          <p>Unsplash: Jacob Le, Paul Stickman, Andre Hunter, Sobhan Joodi, Library of Congress</p>
+          <p>Pexels: Akela Photography, Nicholas Swatz, Asad Photo, Cottonbro</p>
+          <p>Flickr: Kelly Johnson Revolutionary Photography, The U.S. National Archives</p>
+          <p>Wikimedia Commons Public Domain</p>
+          <p>Cover art by Aviva Oskow</p>
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>

--- a/crt_portal/cts_forms/templates/partials/footer.html
+++ b/crt_portal/cts_forms/templates/partials/footer.html
@@ -103,6 +103,7 @@
           </a>
         </div>
       </div>
+
     </div>
   </div>
 </div>

--- a/crt_portal/static/sass/custom/footer.scss
+++ b/crt_portal/static/sass/custom/footer.scss
@@ -143,3 +143,14 @@ footer {
     text-transform: none;
   }
 }
+
+.usa-footer__attribution {
+  margin: 1rem 0;
+  &-names {
+    margin: 1rem 0;
+  }
+  p {
+    margin: 0.1rem 0;
+    font-size: 0.9rem;
+  }
+}

--- a/crt_portal/static/sass/custom/footer.scss
+++ b/crt_portal/static/sass/custom/footer.scss
@@ -145,12 +145,15 @@ footer {
 }
 
 .usa-footer__attribution {
-  margin: 1rem 0;
+  background-color: color('gray-warm-90');
+  color: color('white');
+  padding: 2.5rem 0;
+
   &-names {
-    margin: 1rem 0;
+    margin: 0.5rem 0;
   }
   p {
-    margin: 0.1rem 0;
-    font-size: 0.9rem;
+    @include text--body-copy__small();
+    margin: 0;
   }
 }


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/548)

## What does this change?

Adds attribution for the front page collage image (mobile, tablet, and full screen versions) in the footer.

## Screenshots (for front-end PR):

![2020-06-19_14-57](https://user-images.githubusercontent.com/3013175/85182390-5cece680-b23d-11ea-892f-d090feb2f255.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
