### PR TITLE
Remove pa11y-ci from CI suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     working_directory: ~/code
     docker:
       # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
-      - image: circleci/python:3.8.5-node-browsers
+      - image: circleci/python:3.8.5-node
         environment: # environment variables for primary container
           PIPENV_VENV_IN_PROJECT: true
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
@@ -64,23 +64,23 @@ jobs:
           name: Run flake8 test for Python code style
           command: |
             pipenv run flake8
-      - run:
-          name: run server for tests
-          environment:
-            DEBUG: true
-          command: |
-            # create pa11y_tester
-            echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_user('pa11y_tester', 'admin@myproject.com', '$PA11Y_PASSWORD')" | pipenv run crt_portal/manage.py shell
-            # runserver
-            pipenv run crt_portal/manage.py runserver 8000
-          background: true
-      - run:
-          name: Run pa11y-ci accessibility check
-          command: |
-            curl --retry-delay 5 --retry 10 --retry-connrefused http://127.0.0.1:8000
-            npm run test:a11y
-      - store_artifacts:
-          path: ./pa11y-screenshots
+      # - run:
+      #     name: run server for tests
+      #     environment:
+      #       DEBUG: true
+      #     command: |
+      #       # create pa11y_tester
+      #       echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_user('pa11y_tester', 'admin@myproject.com', '$PA11Y_PASSWORD')" | pipenv run crt_portal/manage.py shell
+      #       # runserver
+      #       pipenv run crt_portal/manage.py runserver 8000
+      #     background: true
+      # - run:
+      #     name: Run pa11y-ci accessibility check
+      #     command: |
+      #       curl --retry-delay 5 --retry 10 --retry-connrefused http://127.0.0.1:8000
+      #       npm run test:a11y
+      # - store_artifacts:
+      #     path: ./pa11y-screenshots
       - run:
           name: Run prettier code formatting check
           command: npm run lint:check


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/589)

## What does this change?
Our current pa11y-ci test suite is often failing due to intermittent timeouts.

These failures have been the result of broken pa11y-ci config implementations, unexpected behavior in Headless Chrome, or an intermittent failure somewhere in the timeline of pa11y-ci actions and the django development server against which the tests are run.

Debugging any of the above is made difficult by pa11y-ci's current lack of debug level logging output and inconsistent results between executions both between CircleCI runs and when comparing CircleCI and local executions.

 
With this PR I propose:
* Disabling pa11y-ci in CircleCI until we've re-evaluated our implementation/options
* Updating PR template to require pa11y execution locally as part of PR review process
* Create a new issue to research, time-boxed, alternative approaches to re-incorporate a11y tests into the CI pipeline
 
### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
