### PR TITLE
View-only Report admin w/ export

### DIFF
--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -1,9 +1,61 @@
-from django.contrib import admin
+import csv
 
-from .models import CommentAndSummary, Report, ProtectedClass, HateCrimesandTrafficking, ResponseTemplate
+from django.contrib import admin
+from django.http import StreamingHttpResponse
+
+from .models import (CommentAndSummary, HateCrimesandTrafficking,
+                     ProtectedClass, Report, ResponseTemplate)
+
+
+class Echo:
+    """An object that implements just the write method of the file-like
+    interface.
+    """
+    def write(self, value):
+        """Write the value by returning it, instead of storing in a buffer."""
+        return value
+
+
+def export_as_csv(modeladmin, request, queryset):
+    """Stream all fields of selected reports as CSV"""
+    pseudo_buffer = Echo()
+    writer = csv.writer(pseudo_buffer)
+    headers = [field.name for field in Report._meta.fields]
+    rows = [headers]
+    for report in queryset:
+        rows.append([getattr(report, field) for field in headers])
+    response = StreamingHttpResponse((writer.writerow(row) for row in rows),
+                                     content_type="text/csv")
+    response['Content-Disposition'] = 'attachment; filename="somefilename.csv"'
+    return response
+export_as_csv.allowed_permissions = ('view',)  # noqa
+
+
+class ReportAdmin(admin.ModelAdmin):
+    """
+    View-only report admin providing filtering and export functionality
+    """
+    list_display = ['public_id', 'status', 'assigned_section', 'create_date', 'modified_date', 'assigned_to']
+    list_filter = ['status', 'create_date', 'modified_date', 'assigned_section', 'servicemember',
+                   'hate_crime', 'primary_complaint', 'assigned_to']
+    ordering = ['public_id']
+    actions = [export_as_csv]
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        return request.user.is_superuser
+
 
 admin.site.register(CommentAndSummary)
-admin.site.register(Report)
+admin.site.register(Report, ReportAdmin)
 admin.site.register(ProtectedClass)
 admin.site.register(HateCrimesandTrafficking)
 admin.site.register(ResponseTemplate)


### PR DESCRIPTION


[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/598)

## What does this change?
We provide a read-only admin interface to reports
and a [custom django admin action](https://docs.djangoproject.com/en/2.2/ref/contrib/admin/actions/#writing-actions) to export selected reports as csv. 
Logging all usage.

This functionality is only available to superusers (system administrators).

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
