### PR TITLE
Modal a11y fixes

### DIFF
--- a/crt_portal/static/js/modal.js
+++ b/crt_portal/static/js/modal.js
@@ -2,6 +2,8 @@
   root.CRT = root.CRT || {};
 
   var previous_onkeydown = dom.onkeydown;
+  var focusable_elements =
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
   root.CRT.openModal = function(modal_el) {
     dom.onkeydown = function(event) {
@@ -15,14 +17,35 @@
       if (isEscape) {
         root.CRT.closeModal(modal_el);
       }
+      var isTab = false;
+      if ('key' in event) {
+        isTab = event.key === 'Tab';
+      } else {
+        isTab = event.keyCode === 9;
+      }
+      if (isTab) {
+        var first = modal_el.querySelectorAll(focusable_elements)[0];
+        var focusable_content = modal_el.querySelectorAll(focusable_elements);
+        var last = focusable_content[focusable_content.length - 1];
+        if (event.shiftKey) {
+          // browse clickable elements moving backwards
+          if (document.activeElement === first) {
+            last.focus();
+            event.preventDefault();
+          }
+        } else {
+          // browse clickable elements moving forwards
+          if (document.activeElement === last) {
+            first.focus();
+            event.preventDefault();
+          }
+        }
+      }
     };
     modal_el.removeAttribute('hidden');
     // get first input in this modal so we can focus on it
-    var focusee =
-      modal_el.querySelector('input') ||
-      modal_el.querySelector('select') || // needed for form letters
-      modal_el.querySelector('a'); // focus on cancel button if nothing else matches
-    focusee.focus();
+    var first = modal_el.querySelectorAll(focusable_elements)[0];
+    first.focus();
     dom.body.classList.add('is-modal');
   };
 
@@ -38,6 +61,5 @@
       root.CRT.closeModal(modal_el);
     };
     cancel_el.addEventListener('click', dismissModal);
-    cancel_el.addEventListener('keydown', dismissModal);
   };
 })(window, document);

--- a/crt_portal/static/sass/custom/modal.scss
+++ b/crt_portal/static/sass/custom/modal.scss
@@ -117,6 +117,9 @@ body.is-modal {
 
   #external-link--cancel {
     margin-left: 0;
+    &:focus {
+      color: color($theme-color-primary-darker) !important;
+    }
   }
 
   #external-link--continue {


### PR DESCRIPTION
follow up work to [Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/663)

## What does this change?

- Focus color
- Forward/backwards tabbing (use shift+tab for backwards)

## Screenshots (for front-end PR):

![20200811_17h32m11s_grim](https://user-images.githubusercontent.com/3013175/89962136-ae3fa380-dbf8-11ea-99ef-4f642bd89d87.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
