### PR TITLE
Modal redirect link adjustments

### DIFF
--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-19 21:12+0000\n"
+"POT-Creation-Date: 2020-07-13 22:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1565,7 +1565,9 @@ msgstr "Siguiente"
 msgid "previous step"
 msgstr "paso previo"
 
-#: templates/forms/report_base.html:96 templates/forms/report_review.html:35
+#: templates/forms/report_base.html:96
+#: templates/forms/report_hate_crime.html:46
+#: templates/forms/report_review.html:35
 msgid "Back"
 msgstr "Volver"
 
@@ -1593,6 +1595,26 @@ msgstr ""
 #: templates/forms/report_hate_crime.html:18 templates/landing.html:222
 msgid "Get help from the National Human Trafficking Hotline"
 msgstr "Reciba ayuda de la Línea Nacional contra la Trata de Personas"
+
+#: templates/forms/report_hate_crime.html:32
+msgid "You are now leaving the Department of Justice website."
+msgstr "Está saliendo del sitio web del Departamento de Justicia."
+
+#: templates/forms/report_hate_crime.html:37
+msgid "You will automatically be redirected to:"
+msgstr ""
+
+#: templates/forms/report_hate_crime.html:43
+msgid ""
+"The Department of Justice does not endorse the organizations or views "
+"represented by this site and takes no responsibility for, and exercises no "
+"control over, the accuracy, accessibility, copyright or trademark compliance "
+"or legality of the material contained on this site."
+msgstr ""
+"El Departamento de Justicia no respalda las organizaciones o los puntos de "
+"vista representados por este sitio y no se responsabiliza ni ejerce control "
+"sobre la precisión, la accesibilidad, el cumplimiento con los derechos de "
+"autor o marca registrada o la legalidad del material contenido en este sitio."
 
 #: templates/forms/report_review.html:10
 msgid "Before you submit your report, please check your responses"

--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -1602,7 +1602,7 @@ msgstr "Está saliendo del sitio web del Departamento de Justicia."
 
 #: templates/forms/report_hate_crime.html:37
 msgid "You will automatically be redirected to:"
-msgstr ""
+msgstr "Será redirigido automáticamente a:"
 
 #: templates/forms/report_hate_crime.html:43
 msgid ""

--- a/crt_portal/cts_forms/templates/forms/report_hate_crime.html
+++ b/crt_portal/cts_forms/templates/forms/report_hate_crime.html
@@ -28,19 +28,22 @@
     <div class="modal-wrapper">
       <div class="modal-content modal-content--small">
         <div class="modal-header">
-          <h1 class="h2__display">You are now leaving the Department of Justice website.</h1>
+          <h1 class="h2__display">
+            {% trans "You are now leaving the Department of Justice website." %}
+          </h1>
         </div>
         <div class="modal-form">
-          <p>You will automatically be redirected to:
+          <p>
+            {% trans "You will automatically be redirected to:" %}
             <span>
               <a id="external-link--address" href="#"></a>
             </span>
           </p>
           <p class="external-link--disclaimer">
-            The Department of Justice does not endorse the organizations or views represented by this site and takes no responsibility for, and exercises no control over, the accuracy, accessibility, copyright or trademark compliance or legality of the material contained on this site.
+            {% trans "The Department of Justice does not endorse the organizations or views represented by this site and takes no responsibility for, and exercises no control over, the accuracy, accessibility, copyright or trademark compliance or legality of the material contained on this site." %}
           </p>
           <div class="modal-footer">
-            <a id="external-link--cancel" href="#" class="usa-button usa-button--outline button--cancel light-button">Back</a>
+            <a id="external-link--cancel" href="#" class="usa-button usa-button--outline button--cancel light-button">{% trans "Back" %}</a>
           </div>
         </div>
       </div>
@@ -71,7 +74,7 @@
          if (modal_el.getAttribute('hidden') === null) {
            window.location.href = link.href;
          }
-       }, 5000);
+       }, 20000);
      }
      var cancel_modal = document.getElementById('external-link--cancel');
      root.CRT.cancelModal(modal_el, cancel_modal);

--- a/crt_portal/cts_forms/templates/forms/report_hate_crime.html
+++ b/crt_portal/cts_forms/templates/forms/report_hate_crime.html
@@ -44,6 +44,7 @@
           </p>
           <div class="modal-footer">
             <a id="external-link--cancel" href="#" class="usa-button usa-button--outline button--cancel light-button">{% trans "Back" %}</a>
+            <a id="external-link--continue" href="#" class="usa-button button--continue">{% trans "Continue" %}</a>
           </div>
         </div>
       </div>
@@ -75,9 +76,14 @@
            window.location.href = link.href;
          }
        }, 20000);
-     }
+     };
      var cancel_modal = document.getElementById('external-link--cancel');
      root.CRT.cancelModal(modal_el, cancel_modal);
+     var continue_button = document.getElementById('external-link--continue');
+     continue_button.onclick = function(event) {
+       event.preventDefault();
+       window.location.href = link.href;
+     };
    })(window)
   </script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_hate_crime.html
+++ b/crt_portal/cts_forms/templates/forms/report_hate_crime.html
@@ -25,10 +25,10 @@
 
 {% block usa_footer %}
   <div id="external-link--modal" hidden>
-    <div class="modal-wrapper">
+    <div class="modal-wrapper" role="dialog" aria-modal="true" aria-describedby="modal_dialog_header">
       <div class="modal-content modal-content--small">
         <div class="modal-header">
-          <h1 class="h2__display">
+          <h1 id="modal_dialog_header" class="h2__display">
             {% trans "You are now leaving the Department of Justice website." %}
           </h1>
         </div>

--- a/crt_portal/static/sass/custom/buttons.scss
+++ b/crt_portal/static/sass/custom/buttons.scss
@@ -30,8 +30,8 @@ button,
   }
 }
 
-button#login {
-  color: color('white');
+.button--continue, button#login {
+  color: color('white') !important;
 }
 
 // glue the review page edit buttons to the bottom of the card on mobile

--- a/crt_portal/static/sass/custom/modal.scss
+++ b/crt_portal/static/sass/custom/modal.scss
@@ -42,7 +42,7 @@ body.is-modal {
       padding: 2rem;
     }
     @include at-media(desktop) {
-      width: 75%;
+      width: 50%;
       padding: 3rem;
     }
   }


### PR DESCRIPTION
Finishes up [Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/640)

## What does this change?

- Modal pop up translation (es)
- Bumps up modal pop up to 20s instead of 5s
- adding "continue" button if users are ready before hand
- a11y: make sure title/heading reads out when the modal opens.
- 50% desktop size breakpoint

## Screenshots (for front-end PR):

![2020-07-13_16-01](https://user-images.githubusercontent.com/3013175/87361933-2f384c00-c522-11ea-8b7e-3acc64e63300.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
