### PR TITLE
Render Report location address details

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1195,8 +1195,7 @@ class ReportEditForm(ProForm, ActivityStreamUpdater):
         """
         exclude = ['intake_format', 'violation_summary', 'contact_first_name', 'contact_last_name', 'election_details',
                    'contact_email', 'contact_phone', 'contact_address_line_1', 'contact_address_line_2', 'contact_state',
-                   'contact_city', 'contact_zip', 'crt_reciept_day', 'crt_reciept_month', 'crt_reciept_year',
-                   'location_address_line_1', 'location_address_line_2']
+                   'contact_city', 'contact_zip', 'crt_reciept_day', 'crt_reciept_month', 'crt_reciept_year']
 
     def success_message(self):
         return self.SUCCESS_MESSAGE

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -155,13 +155,19 @@
         </td>
       </tr>
       <tr>
-        <th>City, State</th>
+        <th>Address</th>
         <td>
           <div class="details {% if details_form.errors %}display-none{% endif %}">
+            {{ data.location_address_line_1|default:"—" }}
+            <br>
+            {{ data.location_address_line_2|default:"—" }}
+            <br>
             {{data.location_city_town|default:"-"}},
             {{data.location_state|default:"-"}}
           </div>
           <div class="details-edit {% if not details_form.errors %}display-none{% endif %}">
+            {% include 'forms/complaint_view/show/details_edit_select.html' with field=details_form.location_address_line_1 %}
+            {% include 'forms/complaint_view/show/details_edit_select.html' with field=details_form.location_address_line_2 %}
             {% include 'forms/complaint_view/show/details_edit_select.html' with field=details_form.location_city_town %}
             {% include 'forms/complaint_view/show/details_edit_select.html' with field=details_form.location_state %}
           </div>

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -162,18 +162,29 @@ class ReportEditFormTests(TestCase):
         self.assertEqual(self.report.get_summary.note, new_summary)
         self.assertEqual(summary.note, new_summary)
 
-    def test_location_address_not_replaced(self):
+    def test_location_address_can_be_updated(self):
         data = self.report_data.copy()
+
+        # Initialize our report with these addresses
         data.update({
             'location_address_line_1': 'location address 1',
             'location_address_line_2': 'location address 2',
         })
         report = Report.objects.create(**data)
+
+        # Update our location address lines for a Form instance
+        data.update({
+            'location_address_line_1': 'NEW address 1',
+            'location_address_line_2': 'NEW address 2',
+        })
         form = ReportEditForm(data, instance=report)
         self.assertTrue(form.is_valid())
-        fields = form.clean()
-        self.assertFalse('location_address_line_1' in fields)
-        self.assertFalse('location_address_line_2' in fields)
+
+        form.save()
+        report.refresh_from_db()
+
+        self.assertEqual(report.location_address_line_1, 'NEW address 1')
+        self.assertEqual(report.location_address_line_2, 'NEW address 2')
 
 
 class ResponseActionTests(TestCase):


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/620)

## What does this change?
We now render `location_address_1` and `location_address_1` fields on the report details page. With inclusion here they may also now be updated.

## Screenshots (for front-end PR):
### View
<img width="433" alt="Screen Shot 2020-08-07 at 2 32 13 PM" src="https://user-images.githubusercontent.com/3485564/89677186-f7bb8600-d8ba-11ea-8722-f4960c0d23a5.png">

### Edit
<img width="441" alt="Screen Shot 2020-08-07 at 2 32 47 PM" src="https://user-images.githubusercontent.com/3485564/89677164-e7a3a680-d8ba-11ea-8234-8d46652992e8.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
