### PR TITLE
Spanish updates: unify 911 wording and fix "continue"

### DIFF
--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-13 22:56+0000\n"
+"POT-Creation-Date: 2020-08-04 21:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:154 forms.py:1127
+#: forms.py:154 forms.py:1125
 msgid " - Select - "
 msgstr " - Elija - "
 
@@ -141,11 +141,11 @@ msgstr ""
 "tomar las medidas apropiadas. Si sucedió a lo largo de un período de tiempo "
 "o todavía está sucediendo, favor de indicar la fecha más reciente."
 
-#: forms.py:877
+#: forms.py:876
 msgid "Primary classification"
 msgstr "Clasificación principal"
 
-#: forms.py:896
+#: forms.py:895
 msgid "Assigned to"
 msgstr "Asignado a"
 
@@ -1458,6 +1458,11 @@ msgid "Get help immediately if you are in danger"
 msgstr "Busque ayuda inmediata si está usted en peligro"
 
 #: templates/forms/confirmation.html:161
+#, fuzzy
+#| msgid ""
+#| "If you reported an incident where you or someone else has experienced or "
+#| "is still experiencing physical harm or violence, or are in immediate "
+#| "danger, please call <a href=\"tel:911\">911</a> and contact the police."
 msgid ""
 "If you reported an incident where you or someone else has experienced or is "
 "still experiencing physical harm or violence, or are in immediate danger, "
@@ -1616,6 +1621,12 @@ msgstr ""
 "sobre la precisión, la accesibilidad, el cumplimiento con los derechos de "
 "autor o marca registrada o la legalidad del material contenido en este sitio."
 
+#: templates/forms/report_hate_crime.html:47
+#, fuzzy
+#| msgid "Continued"
+msgid "Continue"
+msgstr "Continúe"
+
 #: templates/forms/report_review.html:10
 msgid "Before you submit your report, please check your responses"
 msgstr "Antes de entregar su informe, favor de comprobar sus respuestas"
@@ -1680,8 +1691,8 @@ msgstr "Informe sobre una vulneración"
 msgid "Already submitted?"
 msgstr "¿Ya nos informó de una vulneración?"
 
-#: templates/landing.html:59 templates/partials/footer.html:9 views.py:558
-#: views.py:614 views.py:633
+#: templates/landing.html:59 templates/partials/footer.html:9 views.py:561
+#: views.py:617 views.py:636
 msgid "Contact"
 msgstr "Contacto"
 
@@ -1725,8 +1736,7 @@ msgstr "o aprenda más sobre <a href=\"#your-rights\">sus derechos</a>"
 
 #: templates/landing.html:102
 msgid "If you are in danger, contact <a href=\"tel:911\">911</a>"
-msgstr ""
-"Si usted se encuentra en peligro, llame al <a href=\"tel:911\">911</a>"
+msgstr "Si usted se encuentra en peligro, llame al <a href=\"tel:911\">911</a>"
 
 #: templates/landing.html:108
 msgid ""
@@ -2546,38 +2556,38 @@ msgstr ""
 "(25-5-2017).\n"
 "                "
 
-#: views.py:45
+#: views.py:47
 msgid "Bad request"
 msgstr "Solicitud incorrecta"
 
-#: views.py:46
+#: views.py:48
 msgid ""
 "It seems your browser is not responding properly. Try refreshing this page."
 msgstr ""
 "Parece que su navegador no está respondiendo de manera adecuada. Intente "
 "actualizar esta página."
 
-#: views.py:57
+#: views.py:59
 msgid "Unauthorized"
 msgstr "No autorizado"
 
-#: views.py:58
+#: views.py:60
 msgid "This page is off limits to unauthorized users."
 msgstr "Usuario no autorizados no podrán acceder a esta página"
 
-#: views.py:69
+#: views.py:71
 msgid "We can't find the page you are looking for"
 msgstr "No encontramos la página que usted está buscando"
 
-#: views.py:70
+#: views.py:72
 msgid "Try returning to the previous page"
 msgstr "Intente volver a la página anterior"
 
-#: views.py:81
+#: views.py:83
 msgid "There's a problem loading this page"
 msgstr "Hay un problema para cargar esta página"
 
-#: views.py:82
+#: views.py:84
 msgid ""
 "There's a technical problem loading this page. Try refreshing this page or "
 "going to another page. If that doesn't work, try again later."
@@ -2585,20 +2595,20 @@ msgstr ""
 "Hay un problema técnico para cargar esta página. Intente actualizar esta "
 "página o ir a otra página. Si eso no funciona, intente más tarde."
 
-#: views.py:93
+#: views.py:95
 msgid "Not implemented"
 msgstr "No implementado"
 
-#: views.py:94
+#: views.py:96
 msgid "There seems to be a problem with this request. Try refreshing the page."
 msgstr ""
 "Parece que hay un problema con esta solicitud. Intente actualizar la página."
 
-#: views.py:105
+#: views.py:107
 msgid "Bad gateway"
 msgstr "Portal incorrecto"
 
-#: views.py:106
+#: views.py:108
 msgid ""
 "This problem is due to poor IP communication between back-end computers, "
 "possibly including our web server. Try clearing your browser cache "
@@ -2610,11 +2620,11 @@ msgstr ""
 "borrar completamente el caché de su navegador. Puede que haya algún problema "
 "con su conexión interna a Internet o su cortafuegos."
 
-#: views.py:117
+#: views.py:119
 msgid "Service Unavailable"
 msgstr "Servicio no disponible"
 
-#: views.py:118
+#: views.py:120
 msgid ""
 "Our web server is either closed for repair, upgrades or is rebooting. Please "
 "try again later."
@@ -2622,11 +2632,11 @@ msgstr ""
 "Nuestro servidor de web está cerrado para unos arreglos, actualizaciones o "
 "se está reinicializando. Se ruega que lo intente nuevamente más tarde."
 
-#: views.py:129
+#: views.py:131
 msgid "Your browser couldn't create a secure cookie"
 msgstr "Su navegador no pudo crear una cookie segura"
 
-#: views.py:130
+#: views.py:132
 msgid ""
 "We use security cookies to protect your information from attackers. Make "
 "sure you allow cookies for this site. Having the page open for long periods "
@@ -2640,54 +2650,54 @@ msgstr ""
 "acceder a esta página en otra pestaña o ventana en su navegador. Eso le "
 "creará otra cookie de seguridad y debería resolver el problema."
 
-#: views.py:434 views.py:661
+#: views.py:436 views.py:664
 msgid "word remaining"
 msgstr "palabra restante"
 
-#: views.py:435 views.py:662
+#: views.py:437 views.py:665
 msgid " words remaining"
 msgstr "palabras restantes"
 
-#: views.py:436 views.py:663
+#: views.py:438 views.py:666
 msgid " word limit reached"
 msgstr "límite de palabras alcanzado"
 
-#: views.py:559 views.py:615 views.py:616 views.py:634 views.py:635
-#: views.py:670
+#: views.py:562 views.py:618 views.py:619 views.py:637 views.py:638
+#: views.py:673
 msgid "Primary concern"
 msgstr "Motivo principal de preocupación"
 
-#: views.py:560 views.py:617 views.py:618 views.py:619 views.py:620
-#: views.py:621 views.py:622
+#: views.py:563 views.py:620 views.py:621 views.py:622 views.py:623
+#: views.py:624 views.py:625
 msgid "Location"
 msgstr "Lugar"
 
-#: views.py:561 views.py:623 views.py:642
+#: views.py:564 views.py:626 views.py:645
 msgid "Personal characteristics"
 msgstr "Características personales"
 
-#: views.py:562 views.py:624 views.py:643
+#: views.py:565 views.py:627 views.py:646
 msgid "Date"
 msgstr "Fecha"
 
-#: views.py:563 views.py:625 views.py:644
+#: views.py:566 views.py:628 views.py:647
 msgid "Personal description"
 msgstr "Descripción personal"
 
-#: views.py:564 views.py:626 views.py:675
+#: views.py:567 views.py:629 views.py:678
 msgid "Review"
 msgstr "Repasar"
 
-#: views.py:636 views.py:637 views.py:638 views.py:639 views.py:640
-#: views.py:641
+#: views.py:639 views.py:640 views.py:641 views.py:642 views.py:643
+#: views.py:644
 msgid "Location details"
 msgstr "Datos de lugar"
 
-#: views.py:645
+#: views.py:648
 msgid "Review your report"
 msgstr "Revise su informe"
 
-#: views.py:673
+#: views.py:676
 msgid "Please select if any that apply to your situation (optional)"
 msgstr "Favor de elegir esta opción si"
 

--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -158,7 +158,7 @@
           </div>
           <div class='confirmation-content padding-left-6'>
             <p>
-              {% trans 'If you reported an incident where you or someone else has experienced or is still experiencing physical harm or violence, or are in immediate danger, please call <a href="tel:911">9-1-1</a> and contact the police.' %}
+              {% trans 'If you reported an incident where you or someone else has experienced or is still experiencing physical harm or violence, or are in immediate danger, please call <a href="tel:911">911</a> and contact the police.' %}
             </p>
           </div>
         </li>


### PR DESCRIPTION
No Zenhub issue.

- Fixes spanish for "Continue"
- Unifies 911 wording (instead of 9-1-1, this was a minor oversight)

Please note that this targets the **release/08-11-2020** branch.

## What does this change?

Spanish translation

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
