### PR TITLE
Bump gunicorn timeout to 60 seconds

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 # used by cloud.gov
-web: cd crt_portal && python manage.py migrate && python manage.py compilemessages && python manage.py collectstatic --noinput && gunicorn crt_portal.wsgi
+web: cd crt_portal && python manage.py migrate && python manage.py compilemessages && python manage.py collectstatic --noinput && gunicorn crt_portal.wsgi -t 60


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/603)

## What does this change?
Increases gunicorn timeout to 60 seconds

## Why?
The trends data is calculated on each request/page load, the time necessary to generate that data increases as the number of records, and the size of the total set of "violation summary" data grows.

At the moment, we're often hitting the default timeout for gunicorn (30 seconds). This is an immediate intervention to return functionality to the feature. 

Looking ahead we should look at alternative approaches to generate trends data periodically instead of on-demand.


Generating 
## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
