### PR TITLE
Update PR template now that we are disabling pa11y CI

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,7 @@
 ### Reviewer
 
 + [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
++ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
 + [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).
 
 ## Notes for reviewer:


### PR DESCRIPTION
No Zenhub issue.

## What does this change?

Updates PR template to incorporate manual pa11y testing for reviewers as well, because we no longer have pa11y in CI.

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
