### PR TITLE
add primary statute back into intake filters

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -16,6 +16,7 @@
     {% include 'forms/complaint_view/index/filters/summary_filter.html' %}
     {% include 'forms/complaint_view/index/filters/violation_summary_filter.html' %}
     {% include 'forms/complaint_view/index/filters/date.html' %}
+    {% include 'forms/complaint_view/index/filters/primary_statute_filter.html' %}
     {% include 'forms/complaint_view/index/filters/assignee.html' %}
     {% include 'forms/complaint_view/index/filters/incident_location_filter.html' %}
     {% include 'forms/complaint_view/index/filters/section_filter.html' %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/primary_statute_filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/primary_statute_filter.html
@@ -11,7 +11,4 @@
     </label>
     {{ form.primary_statute }}
   </div>
-  <button class="usa-button margin-top-2" type="submit">
-    Filter results
-  </button>
 {% endblock %}

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -382,6 +382,10 @@
       el: complaintIDEl,
       name: 'public_id'
     });
+    textInputView({
+      el: statuteEl,
+      name: 'primary_statute'
+    });
     clearFiltersView({
       el: clearAllEl,
       onClick: clearAllFilters


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/677)

## What does this change?
This adds primary statute back into intake filter selection.
## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/66343959/91081274-dbd31680-e614-11ea-9a7a-b7e71d0f8df2.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
