### PR TITLE
Remove extra padding above question headers

### DIFF
--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -8,20 +8,12 @@ form#report-form,
 form#filters-form {
   .question--header {
     width: 100%; // IE11 fix
-    // margin-top: 0.5rem;
-    // margin-bottom: units($spacer-3x);
-    padding-top: 32px;
     margin: 0;
-    + .help-text,
-    + .help-text__small,
-    + p {
-      // margin-top: -1rem; // to match other help text margins
-    }
   }
 
   .zip--code--margin {
     margin-top: 0;
-    @include at-media-max(mobile-lg){
+    @include at-media-max(mobile-lg) {
       margin-top: 1.5rem;
     }
   }
@@ -280,7 +272,7 @@ form#filters-form {
         margin-bottom: units($spacer-1x);
         padding-left: units($spacer-5x);
         border-bottom: 1px solid color($theme-color-base-lighter);
-        padding-bottom: .5rem;
+        padding-bottom: 0.5rem;
       }
 
       ul {


### PR DESCRIPTION
Hotfix.

## What does this change?
[A recent commit removed an inline style in favor of adding it to the class that existed on the heading](https://github.com/usdoj-crt/crt-portal/commit/1d4129cf857874ab51c9254b817d8f31b77d5c05). This created a visual regression because that padding does not need to be applied to every `question--header` element (and in fact probably should not even have been in service on the original single element).


## Screenshots (for front-end PR):


<img width="691" alt="Screen Shot 2020-08-10 at 5 52 49 PM" src="https://user-images.githubusercontent.com/509309/89842268-5ccce100-db32-11ea-8f62-9cacb27fd02c.png">

<img width="706" alt="Screen Shot 2020-08-10 at 5 53 01 PM" src="https://user-images.githubusercontent.com/509309/89842265-5b9bb400-db32-11ea-945e-37e525e87bb8.png">


## Checklist:

### Author

+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
