### PR TITLE
Revise wording for routing guide modal toggle

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -19,7 +19,7 @@
       </label>
       {{ actions.assigned_section }}
       <button class="help-text usa-button usa-button--unstyled" id="routing-guide-toggle">
-        <span>How do I reroute?</span>
+        <span>rerouting guide</span>
       </button>
     </div>
     <div class="margin-bottom-2 crt-dropdown crt-dropdown__shrink-to-contents">

--- a/crt_portal/static/sass/custom/modal.scss
+++ b/crt_portal/static/sass/custom/modal.scss
@@ -96,6 +96,10 @@ body.is-modal {
     min-height: 40rem; // a11y: don't collapse modal
     padding: 2rem;
   }
+
+  .modal-footer {
+    margin-top: 0.5rem;
+  }
 }
 
 .intake-template--modal {


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/657)

## What does this change?
Using `rerouting guide` as text for opening the routing guide modal and adding a touch of spacing above the modal `Close` button.

## Screenshots (for front-end PR):
### Toggle text
<img width="409" alt="Screen Shot 2020-09-01 at 11 39 17 AM" src="https://user-images.githubusercontent.com/3485564/91874103-cdee4880-ec47-11ea-9432-c7fc7b43348a.png">

### Close button
<img width="976" alt="Screen Shot 2020-09-01 at 11 39 25 AM" src="https://user-images.githubusercontent.com/3485564/91874117-d050a280-ec47-11ea-87e3-066f9b8c1f1a.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
