### PR TITLE
#578 hover accordian button changed to lighter background-color

### DIFF
--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -181,7 +181,7 @@
         <div class="tablet:grid-col-12">
           <div class="grid-row grid-gap">
             <div class="tablet:grid-col-7">
-              <ul class="usa-nav__primary usa-accordion crt-landing--blue crt-landing--large_select">
+              <ul class="usa-nav__primary usa-accordion crt-landing--large_select">
                 <li>
                   <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="crt-landing--examples" aria-label="select example">
                     <div id="crt-landing--example_option">

--- a/crt_portal/static/sass/_uswds-theme-color.scss
+++ b/crt_portal/static/sass/_uswds-theme-color.scss
@@ -128,6 +128,6 @@ General colors
 
 // Links
 $theme-link-color: $theme-color-primary-darker;
-$theme-link-visited-color: $theme-color-primary-darker;
+$theme-link-visited-color: $theme-color-primary-darker; 
 $theme-link-hover-color: 'blue-50';
 $theme-link-active-color: 'primary-darker';

--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -331,7 +331,7 @@ $arrow-height: 24px;
       font-weight: normal;
       color: color('white');
       min-height: 5rem;
-      border-radius: 0;
+      border-radius: 4px;
 
       // caret adjustments -- in many cases overriding the USWDS defaults
       background-repeat: no-repeat !important;

--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -331,6 +331,7 @@ $arrow-height: 24px;
       font-weight: normal;
       color: color('white');
       min-height: 5rem;
+      border-radius: 0;
 
       // caret adjustments -- in many cases overriding the USWDS defaults
       background-repeat: no-repeat !important;

--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -349,7 +349,7 @@ $arrow-height: 24px;
       }
 
       &:hover {
-        background-color: color($theme-color-primary-darker) !important;
+        background-color: color($theme-link-hover-color) !important;
       }
     }
   }
@@ -378,7 +378,6 @@ $arrow-height: 24px;
 
       &:hover {
         color: color($theme-color-primary-darker);
-        background: color($theme-color-primary-lighter) !important;
       }
     }
 

--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -336,6 +336,7 @@ $arrow-height: 24px;
       background-repeat: no-repeat !important;
       background-position: right 1.5rem center !important;
       background-size: 1.5rem !important;
+      background-color: color($theme-color-primary-darker);
       width: 100%;
       height: 100%;
       &[aria-expanded='false'] {
@@ -346,6 +347,9 @@ $arrow-height: 24px;
       }
       &[aria-expanded='true'] {
         background-image: url(../../img/angle-arrow-up-white.svg) !important;
+        &:hover {
+          background-image: url(../../img/angle-arrow-up-primary.svg) !important;
+        }
       }
 
       &:hover {


### PR DESCRIPTION
[Link to ZenHub issue #578.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/578)

## What does this change?
Add rollover to drop down on landing page.

## Screenshots (for front-end PR):
![image](https://images.zenhubusercontent.com/5d1a3b0bcc794602e102a513/811a9859-149a-446d-8781-c2462c46ae0c)

## Checklist:

### Author
Haseeb Khalid

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
