### PR TITLE
fix hover shades

### DIFF
--- a/crt_portal/static/sass/_uswds-theme-color.scss
+++ b/crt_portal/static/sass/_uswds-theme-color.scss
@@ -131,3 +131,5 @@ $theme-link-color: $theme-color-primary-darker;
 $theme-link-visited-color: $theme-color-primary-darker;
 $theme-link-hover-color: 'blue-50';
 $theme-link-active-color: 'primary-darker';
+$theme-link-dark-hover-color:       'blue-warm-30v';
+

--- a/crt_portal/static/sass/custom/footer.scss
+++ b/crt_portal/static/sass/custom/footer.scss
@@ -77,7 +77,7 @@ footer {
     text-transform: uppercase;
     margin-bottom: 1.5em;
     &:hover {
-      color:color($theme-link-dark-hover-color);
+      color:color($theme-link-dark-hover-color) !important;
     }
     }
 }
@@ -94,7 +94,7 @@ footer {
     vertical-align: middle;
   }
   a:hover {
-    color:color($theme-link-dark-hover-color);
+    color:color($theme-link-dark-hover-color) !important;
   }
 }
 

--- a/crt_portal/static/sass/custom/footer.scss
+++ b/crt_portal/static/sass/custom/footer.scss
@@ -76,7 +76,10 @@ footer {
   a {
     text-transform: uppercase;
     margin-bottom: 1.5em;
-  }
+    &:hover {
+      color:color($theme-link-dark-hover-color);
+    }
+    }
 }
 
 .usa-footer__links.usa-footer__language {
@@ -89,6 +92,9 @@ footer {
   a,
   img {
     vertical-align: middle;
+  }
+  a:hover {
+    color:color($theme-link-dark-hover-color);
   }
 }
 

--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -202,6 +202,9 @@ $arrow-height: 24px;
       color: color($theme-color-warning);
       font-weight: bold;
       text-decoration: none;
+      &:hover {
+        color:color($theme-link-dark-hover-color);
+      }  
     }
   }
 
@@ -211,6 +214,9 @@ $arrow-height: 24px;
     a {
       color: color('white');
       font-weight: bold;
+      &:hover {
+        color:color($theme-link-dark-hover-color);
+      }  
     }
   }
 }


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?
Change hover shades to 'blue-warm-30v'

## Screenshots (for front-end PR):
<img width="1040" alt="Screen Shot 2020-07-08 at 2 31 47 PM" src="https://user-images.githubusercontent.com/19350707/86956870-d0d92b00-c127-11ea-97a8-8f3dc5e511d9.png">

## Checklist:

### Author

+ [x ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
