### PR TITLE
added privacy policy footer, and subsequent translation

### DIFF
--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-19 21:12+0000\n"
+"POT-Creation-Date: 2020-07-01 19:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2027,6 +2027,10 @@ msgstr ""
 "\"tel:800-285-2221\">(800) 285-2221</a> para localizar a un abogado a través "
 "del Colegio de Abogados Estadounidense. "
 
+#: templates/landing.html:371
+msgid "Image attributions"
+msgstr ""
+
 #: templates/partials/footer.html:32
 msgid "(toll-free)"
 msgstr "(gratis)"
@@ -2289,7 +2293,7 @@ msgstr ""
 "                    "
 
 # don't have this
-#: templates/privacy.html:97 templates/privacy.html:163
+#: templates/privacy.html:97 templates/privacy.html:168
 msgid "Return to top"
 msgstr "Volver al principio"
 
@@ -2493,6 +2497,25 @@ msgstr ""
 "                    <li>Leyes de Derechos Civiles de 1870, 1957, 1960 y "
 "1964</li>\n"
 "                    "
+
+#: templates/privacy.html:162
+msgid ""
+"\n"
+"                The full list of routine uses for this correspondence can be "
+"found in the System of Records Notice titled, JUSTICE/CRT – 001, \"Central "
+"Civil Rights Division Index File and Associated Records\", 68 Fed. Reg. "
+"47610, 611 (8-11-2003); 70 Fed. Reg. 43904 (7-29-2005); 72 Fed. Reg. 3410 "
+"(1-25-2007) (rescinded by 82 FR 24147); 82 Fed. Reg. 24147 (5-25-2017).\n"
+"                "
+msgstr ""
+"\n"
+"                La lista de usos rutinarios para esta correspondencia se "
+"encuentra en la Notificación del Sistema de Registros bajo el título JUSTICE/"
+"CRT – 001, \"Central Civil Rights Division Index File and Associated Records"
+"\", 68 Reg. Fed. 47610, 611 (11-8-2003); 70 Reg. Fed. 43904 (29-7-2005); 72 "
+"Reg. Fed. 3410 (25-1-2007) (rescindido por 82 FR 24147); 82 Reg. Fed. 24147 "
+"(25-5-2017).\n"
+"                "
 
 #: views.py:45
 msgid "Bad request"

--- a/crt_portal/cts_forms/templates/privacy.html
+++ b/crt_portal/cts_forms/templates/privacy.html
@@ -158,6 +158,11 @@
                     <li>Civil Rights Acts of 1870, 1957, 1960, & 1964</li>
                     {% endblocktrans %}
                 </ul>
+                <p>
+                {% blocktrans %}
+                The full list of routine uses for this correspondence can be found in the System of Records Notice titled, JUSTICE/CRT – 001, "Central Civil Rights Division Index File and Associated Records", 68 Fed. Reg. 47610, 611 (8-11-2003); 70 Fed. Reg. 43904 (7-29-2005); 72 Fed. Reg. 3410 (1-25-2007) (rescinded by 82 FR 24147); 82 Fed. Reg. 24147 (5-25-2017).
+                {% endblocktrans %}
+                </p>
             </div>
         </div>
         <!-- <a class="float-right" href="#">{% trans "Return to top" %}</a> -->


### PR DESCRIPTION
[Link to ZenHub issue #559.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/599)

## What does this change?
Adds a blurb to privacy-policy with the Spanish translation.

## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/66343959/86287204-c95cd380-bbb5-11ea-8ccc-9f07b9866f10.png)

## Checklist:

### Author
Haseeb Khalid

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
