### PR TITLE
Use ProtectedClass str representation for export

### DIFF
--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -43,7 +43,7 @@ def export_as_csv(modeladmin, request, queryset):
     for report in queryset:
         row = [getattr(report, field) for field in non_m2m_fields]
         # Add protected_class M2M field
-        row.append('; '.join([pc.code for pc in report.protected_class.all()]))
+        row.append('; '.join([str(pc) for pc in report.protected_class.all()]))
         rows.append(row)
 
     response = StreamingHttpResponse((writer.writerow(row) for row in rows),


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/639)
Continuation of PR #609

## What does this change?
Legacy protected_class instances which persist in database do not have `code` values. Instead we leverage the already defined __str__ method to render ProtectedClass instances for export.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
