### PR TITLE
Remove modal click from pa11y actions

### DIFF
--- a/pa11y_scripts/.p3-hatecrime.json
+++ b/pa11y_scripts/.p3-hatecrime.json
@@ -11,9 +11,7 @@
         "click element #id_1-primary_complaint_0",
         "wait for element #submit-next to be visible",
         "click element #submit-next",
-        "wait for element #id_2-hate_crime_0 to be visible",
-        "click element .external-link--popup",
-        "wait for element #external-link--modal to be visible"
+        "wait for element #id_2-hate_crime_0 to be visible"
       ],
       "screenCapture": "pa11y-screenshots/page3-hatecrime.png"
     }


### PR DESCRIPTION

[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/589)

## What does this change?
Removes action from pa11y-ci pipeline which opens the external-redirect modal.

The delayed but automatic redirect present in our external-link modal is causing intermittent timeouts in the pa11y-ci pipeline.

Sometimes, pa11y will immediately follow the redirect and load the external page, leading to a timeout on the subsequent wait action.

Last debug message before timeout visible when executed w/ `pa11y` directly.

```
 Debug: Browser Console: [fbpixel] 1740773132705500 is unavailable. Go to Events Manager to learn more
```
This is the `fbpixel` present on https://humantraffickinghotline.org/

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
