### PR TITLE
blue-green-deploy: switch to new org name

### DIFF
--- a/blue-green-deploy.sh
+++ b/blue-green-deploy.sh
@@ -11,7 +11,7 @@ SPACE=$3
 # login to the right place
 cf api https://api.fr.cloud.gov;
 cf auth  $CRT_USERNAME  $CRT_PASSWORD;
-cf target -o doj-crtportal-prototyping -s $SPACE;
+cf target -o doj-crtportal -s $SPACE;
 
 
 # Deploy a new app called crt-portal-django-venerable, if that builds correctly, delete the old app and rename crt-portal-django-venerable to crt-portal-django


### PR DESCRIPTION
No Zenhub issue.

## What does this change?

We are renaming the current cloud.gov org from `doj-crtportal-prototyping` to `doj-crtportal`. This updates the blue-green script (used in CircleCI) to match the new org name. 

## Checklist:

### Author

+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
