### PR TITLE
hotfix: temporarily remove report confirmation page

### DIFF
--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -168,15 +168,6 @@
   </div>
 </section>
 
-<section class="submission">
-  <div id="submission" class="grid-container">
-    <div class="submission-content tablet:grid-col-8 tablet:grid-offset-2">
-        <h2 class='h1__display'>{% trans "Your submission" %}</h2>
-        {% include "forms/report_data.html" with ordered_step_names=ordered_step_names question=questions hide_edit_button=True %}
-    </div>
-  </div>
-</section>
-
 {% endblock %}
 
 {% block footer_extra %}

--- a/crt_portal/static/sass/custom/confirmation.scss
+++ b/crt_portal/static/sass/custom/confirmation.scss
@@ -110,7 +110,7 @@ section hr {
 section.what-to-expect {
   @include u-bg($theme-color-primary-lightest);
   @include u-margin-top(5);
-  padding-bottom: 14rem;
+  padding-bottom: 4rem;
 
   .title {
     @include flex-container();


### PR DESCRIPTION
No Zenhub issue. 

## What does this change?

Removes report confirmation page. 

![localhost_8000_report_ (1)](https://user-images.githubusercontent.com/3013175/87595156-f07dcf80-c6a2-11ea-8e67-3a0fd38e97b2.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
