### PR TITLE
make servicemember and hate_crime query param persistent

### DIFF
--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -122,7 +122,9 @@
     primary_statute: '',
     sort: '',
     page: '',
-    per_page: ''
+    per_page: '',
+    servicemember: '',
+    hate_crime: ''
   };
   var filterDataModel = {};
 


### PR DESCRIPTION
No Zenhub issue yet.

## What does this change?

Adds `servicemember` to the filter state so we don't lose track of it when adding/removing other query parameters or filters.

## Checklist:

### Author

+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
