### PR TITLE
improve pa11y failures

### DIFF
--- a/pa11y_scripts/.crt-view.json
+++ b/pa11y_scripts/.crt-view.json
@@ -8,10 +8,10 @@
             "set field #id_username to pa11y_tester",
             "set field #id_password to imposing40Karl5monomial",
             "click #login",
-            "wait for url to be http://127.0.0.1:8000/form/view/",
-            "wait for element #id_assigned_to to be visible",
+            "wait for url to be http://127.0.0.1:8000/form/view/?status=new&status=open&no_status=false",
+            "wait for element #id_status to be visible",
             "click element #submitted-sort",
-            "wait for url to be http://127.0.0.1:8000/form/view/?sort=create_date"
+            "wait for url to be http://127.0.0.1:8000/form/view/?sort=create_date&status=new&status=open"
           ],
           "screenCapture": "pa11y-screenshots/crt-sort-view.png"
         }


### PR DESCRIPTION
Partially addresses [Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/589)

## What does this change?

Tweaks pa11y to hopefully not fail so often. (I'm sure it will still fail, at this point I want to reduce the frequency)

## Checklist:

### Author

+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
