### PR TITLE
handle comment form validation errors.

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1138,6 +1138,7 @@ class CommentActions(ModelForm):
 
     def __init__(self, *args, **kwargs):
         ModelForm.__init__(self, *args, **kwargs)
+        self.fields['note'].max_length = 7000
         self.fields['note'].widget = Textarea(
             attrs={
                 'class': 'usa-textarea',

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1135,6 +1135,11 @@ class CommentActions(ModelForm):
     class Meta:
         model = CommentAndSummary
         fields = ['note']
+        error_messages = {
+            'note': {
+                'required': _('Comment cannot be empty'),
+            },
+        }
 
     def __init__(self, *args, **kwargs):
         ModelForm.__init__(self, *args, **kwargs)

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -91,6 +91,25 @@ class CommentActionTests(TestCase):
         content = str(response.content)
         self.assertTrue('updated note' in content)
 
+    def test_comment_overflow(self):
+        comment_id = CommentAndSummary.objects.get(note=self.note).pk
+        too_many_words = 'la la la ' * 2500
+        response = self.client.post(
+            reverse(
+                'crt_forms:save-report-comment',
+                kwargs={'report_id': self.pk},
+            ),
+            {
+                'is_summary': False,
+                'note': too_many_words,
+                'comment_id': comment_id,
+            },
+            follow=True
+        )
+        content = str(response.content)
+        self.assertTrue('Could not save comment' in content)
+        self.assertEquals(response.status_code, 200)
+
 
 class ReportEditFormTests(TestCase):
     def setUp(self):

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -470,10 +470,18 @@ class SaveCommentView(LoginRequiredMixin, FormView):
             url = preserve_filter_parameters(report, request.POST)
             return redirect(url)
         else:
-            # TODO handle form validation failures
+            for key in comment_form.errors:
+                errors = '; '.join(comment_form.errors[key])
+                error_message = f'Could not save comment: {errors}'
+                messages.add_message(request, messages.ERROR, error_message)
+
             output = serialize_data(report, request, report_id)
             filter_output = setup_filter_parameters(report, request.POST)
+            contact_form = ContactEditForm(instance=report)
+            details_form = ReportEditForm(instance=report)
             output.update({
+                'contact_form': contact_form,
+                'details_form': details_form,
                 'return_url_args': request.POST.get('next', ''),
                 'index': request.POST.get('index', ''),
                 **filter_output,

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -122,4 +122,8 @@ ul.messages {
 
 h2.messages {
   margin-top: 0px;
+
+  li.error {
+    color: color($theme-color-secondary-dark);
+  }
 }


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/684)

Edit: **and** fixes [Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/601)

## What does this change?

Handle comment form errors. Makes intake errors more visible. And best of all, removes a `TODO` comment!

## Screenshots (for front-end PR):

(too many characters)

![2020-08-31_15-58](https://user-images.githubusercontent.com/3013175/91776973-7bf3e700-eba3-11ea-96d6-0c34e5ac1159.png)

(blank submission)

![2020-09-02_12-47](https://user-images.githubusercontent.com/3013175/92029536-8d133400-ed1a-11ea-8012-c1b88350463f.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
