### PR TITLE
set up organizational GA/google tag tracking

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -261,6 +261,7 @@ if environment in ['PRODUCTION', 'STAGE', 'DEVELOP']:
         'https://touchpoints.app.cloud.gov',
         'https://dap.digitalgov.gov',
         'https://www.google-analytics.com',
+        'https://www.googletagmanager.com/',
     )
     # headers required for security
     SESSION_COOKIE_SECURE = True
@@ -279,6 +280,7 @@ if environment in ['PRODUCTION', 'STAGE', 'DEVELOP']:
         'https://dap.digitalgov.gov',
         'https://www.google-analytics.com',
         'https://touchpoints.app.cloud.gov',
+        'https://www.googletagmanager.com/',
     )
     CSP_CONNECT_SRC = (
         "'self'",
@@ -288,6 +290,7 @@ if environment in ['PRODUCTION', 'STAGE', 'DEVELOP']:
         'https://dap.digitalgov.gov',
         'https://www.google-analytics.com',
         'https://touchpoints.app.cloud.gov',
+        'https://www.googletagmanager.com/',
     )
     CSP_IMG_SRC = allowed_sources
     CSP_MEDIA_SRC = allowed_sources

--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -113,6 +113,13 @@
     {% environment as env %}
     {% if env == "PRODUCTION" %}
       <script async="async" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOJ&amp;sp=find&amp;subagency=crt"></script>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-176942176-1"></script>
+      <script>
+       window.dataLayer = window.dataLayer || [];
+       function gtag(){dataLayer.push(arguments);}
+       gtag('js', new Date());
+       gtag('config', 'UA-176942176-1');
+      </script>
     {% endif %}
     {% endblock %}
   </body>


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/675)

## What does this change?

Adds organizational GA and google tag tracking script. Note that in terms of CSP, I believe we need `img-src` and `script-src` ([documentation here](https://developers.google.com/tag-manager/web/csp)) and `connect-src` to make the actual request.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
