### PR TITLE
add google tracking code for production

### DIFF
--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -24,6 +24,13 @@
         <meta property="name" content="{{meta_title}}" />
       {% endblock meta_title %}
 
+      {% block meta_analytics %}
+        {% environment as env %}
+        {% if env == "PRODUCTION" %}
+          <meta name="google-site-verification" content="UA2qkRn7lIwEkydkzZG2yZEykhLDmEqn8hibqT8105A" />
+        {% endif %}
+      {% endblock %}
+
       {% block meta_description %}
         {% trans 'Have you or someone you know experienced unlawful discrimination? The Civil Rights Division may be able to help. Civil rights laws can protect you from unlawful discrimination, harassment, or abuse in a variety of settings like housing, the workplace, school, voting, businesses, healthcare, public spaces, and more.' as meta_description %}
         <meta property="og:description" content="{{meta_description}}" />

--- a/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% block meta_analytics %}{% endblock %}
 {% block usa_banner %}{% endblock %}
 {% block page_header %}
   {% include 'forms/complaint_view/intake_header.html' with title_text="CRT Public Complaint Intake" %}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/674)

## What does this change?

Adds a `meta` google site verification tag.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
