### PR TITLE
Fix button hover colors for landing page

### DIFF
--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -152,7 +152,7 @@ form#filters-form {
   }
   .usa-button {
     &:hover {
-      background-color: color('blue-50');
+      background-color: color($theme-link-hover-color);
     }
 
     @media (min-width: 30em) {
@@ -354,11 +354,11 @@ a.usa-button {
 
 .usa-button--light {
   background-color: color('gray-warm-3');
-  color: color('blue-50');
+  color: color($theme-link-hover-color);
 
   &:hover {
     background-color: color('gray-warm-5');
-    color: color('blue-50');
+    color: color($theme-link-hover-color);
   }
 
   img {

--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -44,6 +44,10 @@ $arrow-height: 24px;
   font-weight: bold !important;
   margin-top: 0.5rem;
   padding: 1rem 2rem;
+
+  &:hover {
+    background: color($theme-link-hover-color);
+  }
 }
 
 .crt-landing--blue {


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/643)

## What does this change?

- Hover colors for landing page
- Also applies `$theme-link-hover-color` to other applicable elements (instead of hard-coding `blue-50`)

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
