### PR TITLE
[WIP] issue624, remove bold typeface on location of not new complaints

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -48,9 +48,7 @@
         </td>
         <td>
           <a class="td-link display-block" href="{{datum.url}}">
-            <b>
               {{ datum.report.location_city_town }}, {{ datum.report.location_state }}
-            </b>
           </a>
         </td>
         <td>


### PR DESCRIPTION
https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/624

## What does this change?
removes bold typeface on location of not new complaints

## Screenshots (for front-end PR):
<img width="1520" alt="Screen Shot 2020-07-20 at 11 44 30 AM" src="https://user-images.githubusercontent.com/19350707/87957983-f72f8c80-ca7e-11ea-809a-3a2434bccf40.png">

+ [ x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
