### PR TITLE
[deploy release] blue-green-deploy: switch to new org name

### DIFF
--- a/blue-green-deploy.sh
+++ b/blue-green-deploy.sh
@@ -11,7 +11,7 @@ SPACE=$3
 # login to the right place
 cf api https://api.fr.cloud.gov;
 cf auth  $CRT_USERNAME  $CRT_PASSWORD;
-cf target -o doj-crtportal-prototyping -s $SPACE;
+cf target -o doj-crtportal -s $SPACE;
 
 
 # Deploy a new app called crt-portal-django-venerable, if that builds correctly, delete the old app and rename crt-portal-django-venerable to crt-portal-django


### PR DESCRIPTION
We have changed our cloud.gov org name, and this updates the blue-green deploy file accordingly. This cherry picks the change from develop to the release branch. FYI @ilodidoj 