### PR TITLE
fix alignment for filters

### DIFF
--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -97,7 +97,7 @@
     width: 100%;
     flex-wrap: wrap;
     white-space: normal;
-    align-items: baseline;
+    align-items: center;
 
     @include at-media(desktop-lg) {
       padding-right: 4rem;
@@ -125,6 +125,7 @@
 
       input {
         border: none;
+        margin-top: 0;
       }
 
       input[name='contact_first_name'] {


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/679)

## What does this change?

Fixes a fairly subtle alignment issue, most evident in IE11 but also present in Edge/Chrome.

## Screenshots (for front-end PR):

Before (Chrome):

![2020-08-31_15-13_1](https://user-images.githubusercontent.com/3013175/91774007-b7d77e00-eb9c-11ea-9444-e5dfb4e0ec53.png)

Before (IE11)

![2020-08-31_15-16](https://user-images.githubusercontent.com/3013175/91774115-f5d4a200-eb9c-11ea-99ae-d909dbd3f70f.png)

After (Chrome):

![2020-08-31_15-13](https://user-images.githubusercontent.com/3013175/91774014-be65f580-eb9c-11ea-815c-a712d2d778e8.png)

After (IE11):

![2020-08-31_15-15](https://user-images.githubusercontent.com/3013175/91774055-d473b600-eb9c-11ea-995e-135f31e83afc.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
