### PR TITLE
Print records selectively

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -26,7 +26,8 @@ from .model_variables import (COMMERCIAL_OR_PUBLIC_ERROR,
                               PRIMARY_COMPLAINT_CHOICES,
                               PRIMARY_COMPLAINT_CHOICES_TO_EXAMPLES,
                               PRIMARY_COMPLAINT_CHOICES_TO_HELPTEXT,
-                              PRIMARY_COMPLAINT_ERROR, PROTECTED_CLASS_ERROR,
+                              PRIMARY_COMPLAINT_ERROR, PRINT_CHOICES,
+                              PROTECTED_CLASS_ERROR,
                               PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES,
                               PUBLIC_OR_PRIVATE_EMPLOYER_ERROR,
                               PUBLIC_OR_PRIVATE_SCHOOL_CHOICES,
@@ -1153,6 +1154,18 @@ class CommentActions(ModelForm):
             description=self.instance.note,
             target=report
         )
+
+
+class PrintActions(Form):
+    CONTEXT_KEY = 'print_actions'
+
+    options = MultipleChoiceField(
+        initial=('correspondent', 'issue', 'description',),
+        required=False,
+        label='options',
+        choices=PRINT_CHOICES,
+        widget=UsaCheckboxSelectMultiple(),
+    )
 
 
 class ContactEditForm(ModelForm, ActivityStreamUpdater):

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -380,3 +380,12 @@ STATUTE_CHOICES = (
 PUBLIC_USER = 'public user'
 
 CONTACT_PHONE_INVALID_MESSAGE = _('If you submit a phone number, please make sure to include between 7 and 15 digits. The characters "+", ")", "(", "-", and "." are allowed. Please include country code if entering an international phone number.')
+
+PRINT_CHOICES = (
+    ('correspondent', 'Correspondent Information'),
+    ('issue', 'Reported Issue'),
+    ('description', 'Personal Description'),
+    ('activity', 'Activity'),
+    ('summary', 'Summary'),
+    ('comments', 'Comments'),
+)

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -387,5 +387,5 @@ PRINT_CHOICES = (
     ('description', 'Personal Description'),
     ('activity', 'Activity'),
     ('summary', 'Summary'),
-    ('comments', 'Comments'),
+    ('actions', 'Actions'),
 )

--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/actions.html
@@ -1,0 +1,25 @@
+{% extends "forms/complaint_view/show/card.html" %}
+{% load commercial_public_space_view %}
+{% load correctional_facility_view %}
+{% load employer_info_view %}
+{% load static %}
+
+{% block title %}Actions{% endblock %}
+{% block extra_title %}
+  <button aria-label="edit report details" id="edit-details-btn" class="usa-button usa-button--unstyled button--edit margin-left-auto" type="button">Edit</button>
+{% endblock %}
+
+{% block icon %}
+  <img src="{% static "img/intake-icons/ic_folder.svg" %}" alt="icon" class="icon" />
+{% endblock %}
+
+{% block card_content %}
+
+  <ul class="activity-stream-print activity-stream-list usa-list usa-list--unstyled">
+    {% for action in activity %}
+      {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=action %}
+    {% endfor %}
+    {% include 'forms/complaint_view/show/activity_stream_created.html' %}
+  </ul>
+
+{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/actions.html
@@ -1,17 +1,7 @@
 {% extends "forms/complaint_view/show/card.html" %}
-{% load commercial_public_space_view %}
-{% load correctional_facility_view %}
-{% load employer_info_view %}
-{% load static %}
 
+{% block extra_classes %}crt-actions-card{% endblock %}
 {% block title %}Actions{% endblock %}
-{% block extra_title %}
-  <button aria-label="edit report details" id="edit-details-btn" class="usa-button usa-button--unstyled button--edit margin-left-auto" type="button">Edit</button>
-{% endblock %}
-
-{% block icon %}
-  <img src="{% static "img/intake-icons/ic_folder.svg" %}" alt="icon" class="icon" />
-{% endblock %}
 
 {% block card_content %}
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/activities.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/activities.html
@@ -1,7 +1,7 @@
 {% extends "forms/complaint_view/show/card.html" %}
 
-{% block extra_classes %}crt-actions-card{% endblock %}
-{% block title %}Actions{% endblock %}
+{% block extra_classes %}crt-activities-card{% endblock %}
+{% block title %}Activity{% endblock %}
 
 {% block card_content %}
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/comments.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/comments.html
@@ -1,0 +1,23 @@
+{% extends "forms/complaint_view/show/card.html" %}
+{% load commercial_public_space_view %}
+{% load correctional_facility_view %}
+{% load employer_info_view %}
+{% load static %}
+
+{% block title %}Comments{% endblock %}
+{% block extra_title %}
+  <button aria-label="edit report details" id="edit-details-btn" class="usa-button usa-button--unstyled button--edit margin-left-auto" type="button">Edit</button>
+{% endblock %}
+
+{% block icon %}
+  <img src="{% static "img/intake-icons/ic_folder.svg" %}" alt="icon" class="icon" />
+{% endblock %}
+
+{% block card_content %}
+
+  <ul class="activity-stream-print activity-stream-list usa-list usa-list--unstyled">
+    {% for comment in print_comments %}
+      {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=comment %}    {% endfor %}
+  </ul>
+
+{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/comments.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/comments.html
@@ -1,7 +1,7 @@
 {% extends "forms/complaint_view/show/card.html" %}
 
 {% block extra_classes %}crt-comments-card{% endblock %}
-{% block title %}Comments{% endblock %}
+{% block title %}Actions{% endblock %}
 
 {% block card_content %}
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/comments.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/comments.html
@@ -1,23 +1,14 @@
 {% extends "forms/complaint_view/show/card.html" %}
-{% load commercial_public_space_view %}
-{% load correctional_facility_view %}
-{% load employer_info_view %}
-{% load static %}
 
+{% block extra_classes %}crt-comments-card{% endblock %}
 {% block title %}Comments{% endblock %}
-{% block extra_title %}
-  <button aria-label="edit report details" id="edit-details-btn" class="usa-button usa-button--unstyled button--edit margin-left-auto" type="button">Edit</button>
-{% endblock %}
-
-{% block icon %}
-  <img src="{% static "img/intake-icons/ic_folder.svg" %}" alt="icon" class="icon" />
-{% endblock %}
 
 {% block card_content %}
 
   <ul class="activity-stream-print activity-stream-list usa-list usa-list--unstyled">
     {% for comment in print_comments %}
-      {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=comment %}    {% endfor %}
+      {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=comment %}
+    {% endfor %}
   </ul>
 
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/summary.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/summary.html
@@ -1,0 +1,24 @@
+{% extends "forms/complaint_view/show/card.html" %}
+{% load commercial_public_space_view %}
+{% load correctional_facility_view %}
+{% load employer_info_view %}
+{% load static %}
+
+{% block title %}Summary{% endblock %}
+{% block extra_title %}
+  <button aria-label="edit report details" id="edit-details-btn" class="usa-button usa-button--unstyled button--edit margin-left-auto" type="button">Edit</button>
+{% endblock %}
+
+{% block icon %}
+  <img src="{% static "img/intake-icons/ic_folder.svg" %}" alt="icon" class="icon" />
+{% endblock %}
+
+{% block card_content %}
+
+  {% if summary %}
+    <div>
+      {{ summary.note | default:"Not given" | linebreaks }}
+    </div>
+  {% endif %}
+
+{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/summary.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/summary.html
@@ -1,24 +1,10 @@
 {% extends "forms/complaint_view/show/card.html" %}
-{% load commercial_public_space_view %}
-{% load correctional_facility_view %}
-{% load employer_info_view %}
-{% load static %}
 
+{% block extra_classes %}crt-summary-card{% endblock %}
 {% block title %}Summary{% endblock %}
-{% block extra_title %}
-  <button aria-label="edit report details" id="edit-details-btn" class="usa-button usa-button--unstyled button--edit margin-left-auto" type="button">Edit</button>
-{% endblock %}
-
-{% block icon %}
-  <img src="{% static "img/intake-icons/ic_folder.svg" %}" alt="icon" class="icon" />
-{% endblock %}
 
 {% block card_content %}
 
-  {% if summary %}
-    <div>
-      {{ summary.note | default:"Not given" | linebreaks }}
-    </div>
-  {% endif %}
+  {{ summary.note | default:"Not given" | linebreaks }}
 
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -1,6 +1,7 @@
 {% extends "forms/complaint_view/show/card.html" %}
 {% load static %}
 {% block title %}{{title}}{% endblock %}
+{% block extra_classes %}crt-action-card{% endblock %}
 {% block icon %}
 <img src="{% static icon %}" alt="" class="icon" />
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -48,7 +48,7 @@
     </div>
     <div class="intake-section">
       <button class="outline-button outline-button--blue" id="contact_complainant">
-        <img src="{% static "img/intake-icons/ic_email.svg" %}" class="icon" alt="email">
+        <img src="{% static "img/intake-icons/ic_email.svg" %}" class="icon" alt="from email">
         Contact complainant
       </button>
       <button class="outline-button outline-button--blue" id="printout_report">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -47,8 +47,12 @@
     </div>
     <div class="intake-section">
       <button class="outline-button outline-button--blue" id="contact_complainant">
-        <img src="{% static "img/intake-icons/ic_email.svg" %}" class="icon" alt="from email">
+        <img src="{% static "img/intake-icons/ic_email.svg" %}" class="icon" alt="email">
         Contact complainant
+      </button>
+      <button class="outline-button outline-button--blue" id="print_report">
+        <img src="{% static "img/intake-icons/ic_fax.svg" %}" class="icon" alt="printer">
+        Print
       </button>
     </div>
     <button class="usa-button" type="submit" name='type' value='{{actions.CONTEXT_KEY}}'>Apply changes</button>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -50,7 +50,7 @@
         <img src="{% static "img/intake-icons/ic_email.svg" %}" class="icon" alt="email">
         Contact complainant
       </button>
-      <button class="outline-button outline-button--blue" id="print_report">
+      <button class="outline-button outline-button--blue" id="printout_report">
         <img src="{% static "img/intake-icons/ic_fax.svg" %}" class="icon" alt="printer">
         Print
       </button>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
@@ -11,15 +11,4 @@
     {% endfor %}
     {% include 'forms/complaint_view/show/activity_stream_created.html' %}
   </ul>
-  {# for print media consumption #}
-  <ul class="activity-stream-print activity-stream-list usa-list usa-list--unstyled">
-    {% for action in print_actions %}
-      {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=action %}
-    {% endfor %}
-    {% include 'forms/complaint_view/show/activity_stream_created.html' %}
-  </ul>
-  <ul class="activity-stream-print activity-stream-list usa-list usa-list--unstyled">
-    {% for comment in print_comments %}
-      {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=comment %}    {% endfor %}
-  </ul>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
@@ -12,14 +12,14 @@
     {% include 'forms/complaint_view/show/activity_stream_created.html' %}
   </ul>
   {# for print media consumption #}
-  <ul hidden class="activity-stream-list usa-list usa-list--unstyled">
-    {% for comment in print_comments %}
-      {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=comment %}    {% endfor %}
-  </ul>
-  <ul hidden class="activity-stream-list usa-list usa-list--unstyled">
+  <ul class="activity-stream-print activity-stream-list usa-list usa-list--unstyled">
     {% for action in print_actions %}
       {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=action %}
     {% endfor %}
     {% include 'forms/complaint_view/show/activity_stream_created.html' %}
+  </ul>
+  <ul class="activity-stream-print activity-stream-list usa-list usa-list--unstyled">
+    {% for comment in print_comments %}
+      {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=comment %}    {% endfor %}
   </ul>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
@@ -7,28 +7,19 @@
 {% block card_content %}
   <ul class="activity-stream-list usa-list usa-list--unstyled">
     {% for activity in activity_stream %}
-      <li class="activity-stream-item">
-        <div class="display-flex flex-justify">
-          <b>{{ activity.actor.username }}</b>
-          <span class="date font-sans-sm flex-align-end">
-            {{ activity.timestamp|date:'n/d/y' }} {{ activity.timestamp|time }}
-          </span>
-        </div>
-        <p class="margin-top-05">
-          {{ activity.verb }}{{ activity.description|linebreaks }}
-        </p>
-      </li>
+      {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=activity %}
     {% endfor %}
-    <li class="activity-stream-item">
-      <div class="display-flex flex-justify">
-        <b>{{ data.author }}</b>
-        <span class="date font-sans-sm flex-align-end">
-         {{ data.create_date|date:'n/d/y'}} {{ data.create_date|time}}
-        </span>
-      </div>
-      <p class="margin-top-05">
-        Created record from {{data.get_intake_format_display}}
-      </p>
-    </li>
+    {% include 'forms/complaint_view/show/activity_stream_created.html' %}
+  </ul>
+  {# for print media consumption #}
+  <ul hidden class="activity-stream-list usa-list usa-list--unstyled">
+    {% for comment in print_comments %}
+      {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=comment %}    {% endfor %}
+  </ul>
+  <ul hidden class="activity-stream-list usa-list usa-list--unstyled">
+    {% for action in print_actions %}
+      {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=action %}
+    {% endfor %}
+    {% include 'forms/complaint_view/show/activity_stream_created.html' %}
   </ul>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream_created.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream_created.html
@@ -1,0 +1,11 @@
+<li class="activity-stream-item">
+  <div class="display-flex flex-justify">
+    <b>{{ data.author }}</b>
+    <span class="date font-sans-sm flex-align-end">
+      {{ data.create_date|date:'n/d/y'}} {{ data.create_date|time}}
+    </span>
+  </div>
+  <p class="margin-top-05">
+    Created record from {{data.get_intake_format_display}}
+  </p>
+</li>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream_item.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream_item.html
@@ -1,0 +1,11 @@
+<li class="activity-stream-item">
+  <div class="display-flex flex-justify">
+    <b>{{ activity.actor.username }}</b>
+    <span class="date font-sans-sm flex-align-end">
+      {{ activity.timestamp|date:'n/d/y' }} {{ activity.timestamp|time }}
+    </span>
+  </div>
+  <p class="margin-top-05">
+    {{ activity.verb }}{{ activity.description|linebreaks }}
+  </p>
+</li>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/card.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/card.html
@@ -1,4 +1,4 @@
-<div class="crt-portal-card">
+<div class="crt-portal-card {% block extra_classes %}{% endblock %}">
   <div class="crt-portal-card__content crt-portal-card__content--sm">
     <div class="title">
       <div class="title-icon margin-right-1">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -8,6 +8,7 @@
 {% block extra_title %}
 <button aria-label="edit report details" id="edit-details-btn" class="usa-button usa-button--unstyled button--edit margin-left-auto" type="button">Edit</button>
 {% endblock %}
+{% block extra_classes %}crt-report-card{% endblock %}
 
 {% block icon %}
 <img src="{% static "img/intake-icons/ic_folder.svg" %}" alt="icon" class="icon" />

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -16,7 +16,7 @@
 {% block card_content %}
 <form id="details-edit-form" class="usa-form " method="post" novalidate>
 
-<div class="blue-background usa-prose">
+<div class="crt-current-summary blue-background usa-prose">
   <div id="current-summary" class="details">
     {% if summary %}
     <label class="bold backend-blue" for="current-summary-text">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -45,7 +45,7 @@
       <tr>
         <th>
           <div class="report-print-question">
-            What is your primary reason for contacting the Civil Rights Division?
+            {{ questions.primary_reason }}
           </div>
           <label class="report-details-label" for="{{details_form.primary_complaint.id_for_label}}">Primary issue</label>
         </th>
@@ -62,7 +62,7 @@
       <tr>
         <th>
           <div class="report-print-question">
-            What is your primary reason for contacting the Civil Rights Division?
+            {{ questions.hate_crime }}
           </div>
           <div class="report-details-label">
             Hate crime
@@ -121,7 +121,7 @@
       <tr>
         <th>
           <div class="report-print-question">
-            ???
+            {{ questions.hate_crime }}
           </div>
           <label class="report-details-label" for="{{details_form.hate_crime.id_for_label}}">Hate crime</label>
         </th>
@@ -138,7 +138,23 @@
       <tr>
         <th>
           <div class="report-print-question">
-            ???
+            {% if data.election_details %}
+              {{ questions.election }}
+            {% elif data.commercial_or_public_place %}
+              {{ questions.public }}
+            {% elif data.inside_correctional_facility %}
+              {% for question in questions.police.values %}
+                {{ question }}<br>
+              {% endfor %}
+            {% elif data.public_or_private_school %}
+              {{ questions.education }}
+            {% elif data.public_or_private_employer %}
+              {% for question in questions.workplace.values %}
+                {{ question }}<br>
+              {% endfor %}
+            {% else %}
+              —
+            {% endif %}
           </div>
           <div class="report-details-label">
             Relevant Details
@@ -178,7 +194,7 @@
       <tr>
         <th>
           <div class="report-print-question">
-            ???
+            {{ questions.location.location_name }}
           </div>
           <label class="report-details-label" for="{{details_form.location_name.id_for_label}}">Location name</label>
         </th>
@@ -194,7 +210,7 @@
       <tr>
         <th>
           <div class="report-print-question">
-            ???
+            {{ questions.location.location_title }}
           </div>
           <div class="report-details-label">
             Address
@@ -220,7 +236,7 @@
       <tr>
         <th>
           <div class="report-print-question">
-            ???
+            {{ questions.characteristics }}
           </div>
           <label class="report-details-label" for="{{details_form.protected_class.id_for_label}}">Reported reason</label>
         </th>
@@ -249,7 +265,7 @@
       <tr>
         <th>
           <div class="report-print-question">
-            ???
+            {{ questions.servicemember }}
           </div>
           <label class="report-details-label" for="{{details_form.servicemember.id_for_label}}">Service Member</label>
         </th>
@@ -265,7 +281,7 @@
       <tr>
         <th>
           <div class="report-print-question">
-            ???
+            {{ questions.date.date_title }}
           </div>
           <div class="report-details-label">
             Date of incident

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -43,7 +43,12 @@
     <input type="hidden" value="{{ index }}" name="index" id="index-{{ id_name }}" />
     <table class="usa-table usa-table--borderless complaint-card-table">
       <tr>
-        <th><label for="{{details_form.primary_complaint.id_for_label}}">Primary issue</label></th>
+        <th>
+          <div class="report-print-question">
+            What is your primary reason for contacting the Civil Rights Division?
+          </div>
+          <label class="report-details-label" for="{{details_form.primary_complaint.id_for_label}}">Primary issue</label>
+        </th>
         <td>
           <div class="details {% if details_form.errors %}display-none{% endif %}">
             {{primary_complaint.0}}
@@ -55,7 +60,14 @@
       {# showing old data with hate crimes #}
       {% if crimes.physical_harm or crimes.trafficking %}
       <tr>
-        <th>Hate crime</th>
+        <th>
+          <div class="report-print-question">
+            What is your primary reason for contacting the Civil Rights Division?
+          </div>
+          <div class="report-details-label">
+            Hate crime
+          </div>
+        </th>
         <td>
           <div class="details {% if details_form.errors %}display-none{% endif %}">
             {# show new hate crime field if it exists #}
@@ -77,7 +89,14 @@
       </tr>
       {# showing old data with trafficking #}
       <tr>
-        <th>Human Trafficking</th>
+        <th>
+          <div class="report-print-question">
+            ???
+          </div>
+          <div class="report-details-label">
+            Human Trafficking
+          </div>
+        </th>
         <td>
           <div class="details {% if details_form.errors %}display-none{% endif %}">
             {% if crimes.trafficking %}
@@ -100,7 +119,12 @@
       {# current version of hate crimes. This will also show "no" responses from earlier forms #}
       {% if not crimes.trafficking and not crimes.physical_harm %}
       <tr>
-        <th><label for="{{details_form.hate_crime.id_for_label}}">Hate crime</label></th>
+        <th>
+          <div class="report-print-question">
+            ???
+          </div>
+          <label class="report-details-label" for="{{details_form.hate_crime.id_for_label}}">Hate crime</label>
+        </th>
           <td>
             <div class="details {% if details_form.errors %}display-none{% endif %}">
               {{data.hate_crime|title|default:"—"}}
@@ -112,7 +136,14 @@
       </tr>
       {% endif %}
       <tr>
-        <th>Relevant Details</th>
+        <th>
+          <div class="report-print-question">
+            ???
+          </div>
+          <div class="report-details-label">
+            Relevant Details
+          </div>
+        </th>
         <td>
           <div class="details {% if details_form.errors %}display-none{% endif %}">
             {% if data.election_details %}
@@ -145,7 +176,12 @@
         </td>
       </tr>
       <tr>
-        <th><label for="{{details_form.location_name.id_for_label}}">Location name</label></th>
+        <th>
+          <div class="report-print-question">
+            ???
+          </div>
+          <label class="report-details-label" for="{{details_form.location_name.id_for_label}}">Location name</label>
+        </th>
         <td>
           <div class="details {% if details_form.errors %}display-none{% endif %}">
             {{data.location_name|default:"-"}}
@@ -156,7 +192,14 @@
         </td>
       </tr>
       <tr>
-        <th>Address</th>
+        <th>
+          <div class="report-print-question">
+            ???
+          </div>
+          <div class="report-details-label">
+            Address
+          </div>
+        </th>
         <td>
           <div class="details {% if details_form.errors %}display-none{% endif %}">
             {{ data.location_address_line_1|default:"—" }}
@@ -175,7 +218,12 @@
         </td>
       </tr>
       <tr>
-        <th><label for="{{details_form.protected_class.id_for_label}}">Reported reason</label></th>
+        <th>
+          <div class="report-print-question">
+            ???
+          </div>
+          <label class="report-details-label" for="{{details_form.protected_class.id_for_label}}">Reported reason</label>
+        </th>
         <td>
           <div class="details {% if details_form.errors %}display-none{% endif %}">
             {% for p_class in p_class_list %}
@@ -199,7 +247,12 @@
         </td>
       </tr>
       <tr>
-        <th><label for="{{details_form.servicemember.id_for_label}}">Service Member</label></th>
+        <th>
+          <div class="report-print-question">
+            ???
+          </div>
+          <label class="report-details-label" for="{{details_form.servicemember.id_for_label}}">Service Member</label>
+        </th>
           <td>
             <div class="details {% if details_form.errors %}display-none{% endif %}">
               {{data.servicemember|title|default:"—"}}
@@ -210,7 +263,14 @@
           </td>
       </tr>
       <tr>
-        <th>Date of incident</th>
+        <th>
+          <div class="report-print-question">
+            ???
+          </div>
+          <div class="report-details-label">
+            Date of incident
+          </div>
+        </th>
         <td>
           <div class="details {% if details_form.errors %}display-none{% endif %}">
           {{ data.last_incident_month|default:"-"}}/{{data.last_incident_day|default:"-"}}/{{data.last_incident_year|default:"-"}}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -92,7 +92,7 @@
       <tr>
         <th>
           <div class="report-print-question">
-            ???
+            Human Trafficking
           </div>
           <div class="report-details-label">
             Human Trafficking

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/correspondent_info.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/correspondent_info.html
@@ -5,6 +5,7 @@
 {% block extra_title %}  <button aria-label="edit contact information" id="edit-contact-info-btn"
 class="usa-button usa-button--unstyled button--edit margin-left-auto" type="button">Edit</button>
 {% endblock %}
+{% block extra_classes %}crt-correspondent-card{% endblock %}
 
 {% block icon %}
   <img src="{% static "img/intake-icons/ic_contact.svg" %}" alt="" class="icon" />

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
@@ -1,4 +1,4 @@
-<div class="crt-portal-card">
+<div class="crt-portal-card crt-description-card">
   <div class="crt-portal-card__content">
     <h3 class="complaint-card-heading text-uppercase">Personal Description</h3>
     <p>{{ description|linebreaks }}</p>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -15,7 +15,7 @@
     <div class="grid-container-widescreen">
       <div class="grid-row margin-bottom-1">
         <div class="tablet:grid-col-10 grid-offset-1 padding-left-05">
-          <div class="complaint-navigation display-flex flex-row flex-justify">
+          <div class="complaint-filter-navigation display-flex flex-row flex-justify">
             <div class="display-flex">
               <a class="outline-button outline-button--dark" href="{% url 'crt_forms:crt-forms-index' %}{{ return_url_args }}">
                 <img src="{% static "img/intake-icons/ic_arrow_forward.svg" %}" alt="back arrow" class="icon">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -2,11 +2,11 @@
 {% load static %}
 
 {% block page_title %}
-  <title>CRT Complaint Records{% for message in messages %} - {{ message }}{% endfor %}</title>
+ <title>CRT Complaint Records{% for message in messages %} - {{ message }}{% endfor %}</title>
 {% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{% static "css/accessible-autocomplete.min.css" %}" />
+<link rel="stylesheet" href="{% static "css/accessible-autocomplete.min.css" %}" />
 {% endblock head %}
 
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -2,11 +2,11 @@
 {% load static %}
 
 {% block page_title %}
- <title>CRT Complaint Records{% for message in messages %} - {{ message }}{% endfor %}</title>
+  <title>CRT Complaint Records{% for message in messages %} - {{ message }}{% endfor %}</title>
 {% endblock %}
 
 {% block head %}
-<link rel="stylesheet" href="{% static "css/accessible-autocomplete.min.css" %}" />
+  <link rel="stylesheet" href="{% static "css/accessible-autocomplete.min.css" %}" />
 {% endblock head %}
 
 
@@ -15,7 +15,7 @@
     <div class="grid-container-widescreen">
       <div class="grid-row margin-bottom-1">
         <div class="tablet:grid-col-10 grid-offset-1 padding-left-05">
-          <div class="display-flex flex-row flex-justify">
+          <div class="complaint-navigation display-flex flex-row flex-justify">
             <div class="display-flex">
               <a class="outline-button outline-button--dark" href="{% url 'crt_forms:crt-forms-index' %}{{ return_url_args }}">
                 <img src="{% static "img/intake-icons/ic_arrow_forward.svg" %}" alt="back arrow" class="icon">
@@ -90,19 +90,19 @@
         {% include 'partials/messages.html' %}
       </div>
     </div>
-    <div class="grid-row grid-gap-4">
+    <div class="complaint-actions grid-row grid-gap-4">
       <div class="tablet:grid-col-4 grid-offset-1">
         {% include 'forms/complaint_view/show/actions.html' with title="Actions" icon="img/intake-icons/ic_check-circle.svg" %}
         <div class="activity-stream">
           {% include 'forms/complaint_view/show/activity_stream.html' with title="Activity" icon="img/intake-icons/ic_activity.svg" %}
         </div>
-        <div class="crt-portal-card">
+        <div class="crt-portal-card crt-comment-new">
           <div class="crt-portal-card__content">
             {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="comment" is_summary=False button_text='Save' button_aria_label='save comment' label='New comment' comment_box=comments.note %}
           </div>
         </div>
       </div>
-      <div class="tablet:grid-col-6">
+      <div class="tablet:grid-col-6 mobile-lg:grid-offset-1">
         {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}
 
         {% include 'forms/complaint_view/show/complaint_details.html' with data=data primary_complaint=primary_complaint summary=summary %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -101,7 +101,10 @@
             {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="comment" is_summary=False button_text='Save' button_aria_label='save comment' label='New comment' comment_box=comments.note %}
           </div>
         </div>
-        {% include 'forms/complaint_view/print/actions.html' with activity=print_actions %}
+        {% include 'forms/complaint_view/print/activities.html' with activity=print_actions %}
+
+        {% include 'forms/complaint_view/print/summary.html' with summary=summary %}
+
         {% include 'forms/complaint_view/print/comments.html' with activity=print_comments %}
       </div>
       <div class="complaint-information tablet:grid-col-6">
@@ -110,8 +113,6 @@
         {% include 'forms/complaint_view/show/complaint_details.html' with data=data primary_complaint=primary_complaint summary=summary %}
 
         {% include 'forms/complaint_view/show/description.html' with description=data.violation_summary %}
-
-        {% include 'forms/complaint_view/print/summary.html' with summary=summary %}
       </div>
     </div>
   </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -101,6 +101,8 @@
             {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="comment" is_summary=False button_text='Save' button_aria_label='save comment' label='New comment' comment_box=comments.note %}
           </div>
         </div>
+        {% include 'forms/complaint_view/print/actions.html' with activity=print_actions %}
+        {% include 'forms/complaint_view/print/comments.html' with activity=print_comments %}
       </div>
       <div class="complaint-information tablet:grid-col-6">
         {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}
@@ -108,6 +110,8 @@
         {% include 'forms/complaint_view/show/complaint_details.html' with data=data primary_complaint=primary_complaint summary=summary %}
 
         {% include 'forms/complaint_view/show/description.html' with description=data.violation_summary %}
+
+        {% include 'forms/complaint_view/print/summary.html' with summary=summary %}
       </div>
     </div>
   </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -101,11 +101,11 @@
             {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="comment" is_summary=False button_text='Save' button_aria_label='save comment' label='New comment' comment_box=comments.note %}
           </div>
         </div>
-        {% include 'forms/complaint_view/print/activities.html' with activity=print_actions %}
+        {% include 'forms/complaint_view/print/comments.html' with activity=print_comments %}
 
         {% include 'forms/complaint_view/print/summary.html' with summary=summary %}
 
-        {% include 'forms/complaint_view/print/comments.html' with activity=print_comments %}
+        {% include 'forms/complaint_view/print/activities.html' with activity=print_actions %}
       </div>
       <div class="complaint-information tablet:grid-col-6">
         {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -90,8 +90,8 @@
         {% include 'partials/messages.html' %}
       </div>
     </div>
-    <div class="complaint-actions grid-row grid-gap-4">
-      <div class="tablet:grid-col-4 grid-offset-1">
+    <div class="complaint-page grid-row grid-gap-4">
+      <div class="complaint-actions tablet:grid-col-4 grid-offset-1">
         {% include 'forms/complaint_view/show/actions.html' with title="Actions" icon="img/intake-icons/ic_check-circle.svg" %}
         <div class="activity-stream">
           {% include 'forms/complaint_view/show/activity_stream.html' with title="Activity" icon="img/intake-icons/ic_activity.svg" %}
@@ -102,7 +102,7 @@
           </div>
         </div>
       </div>
-      <div class="tablet:grid-col-6 mobile-lg:grid-offset-1">
+      <div class="complaint-information tablet:grid-col-6">
         {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}
 
         {% include 'forms/complaint_view/show/complaint_details.html' with data=data primary_complaint=primary_complaint summary=summary %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -116,6 +116,7 @@
 
 {% block usa_footer %}
   {% include 'forms/complaint_view/show/response_template.html' %}
+  {% include 'forms/complaint_view/show/print_report.html' %}
 {% endblock %}
 
 {% block page_js %}
@@ -124,6 +125,7 @@
 <script src="{% static 'js/edit_details.js' %}"></script>
 <script src="{% static 'js/modal.js' %}"></script>
 <script src="{% static 'js/form_letter.js' %}"></script>
+<script src="{% static 'js/print_report.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/accessible-autocomplete.min.js' %}"></script>
 <script nonce="{{request.csp_nonce}}">
   accessibleAutocomplete.enhanceSelectElement({

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
@@ -10,9 +10,9 @@
           <h1>Print</h1>
         </div>
         <div class="modal-form">
-
+          {{ print_options.options }}
           <div class="modal-footer">
-            <button disabled id="do_print_report" class="usa-button" type="submit" name="type" value="print">Print</button>
+            <button id="do_print_report" class="usa-button" type="submit" name="type" value="print">Print</button>
             <a id="print_report_cancel" href="#">Cancel</a>
           </div>
         </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
@@ -1,16 +1,19 @@
 {% load static %}
 
-<form class="usa-form" method="post" action="{% url 'crt_forms:crt-forms-response' id=data.id %}">
+<form class="usa-form" method="post" action="{% url 'crt_forms:crt-forms-print' id=data.id %}">
   {% csrf_token %}
   <input type="hidden" value="{{ return_url_args }}" name="next" id="modal_next" />
   <div id="print_report" hidden>
-    <div class="modal-wrapper intake-template--modal">
+    <div class="modal-wrapper print-report--modal">
       <div class="modal-content modal-content--large">
         <div class="modal-header">
           <h1>Print</h1>
         </div>
         <div class="modal-form">
-          {{ print_options.options }}
+          <p>Please select the following options for printing:</p>
+          <div class="print-report--content">
+            {{ print_options.options }}
+          </div>
           <div class="modal-footer">
             <button id="do_print_report" class="usa-button" type="submit" name="type" value="print">Print</button>
             <a id="print_report_cancel" href="#">Cancel</a>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
@@ -3,6 +3,7 @@
 <form class="usa-form" method="post" action="{% url 'crt_forms:crt-forms-print' id=data.id %}">
   {% csrf_token %}
   <input type="hidden" value="{{ return_url_args }}" name="next" id="modal_next" />
+  <input type="hidden" value="{{ index }}" name="index" id="index" />
   <div id="print_report" hidden>
     <div class="modal-wrapper print-report--modal">
       <div class="modal-content modal-content--large">
@@ -11,7 +12,7 @@
         </div>
         <div class="modal-form">
           <p>Please select the following options for printing:</p>
-          <div class="print-report--content">
+          <div class="modal-main">
             {{ print_options.options }}
           </div>
           <div class="modal-footer">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
@@ -1,0 +1,22 @@
+{% load static %}
+
+<form class="usa-form" method="post" action="{% url 'crt_forms:crt-forms-response' id=data.id %}">
+  {% csrf_token %}
+  <input type="hidden" value="{{ return_url_args }}" name="next" id="modal_next" />
+  <div id="print_report" hidden>
+    <div class="modal-wrapper intake-template--modal">
+      <div class="modal-content modal-content--large">
+        <div class="modal-header">
+          <h1>Print</h1>
+        </div>
+        <div class="modal-form">
+
+          <div class="modal-footer">
+            <button disabled id="do_print_report" class="usa-button" type="submit" name="type" value="print">Print</button>
+            <a id="print_report_cancel" href="#">Cancel</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template.html
@@ -15,7 +15,7 @@
             <strong id="intake_description">(no template chosen)</strong>
           </p>
           {{ responses.templates }}
-          <div class="intake-template--content">
+          <div class="modal-main">
             <textarea disabled aria-label="intake letter" id="intake_letter" rows="10" cols="80"></textarea>
           </div>
           <div class="modal-footer">

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -348,9 +348,9 @@ class PrintActionTests(TestCase):
         return str(response.content)
 
     def test_response_action_print(self):
-        options = ['correspondent', 'comments']
+        options = ['correspondent', 'actions']
         content = self.post_print_action(options)
         # verify that next QP is preserved and activity log shows up
         self.assertTrue('?per_page=15' in content)
         self.assertTrue('Printed report' in content)
-        self.assertTrue(escape(f"Selected correspondent, comments") in content)
+        self.assertTrue(escape('Selected correspondent, actions') in content)

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
-from .views import IndexView, ShowView, ProFormView, SaveCommentView, TrendView, ResponseView
+from .views import (IndexView, ShowView, ProFormView, SaveCommentView,
+                    TrendView, ResponseView, PrintView)
 from .forms import ProForm
 
 app_name = 'crt_forms'
@@ -9,6 +10,7 @@ app_name = 'crt_forms'
 urlpatterns = [
     path('view/<int:id>/', ShowView.as_view(), name='crt-forms-show'),
     path('view/<int:id>/response', ResponseView.as_view(), name='crt-forms-response'),
+    path('view/<int:id>/print', PrintView.as_view(), name='crt-forms-print'),
     path('view/', IndexView, name='crt-forms-index'),
     path('new/', ProFormView.as_view([ProForm]), name='crt-pro-form'),
     path('comment/report/<int:report_id>/', SaveCommentView.as_view(), name='save-report-comment'),

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -325,7 +325,8 @@ def serialize_data(report, request, report_id):
         'summary': report.get_summary,
         # for print media consumption
         'print_actions': report.target_actions.exclude(verb__contains='comment:'),
-        'print_comments': report.target_actions.filter(verb__contains='comment:')
+        'print_comments': report.target_actions.filter(verb__contains='comment:'),
+        'questions': Review.question_text,
     }
 
     return output
@@ -809,7 +810,8 @@ class CRTReportWizard(SessionWizardView):
         return render(
             self.request, 'forms/confirmation.html',
             {
-                'report': report, 'questions': Review.question_text,
+                'report': report,
+                'questions': Review.question_text,
                 'ordered_step_names': self.ORDERED_STEP_NAMES
             },
         )

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -363,10 +363,7 @@ class PrintView(LoginRequiredMixin, View):
             add_activity(request.user, "Printed report", description, report)
             messages.add_message(request, messages.SUCCESS, description)
 
-        # preserve the query that got the user to this page
-        return_url_args = request.POST.get('next', '')
-        next_page = urllib.parse.quote(return_url_args)
-        url = f'{report.get_absolute_url()}?next={next_page}'
+        url = preserve_filter_parameters(report, request.POST)
         return redirect(url)
 
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -17,8 +17,8 @@ from formtools.wizard.views import SessionWizardView
 
 from .filters import report_filter
 from .forms import (CommentActions, ComplaintActions, ResponseActions,
-                    ContactEditForm, Filters, ReportEditForm, Review,
-                    add_activity)
+                    PrintActions, ContactEditForm, Filters,
+                    ReportEditForm, Review, add_activity)
 from .model_variables import (COMMERCIAL_OR_PUBLIC_PLACE_DICT,
                               CORRECTIONAL_FACILITY_LOCATION_DICT,
                               CORRECTIONAL_FACILITY_LOCATION_TYPE_DICT,
@@ -314,6 +314,7 @@ def serialize_data(report, request, report_id):
         'actions': ComplaintActions(instance=report),
         'responses': ResponseActions(instance=report),
         'comments': CommentActions(),
+        'print_options': PrintActions(),
         'activity_stream': report.target_actions.all(),
         'crimes': crimes,
         'data': report,

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -323,6 +323,9 @@ def serialize_data(report, request, report_id):
         'return_url_args': request.GET.get('next', ''),
         'index': request.GET.get('index', ''),
         'summary': report.get_summary,
+        # for print media consumption
+        'print_actions': report.target_actions.exclude(verb__contains='comment:'),
+        'print_comments': report.target_actions.filter(verb__contains='comment:')
     }
 
     return output

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -346,6 +346,26 @@ class ResponseView(LoginRequiredMixin, View):
         return redirect(url)
 
 
+class PrintView(LoginRequiredMixin, View):
+
+    def post(self, request, id):
+        report = get_object_or_404(Report, pk=id)
+        form = PrintActions(request.POST)
+
+        if form.is_valid():
+            options = form.cleaned_data['options']
+            all_options = ', '.join(options)
+            description = f"Selected {all_options}"
+            add_activity(request.user, "Printed report", description, report)
+            messages.add_message(request, messages.SUCCESS, description)
+
+        # preserve the query that got the user to this page
+        return_url_args = request.POST.get('next', '')
+        next_page = urllib.parse.quote(return_url_args)
+        url = f'{report.get_absolute_url()}?next={next_page}'
+        return redirect(url)
+
+
 class ShowView(LoginRequiredMixin, View):
     forms = {
         form.CONTEXT_KEY: form

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -161,7 +161,6 @@
 
     filters.addEventListener('click', function handleFilterTagClick(event) {
       var node = event.target;
-      console.log(node, event.currentTarget);
       if (node.tagName === 'BUTTON') {
         onClickHandler(node);
       }

--- a/crt_portal/static/js/print_report.js
+++ b/crt_portal/static/js/print_report.js
@@ -1,22 +1,76 @@
-(function(root) {
-  var modal = document.getElementById('print_report');
+(function(root, dom) {
+  var complaint_page = document.querySelector('.complaint-show-body');
+  var option_mapping_to_section = {
+    id_options_0: '.crt-correspondent-card',
+    id_options_1: '.crt-report-card',
+    id_options_2: '.crt-description-card',
+    id_options_3: '.crt-activities-card',
+    id_options_4: '.crt-summary-card',
+    id_options_5: '.crt-comments-card'
+  };
 
-  var report = document.getElementById('printout_report');
+  var modal = document.getElementById('print_report');
+  var original_beforeprint = root.onbeforeprint;
+  var original_afterprint = root.onafterprint;
   var showModal = function(event) {
     event.preventDefault();
     if (modal.getAttribute('hidden') !== null) {
+      // set up before and after print handlers so that we can
+      // selectively hide or show sections.
+      root.onbeforeprint = function(event) {
+        for (var option_id in option_mapping_to_section) {
+          var el = document.getElementById(option_id);
+          var classname = option_mapping_to_section[option_id];
+          var section = complaint_page.querySelector(classname);
+          if (!el.checked) {
+            section.setAttribute('hidden', 'hidden');
+          }
+        }
+      };
+      root.onafterprint = function(event) {
+        for (var option_id in option_mapping_to_section) {
+          var el = document.getElementById(option_id);
+          var classname = option_mapping_to_section[option_id];
+          var section = complaint_page.querySelector(classname);
+          if (!el.checked) {
+            section.removeAttribute('hidden');
+          }
+        }
+      };
       root.CRT.openModal(modal);
     } else {
+      // reset before and after print handlers.
+      root.onbeforeprint = original_beforeprint;
+      root.onafterprint = original_afterprint;
       root.CRT.closeModal(modal);
     }
   };
+
+  var report = document.getElementById('printout_report');
   report.addEventListener('click', showModal);
   report.addEventListener('keydown', showModal);
 
   var cancel_modal = document.getElementById('print_report_cancel');
   root.CRT.cancelModal(modal, cancel_modal);
 
-  // TODO
-  // if no options are clicked, disable print button
+  // if no options are clicked, disable the print button.
+  var print_button = document.getElementById('do_print_report');
+  for (var option_id in option_mapping_to_section) {
+    var el = document.getElementById(option_id);
+    el.onclick = function(event) {
+      var selected = modal.querySelectorAll('input[type=checkbox]:checked');
+      if (selected.length == 0) {
+        print_button.setAttribute('disabled', 'disabled');
+      } else {
+        print_button.removeAttribute('disabled');
+      }
+    };
+  }
 
-})(window);
+  print_button.onclick = function(event) {
+    // hide the modal lest we print the modal itself.
+    dom.body.classList.remove('is-modal');
+    modal.setAttribute('hidden', 'hidden');
+    root.print();
+  };
+})(window, document);

--- a/crt_portal/static/js/print_report.js
+++ b/crt_portal/static/js/print_report.js
@@ -16,4 +16,7 @@
   var cancel_modal = document.getElementById('print_report_cancel');
   root.CRT.cancelModal(modal, cancel_modal);
 
+  // TODO
+  // if no options are clicked, disable print button
+
 })(window);

--- a/crt_portal/static/js/print_report.js
+++ b/crt_portal/static/js/print_report.js
@@ -4,9 +4,9 @@
     id_options_0: '.crt-correspondent-card',
     id_options_1: '.crt-report-card',
     id_options_2: '.crt-description-card',
-    id_options_3: '.crt-activities-card',
+    id_options_3: '.crt-comments-card',
     id_options_4: '.crt-summary-card',
-    id_options_5: '.crt-comments-card'
+    id_options_5: '.crt-activities-card'
   };
 
   var modal = document.getElementById('print_report');

--- a/crt_portal/static/js/print_report.js
+++ b/crt_portal/static/js/print_report.js
@@ -1,0 +1,19 @@
+(function(root) {
+  var modal = document.getElementById('print_report');
+
+  var report = document.getElementById('printout_report');
+  var showModal = function(event) {
+    event.preventDefault();
+    if (modal.getAttribute('hidden') !== null) {
+      root.CRT.openModal(modal);
+    } else {
+      root.CRT.closeModal(modal);
+    }
+  };
+  report.addEventListener('click', showModal);
+  report.addEventListener('keydown', showModal);
+
+  var cancel_modal = document.getElementById('print_report_cancel');
+  root.CRT.cancelModal(modal, cancel_modal);
+
+})(window);

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -421,6 +421,10 @@
 .intake-section {
   margin: 2rem 0;
 
+  button {
+    margin: 0.5rem 0.5rem 0.5rem 0;
+  }
+
   .icon {
     width: initial;
   }

--- a/crt_portal/static/sass/custom/modal.scss
+++ b/crt_portal/static/sass/custom/modal.scss
@@ -99,6 +99,25 @@ body.is-modal {
   }
 }
 
+.print-report--modal {
+  // TODO refactor css with .intake-template--modal
+  h1 {
+    color: color($theme-color-primary-darker);
+    margin-top: 0;
+    font-size: 2rem;
+    border-bottom: 1px solid color($theme-color-primary-darker);
+  }
+
+  .print-report--content {
+    flex-grow: 1;
+  }
+
+  ul {
+    list-style-type: none;
+    margin-left: 1rem;
+  }
+}
+
 .intake-letter-preview {
   @media print {
     position: absolute;

--- a/crt_portal/static/sass/custom/modal.scss
+++ b/crt_portal/static/sass/custom/modal.scss
@@ -52,6 +52,14 @@ body.is-modal {
     height: 60%;
     min-height: 40rem; // a11y: don't collapse modal
     padding: 2rem;
+    @include at-media(tablet) {
+      width: 70%;
+      padding: 2rem;
+    }
+    @include at-media(desktop) {
+      width: 50%;
+      padding: 3rem;
+    }
   }
 
   .modal-form {

--- a/crt_portal/static/sass/custom/modal.scss
+++ b/crt_portal/static/sass/custom/modal.scss
@@ -4,7 +4,7 @@ body.is-modal {
   overflow-y: hidden;
 
   @media print {
-    main, header, .crt-header--warning-pii {
+    main, header {
       display: none;
     }
   }
@@ -62,21 +62,26 @@ body.is-modal {
     }
   }
 
+  .modal-main {
+    flex-grow: 1;
+  }
+
   .modal-form {
     display: flex;
     flex-direction: column;
     height: calc(100% - 4rem);
   }
-}
 
-// specific modal instances
-.intake-template--modal {
-  h1 {
+  h1:not(.h2__display) {
     color: color($theme-color-primary-darker);
     margin-top: 0;
     font-size: 2rem;
     border-bottom: 1px solid color($theme-color-primary-darker);
   }
+}
+
+// specific modal instances
+.intake-template--modal {
 
   .intake-template--description {
     min-height: 2rem;
@@ -85,10 +90,6 @@ body.is-modal {
   #intake_select {
     width: 50%;
     margin-bottom: 2rem;
-  }
-
-  .intake-template--content {
-    flex-grow: 1;
   }
 
   #intake_letter {
@@ -100,18 +101,6 @@ body.is-modal {
 }
 
 .print-report--modal {
-  // TODO refactor css with .intake-template--modal
-  h1 {
-    color: color($theme-color-primary-darker);
-    margin-top: 0;
-    font-size: 2rem;
-    border-bottom: 1px solid color($theme-color-primary-darker);
-  }
-
-  .print-report--content {
-    flex-grow: 1;
-  }
-
   ul {
     list-style-type: none;
     margin-left: 1rem;

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -65,7 +65,7 @@
 }
 
 // print-only cards
-.crt-actions-card, .crt-comments-card, .crt-summary-card {
+.crt-activities-card, .crt-comments-card, .crt-summary-card {
   display: none;
   @media print {
     display: block;

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -3,15 +3,27 @@
     background-color: color('white');
   }
 
-  // TODO check to make sure this doesn't impact confirmation page
-  // TODO hide messages
+  // selectively hide page elements that we don't want to be visible
+  // when printing.
+  // - hide the header.
   header.intake-header,
+  // - do not show any status messages, if any.
+  #status-update,
+  // - hide complaint filter navigation.
   .complaint-navigation,
+  // - hide the actions form card.
   .crt-action-card,
+  // - hide the "new comment" card.
   .crt-comment-new,
+  // - hide the current summary (embedded in the details form) as we
+  //   have a separate print-only summary section.
   .crt-current-summary,
-  .activity-stream, // TODO
+  // - hide the activity stream section, since we have separate
+  //   print-only actions and comments sections.
+  .activity-stream,
+  // - we want to show report questions instead.
   .report-details-label,
+  // - always hide the warning banner.
   .crt-header--warning-pii {
     display: none;
   }
@@ -45,6 +57,7 @@
       padding: 0;
     }
 
+    // simulate personal description card to look like its own section.
     .complaint-card-heading {
       // below does not work: can only @extend from within same directive
       // @extend .intake-section-title;

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -4,10 +4,13 @@
   }
 
   // TODO check to make sure this doesn't impact confirmation page
+  // TODO hide messages
   header.intake-header,
   .complaint-navigation,
   .crt-action-card,
   .crt-comment-new,
+  .crt-current-summary,
+  .activity-stream, // TODO
   .crt-header--warning-pii {
     display: none;
   }
@@ -22,7 +25,7 @@
     }
 
     .complaint-page {
-      flex-direction: column-reverse; // make activity log last
+      flex-direction: column-reverse; // make activity section last
     }
     .complaint-information {
       @include grid-col(11);
@@ -41,7 +44,7 @@
       padding: 0;
     }
 
-    .complaint-card-heading, [for=current-summary-text] {
+    .complaint-card-heading {
       // below does not work: can only @extend from within same directive
       // @extend .intake-section-title;
       @include text--heading__medium();

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -11,8 +11,20 @@
     display: none;
   }
 
-  .crt-portal-card {
+  #main-content, .details-id {
+    margin: 0;
+  }
 
+  .complaint-page {
+    flex-direction: column-reverse; // make activity log last
+  }
+  .complaint-information {
+    @include grid-col(12);
+    @include grid-offset(0);
+  }
+  .complaint-actions {
+    @include grid-col(12);
+    @include grid-offset(0);
   }
 
   .activity-stream .crt-portal-card__content {

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -1,6 +1,23 @@
 @media print {
-  header.intake-header, .crt-header--warning-pii {
+  .intake-bg {
+    background-color: color('white');
+  }
+
+  header.intake-header,
+  .complaint-navigation,
+  .crt-action-card,
+  .crt-comment-new,
+  .crt-header--warning-pii {
     display: none;
+  }
+
+  .crt-portal-card {
+
+  }
+
+  .activity-stream .crt-portal-card__content {
+    max-height: none;
+    overflow-y: visible;
   }
 }
 

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -11,6 +11,7 @@
   .crt-comment-new,
   .crt-current-summary,
   .activity-stream, // TODO
+  .report-details-label,
   .crt-header--warning-pii {
     display: none;
   }
@@ -65,7 +66,11 @@
 }
 
 // print-only cards
-.crt-activities-card, .crt-comments-card, .crt-summary-card {
+.crt-activities-card,
+.crt-comments-card,
+.crt-summary-card,
+// and question columns
+.report-print-question {
   display: none;
   @media print {
     display: block;

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -3,6 +3,7 @@
     background-color: color('white');
   }
 
+  // TODO check to make sure this doesn't impact confirmation page
   header.intake-header,
   .complaint-navigation,
   .crt-action-card,
@@ -15,21 +16,48 @@
     margin: 0;
   }
 
-  .complaint-page {
-    flex-direction: column-reverse; // make activity log last
-  }
-  .complaint-information {
-    @include grid-col(12);
-    @include grid-offset(0);
-  }
-  .complaint-actions {
-    @include grid-col(12);
-    @include grid-offset(0);
-  }
+  .complaint-show-body {
+    .title-icon, .usa-button {
+      display: none;
+    }
 
-  .activity-stream .crt-portal-card__content {
-    max-height: none;
-    overflow-y: visible;
+    .complaint-page {
+      flex-direction: column-reverse; // make activity log last
+    }
+    .complaint-information {
+      @include grid-col(11);
+      @include grid-offset(1);
+    }
+    .complaint-actions {
+      @include grid-col(11);
+      @include grid-offset(1);
+    }
+
+    .crt-portal-card {
+      box-shadow: unset;
+    }
+
+    .crt-portal-card__content {
+      padding: 0;
+    }
+
+    .complaint-card-heading, [for=current-summary-text] {
+      // below does not work: can only @extend from within same directive
+      // @extend .intake-section-title;
+      @include text--heading__medium();
+      font-family: family('heading');
+      font-weight: $theme-font-weight-bold;
+      color: color($theme-color-primary-darker);
+      text-transform: none;
+
+      padding-bottom: 0.8rem;
+      border-bottom: 1px solid;
+    }
+
+    .activity-stream .crt-portal-card__content {
+      max-height: none;
+      overflow-y: visible;
+    }
   }
 }
 

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -1,0 +1,18 @@
+@media print {
+  header.intake-header, .crt-header--warning-pii {
+    display: none;
+  }
+}
+
+.activity-stream-list {
+  display: block;
+  @media print {
+    display: none;
+  }
+  &.activity-stream-print {
+    display: none;
+    @media print {
+      display: block;
+    }
+  }
+}

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -10,7 +10,7 @@
   // - do not show any status messages, if any.
   #status-update,
   // - hide complaint filter navigation.
-  .complaint-navigation,
+  .complaint-filter-navigation,
   // - hide the actions form card.
   .crt-action-card,
   // - hide the "new comment" card.

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -64,15 +64,10 @@
   }
 }
 
-.activity-stream-list {
-  display: block;
+// print-only cards
+.crt-actions-card, .crt-comments-card, .crt-summary-card {
+  display: none;
   @media print {
-    display: none;
-  }
-  &.activity-stream-print {
-    display: none;
-    @media print {
-      display: block;
-    }
+    display: block;
   }
 }

--- a/crt_portal/static/sass/styles.scss
+++ b/crt_portal/static/sass/styles.scss
@@ -49,3 +49,4 @@
 @import 'custom/touchpoints';
 @import 'custom/links';
 @import 'custom/modal';
+@import 'custom/print';


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/629)

## What does this change?

Adds a new form to print out the current report sections selectively. The bulk of the work here is adding a new print scss file and adding information where necessary to support an alternative "print" page for the report.

## Screenshots (for front-end PR):

![2020-08-27_16-12](https://user-images.githubusercontent.com/3013175/91503714-12609980-e880-11ea-8963-f5d032ab39da.png)

Note that for testing purposes, it may be easier to enable "print" media rendering as seen in the below screenshot.

![2020-08-27_15-52](https://user-images.githubusercontent.com/3013175/91502599-500ff300-e87d-11ea-9402-dc1208b41565.png)

**Please note that [Safari has known issues with print dialogs](https://developer.mozilla.org/en-US/docs/Web/API/Window/print)** and that IE 11 does not render to PDFs by default (it will actually try to print).

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
