### PR TITLE
Reset status and assignee

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -305,6 +305,13 @@ class Report(models.Model):
         self.assigned_to = None
         self.closed_date = datetime.now()
 
+    def status_assignee_reset(self):
+        """
+        Remove assignee and update status to new
+        """
+        self.assigned_to = None
+        self.status = 'new'
+
 
 class Trends(models.Model):
     """see the top 10 non-stop words from violation summary """

--- a/crt_portal/cts_forms/tests/tests.py
+++ b/crt_portal/cts_forms/tests/tests.py
@@ -871,7 +871,7 @@ class Complaint_Update_Tests(TestCase):
         test_report.location_city_town = 'Cleveland'
         test_report.location_state = 'OH'
         test_report.assigned_section = test_report.assign_section()
-        test_report.status = 'new'
+        test_report.status = 'open'
         test_report.save()
 
         self.test_report = test_report
@@ -888,10 +888,10 @@ class Complaint_Update_Tests(TestCase):
         self.user.delete()
 
     def test_update_status_property(self):
-        self.form_data.update({'status': 'open'})
-        self.assertTrue(self.test_report.status == 'new')
+        self.form_data.update({'status': 'new'})
+        self.assertTrue(self.test_report.status == 'open')
         response = self.client.post(self.url, self.form_data, follow=True)
-        self.assertTrue(response.context['data'].status == 'open')
+        self.assertTrue(response.context['data'].status == 'new')
 
     def test_update_assigned_section_property(self):
         self.form_data.update({'assigned_section': 'VOT'})

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -381,6 +381,10 @@ class ShowView(LoginRequiredMixin, View):
         if form.is_valid() and form.has_changed():
             report = form.save(commit=False)
 
+            # Reset Assignee and Status if assigned_section is changed
+            if 'assigned_section' in form.changed_data:
+                report.status_assignee_reset()
+
             # district and location are on different forms so handled here.
             # If the incident location changes, update the district.
             # District can be overwritten in the drop down.


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/661undefined)

## What does this change?
When updating a complaint record where assigned section is modified the following changes are also applied. Status is set to 'new' and assignee is set to none.

## Screenshots (for front-end PR):
**Before Update**
![image](https://user-images.githubusercontent.com/66343959/91489607-150ebf00-e87f-11ea-81fd-dbb06bdd68d9.png)
**After Update**
![image](https://user-images.githubusercontent.com/66343959/91490019-cc0b3a80-e87f-11ea-8b75-c12e0eec2c7b.png)

## Checklist:

### Author
hakhalid11

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
