### PR TITLE
Tweaking new relic initialization

### DIFF
--- a/crt_portal/crt_portal/wsgi.py
+++ b/crt_portal/crt_portal/wsgi.py
@@ -13,6 +13,8 @@ import json
 import logging
 logger = logging.getLogger(__name__)
 
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'crt_portal.settings')
+
 
 def get_newrelic_key():
     """
@@ -21,27 +23,28 @@ def get_newrelic_key():
     """
     environment = os.environ.get('ENV', 'UNDEFINED')
     if environment in ['STAGE', 'DEVELOP', 'PRODUCTION']:
+        logger.warning('Looking for New Relic key...')
         vcap = json.loads(os.environ['VCAP_SERVICES'])
         for service in vcap['user-provided']:
             if service['instance_name'] == "VCAP_SERVICES":
-                return service['credentials']['NEW_RELIC_LICENSE_KEY']
+                key = service['credentials'].get('NEW_RELIC_LICENSE_KEY')
+                if not key:
+                    logger.warning('No New Relic Key found')
+                return key
 
 
 def initialize_newrelic():
     """Initialize NewRelic instrumentation if we have a key"""
     license_key = get_newrelic_key()
-
     if license_key:
-        logger.info('New Relic key found, initializing...')
+        logger.warning('New Relic key found, initializing...')
         settings = newrelic.agent.global_settings()
         settings.license_key = license_key
         newrelic.agent.initialize()
-        logger.info('New Relic initialized')
+        logger.warning('New Relic initialized')
 
 
 initialize_newrelic()
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'crt_portal.settings')
 
 from django.core.wsgi import get_wsgi_application # noqa
 

--- a/crt_portal/crt_portal/wsgi.py
+++ b/crt_portal/crt_portal/wsgi.py
@@ -7,14 +7,10 @@ For more information on this file, see
 https://docs.djangoproject.com/en/2.2/howto/deployment/wsgi/
 """
 
+import newrelic.agent
 import os
 import json
 import logging
-
-from django.core.wsgi import get_wsgi_application
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'crt_portal.settings')
-
 logger = logging.getLogger(__name__)
 
 
@@ -36,7 +32,6 @@ def initialize_newrelic():
     license_key = get_newrelic_key()
 
     if license_key:
-        import newrelic.agent
         logger.info('New Relic key found, initializing...')
         settings = newrelic.agent.global_settings()
         settings.license_key = license_key
@@ -45,5 +40,9 @@ def initialize_newrelic():
 
 
 initialize_newrelic()
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'crt_portal.settings')
+
+from django.core.wsgi import get_wsgi_application # noqa
 
 application = get_wsgi_application()

--- a/manifest_dev.yaml
+++ b/manifest_dev.yaml
@@ -8,8 +8,9 @@ applications:
   env:
     ENV: DEVELOP
     NEW_RELIC_CONFIG_FILE: /root/code/newrelic.ini
-    NEW_RELIC_ENV: dev
+    NEW_RELIC_ENVIRONMENT: dev
     NEW_RELIC_LOG: stdout
+    NEW_RELIC_APP_NAME: CRT PORTAL (dev)
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack

--- a/manifest_dev.yaml
+++ b/manifest_dev.yaml
@@ -7,7 +7,7 @@ applications:
   instances: 1
   env:
     ENV: DEVELOP
-    NEW_RELIC_CONFIG_FILE: /root/code/newrelic.ini
+    NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
     NEW_RELIC_ENVIRONMENT: dev
     NEW_RELIC_LOG: stdout
     NEW_RELIC_APP_NAME: CRT PORTAL (dev)

--- a/manifest_dev.yaml
+++ b/manifest_dev.yaml
@@ -7,7 +7,7 @@ applications:
   instances: 1
   env:
     ENV: DEVELOP
-    NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
+    NEW_RELIC_CONFIG_FILE: /root/code/newrelic.ini
     NEW_RELIC_ENV: dev
     NEW_RELIC_LOG: stdout
   buildpacks:

--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -11,7 +11,7 @@ applications:
     ENV: PRODUCTION
     AUTH_RELYING_PARTY_ID: "crt-portal-django-prod.app.cloud.gov"
     AUTH_AUDIENCE: "microsoft:identityserver:crt-portal-django-prod.app.cloud.gov"
-    NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
+    NEW_RELIC_CONFIG_FILE: /root/code/newrelic.ini
     NEW_RELIC_ENV: production
     NEW_RELIC_LOG: stdout
   buildpacks:

--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -11,8 +11,9 @@ applications:
     ENV: PRODUCTION
     AUTH_RELYING_PARTY_ID: "crt-portal-django-prod.app.cloud.gov"
     AUTH_AUDIENCE: "microsoft:identityserver:crt-portal-django-prod.app.cloud.gov"
-    NEW_RELIC_CONFIG_FILE: /root/code/newrelic.ini
-    NEW_RELIC_ENV: production
+    NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
+    NEW_RELIC_ENVIRONMENT: production
+    NEW_RELIC_APP_NAME: CRT PORTAL (prod)
     NEW_RELIC_LOG: stdout
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -11,7 +11,8 @@ applications:
     AUTH_RELYING_PARTY_ID: "crt-portal-django-stage.app.cloud.gov"
     AUTH_AUDIENCE: "microsoft:identityserver:crt-portal-django-stage.app.cloud.gov"
     NEW_RELIC_CONFIG_FILE: /root/code/newrelic.ini
-    NEW_RELIC_ENV: staging
+    NEW_RELIC_ENVIRONMENT: staging
+    NEW_RELIC_APP_NAME: CRT PORTAL (stage)
     NEW_RELIC_LOG: stdout
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -10,7 +10,7 @@ applications:
     FORM_AUTOCOMPLETE_OFF: True
     AUTH_RELYING_PARTY_ID: "crt-portal-django-stage.app.cloud.gov"
     AUTH_AUDIENCE: "microsoft:identityserver:crt-portal-django-stage.app.cloud.gov"
-    NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
+    NEW_RELIC_CONFIG_FILE: /root/code/newrelic.ini
     NEW_RELIC_ENV: staging
     NEW_RELIC_LOG: stdout
   buildpacks:

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -10,7 +10,7 @@ applications:
     FORM_AUTOCOMPLETE_OFF: True
     AUTH_RELYING_PARTY_ID: "crt-portal-django-stage.app.cloud.gov"
     AUTH_AUDIENCE: "microsoft:identityserver:crt-portal-django-stage.app.cloud.gov"
-    NEW_RELIC_CONFIG_FILE: /root/code/newrelic.ini
+    NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
     NEW_RELIC_ENVIRONMENT: staging
     NEW_RELIC_APP_NAME: CRT PORTAL (stage)
     NEW_RELIC_LOG: stdout


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/61)

## What does this change?
Initializing newrelic as early as possible per https://docs.newrelic.com/docs/agents/python-agent/installation/python-agent-advanced-integration#manual-integration

Updating, hopefully correcting, path to `newrelic.ini` file.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
