### PR TITLE
modal tweak: remove keydown as to avoid triggering when tabbing

### DIFF
--- a/crt_portal/static/js/form_letter.js
+++ b/crt_portal/static/js/form_letter.js
@@ -11,7 +11,6 @@
     }
   };
   contact.addEventListener('click', showModal);
-  contact.addEventListener('keydown', showModal);
 
   var cancel_modal = document.getElementById('intake_template_cancel');
   root.CRT.cancelModal(modal, cancel_modal);

--- a/crt_portal/static/js/print_report.js
+++ b/crt_portal/static/js/print_report.js
@@ -48,7 +48,6 @@
 
   var report = document.getElementById('printout_report');
   report.addEventListener('click', showModal);
-  report.addEventListener('keydown', showModal);
 
   var cancel_modal = document.getElementById('print_report_cancel');
   root.CRT.cancelModal(modal, cancel_modal);

--- a/crt_portal/static/js/routing_guide.js
+++ b/crt_portal/static/js/routing_guide.js
@@ -11,7 +11,6 @@
     }
   };
   toggle.addEventListener('click', showModal);
-  toggle.addEventListener('keydown', showModal);
 
   var cancel_modal = document.getElementById('routing_guide_close');
   root.CRT.cancelModal(modal, cancel_modal);


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/688)

## What does this change?

Remove `keydown` as a trigger for modals. User must hit `<Enter>` or click explicitly.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
