### PR TITLE
new-relic setting changes fix

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -195,6 +195,5 @@ monitor_mode = true
 [newrelic:production]
 app_name = CRT Portal (Production)
 monitor_mode = true
-high_security = true
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/671)

## What does this change?
Change the agent configuration setting of new relic monitoring



## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
