### PR TITLE
Show other text when rendering page if it's selected

### DIFF
--- a/crt_portal/static/js/other_show_hide.js
+++ b/crt_portal/static/js/other_show_hide.js
@@ -43,7 +43,10 @@
     }
 
     parentEl.addEventListener('click', toggleOtherOptionTextInput);
-    otherOptionTextEl.setAttribute('hidden', '');
+
+    if (!otherOptionFormEl.checked) {
+      otherOptionTextEl.setAttribute('hidden', '');
+    }
   };
 
   return root;


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?
If `Other` checkbox is selected when navigating to a form page, don't the associated hide the text input element.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
