### PR TITLE
changed icon to white when hovering based on UAT feedback

### DIFF
--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -342,15 +342,9 @@ $arrow-height: 24px;
       height: 100%;
       &[aria-expanded='false'] {
         background-image: url(../../img/angle-arrow-down-white.svg) !important;
-        &:hover {
-          background-image: url(../../img/angle-arrow-down-primary.svg) !important;
-        }
       }
       &[aria-expanded='true'] {
         background-image: url(../../img/angle-arrow-up-white.svg) !important;
-        &:hover {
-          background-image: url(../../img/angle-arrow-up-primary.svg) !important;
-        }
       }
 
       &:hover {


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/578)

## What does this change?
Changes Icons to white when hovering based on UAT feedback
## Screenshots (for front-end PR):
https://images.zenhubusercontent.com/5efb8164bf9ea016ca6016f2/015f37b6-3d5e-4466-8132-9b34076a921f

https://images.zenhubusercontent.com/5efb8164bf9ea016ca6016f2/660bdcb2-9537-44bc-abd9-aa9b2f0548bb
## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
