### PR TITLE
Quickview

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -4,6 +4,7 @@
 <table class="usa-table crt-table sort-table">
   <thead>
     <tr>
+      <th></th>
       {% render_sortable_heading 'Status' sort_state filter_state %}
       {% render_sortable_heading 'Routed' sort_state filter_state %}
       {% render_sortable_heading 'Submitted' sort_state filter_state %}
@@ -18,6 +19,9 @@
     <tbody>
     {% for datum in data_dict %}
       <tr class="tr-status-{{ datum.report.status }} tr--hover{% cycle ' stripe' '' %}">
+        <td>
+          &gt;
+        </td>
         <td>
           <a class="td-link display-block" href="{{datum.url}}">
             <span class="status-tag status-{{ datum.report.status }}">
@@ -64,6 +68,35 @@
             {{ datum.report.last_incident_month|default:"-" }}/{{datum.report.last_incident_day|default:"-"}}/{{ datum.report.last_incident_year|default:"-" }}
           </a>
         </td>
+      </tr>
+      {# this row is hidden by default #}
+      <tr>
+        <td></td>
+        <td colspan="2">
+          <div class="td-quickview">
+            Contact
+          </div>
+          <div class="display-flex flex-column">
+            <span>
+              {{ datum.report.contact_last_name|default:"-" }} {{ datum.report.contact_first_name|default:"-" }}
+            </span>
+            <span>
+              {{ datum.report.contact_email|default:"-" }}
+            </span>
+            <span>
+              {{ datum.report.contact_phone|default:"-" }}
+            </span>
+          </div>
+        </td>
+        <td colspan="4">
+          <div class="td-quickview">
+            Summary
+          </div>
+          <div class="td-summary">
+            {{ datum.report.violation_summary|linebreaks|default:"-" }}
+          </div>
+        </td>
+        <td colspan="2"></td>
       </tr>
     {% endfor %}
     </tbody>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -21,7 +21,7 @@
       <tr class="tr-status-{{ datum.report.status }} tr--hover{% cycle ' stripe' '' %}">
         <td>
           <a data-id="{{ datum.report.id }}" class="td-toggle display-flex" href="#">
-            <img src="{% static "img/intake-icons/ic_chevron-right.svg" %}" alt="toggle" class="icon">
+            <img src="{% static "img/intake-icons/ic_chevron-right.svg" %}" alt="show additional information in a new row" class="icon">
           </a>
         </td>
         <td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -20,7 +20,9 @@
     {% for datum in data_dict %}
       <tr class="tr-status-{{ datum.report.status }} tr--hover{% cycle ' stripe' '' %}">
         <td>
-          &gt;
+          <a class="td-toggle display-flex" href="#">
+            <img src="{% static "img/intake-icons/ic_chevron-right.svg" %}" alt="toggle" class="icon">
+          </a>
         </td>
         <td>
           <a class="td-link display-block" href="{{datum.url}}">
@@ -62,7 +64,6 @@
             {% endwith %}
           </a>
         </td>
-
         <td>
           <a class="td-link display-block" href="{{datum.url}}">
             {{ datum.report.last_incident_month|default:"-" }}/{{datum.report.last_incident_day|default:"-"}}/{{ datum.report.last_incident_year|default:"-" }}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -20,7 +20,7 @@
     {% for datum in data_dict %}
       <tr class="tr-status-{{ datum.report.status }} tr--hover{% cycle ' stripe' '' %}">
         <td>
-          <a class="td-toggle display-flex" href="#">
+          <a data-id="{{ datum.report.id }}" class="td-toggle display-flex" href="#">
             <img src="{% static "img/intake-icons/ic_chevron-right.svg" %}" alt="toggle" class="icon">
           </a>
         </td>
@@ -71,7 +71,7 @@
         </td>
       </tr>
       {# this row is hidden by default #}
-      <tr>
+      <tr id="tr-additional-{{ datum.report.id }}" hidden>
         <td></td>
         <td colspan="2">
           <div class="td-quickview">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -32,6 +32,7 @@
 {% endblock %}
 {% block page_js %}
 {{ block.super }}
+<script src="{% static 'js/complaint_quick_view.js' %}"></script>
 <script src="{% static 'js/complaint_view_filters.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/accessible-autocomplete.min.js' %}"></script>
 <script nonce="{{request.csp_nonce}}">

--- a/crt_portal/static/js/complaint_quick_view.js
+++ b/crt_portal/static/js/complaint_quick_view.js
@@ -1,0 +1,3 @@
+(function(root, dom) {
+  console.log('foo');
+})(window, document);

--- a/crt_portal/static/js/complaint_quick_view.js
+++ b/crt_portal/static/js/complaint_quick_view.js
@@ -1,13 +1,18 @@
 (function(root, dom) {
-  var toggles = dom.querySelectorAll('.td-toggle');
+  var toggles = dom.querySelectorAll('a.td-toggle');
   for (var i = 0; i < toggles.length; i++) {
     var toggle = toggles[i];
     toggle.onclick = function(event) {
-      var target = event.target;
-      if (target.classList.contains('rotate')) {
-        target.classList.remove('rotate');
+      var target = event.currentTarget;
+      var id = target.dataset["id"];
+      var image = target.children[0];
+      var row = dom.getElementById("tr-additional-" + id);
+      if (image.classList.contains('rotate')) {
+        image.classList.remove('rotate');
+        row.setAttribute('hidden', '');
       } else {
-        target.classList.add('rotate');
+        image.classList.add('rotate');
+        row.removeAttribute('hidden');
       }
       event.preventDefault();
     };

--- a/crt_portal/static/js/complaint_quick_view.js
+++ b/crt_portal/static/js/complaint_quick_view.js
@@ -4,9 +4,9 @@
     var toggle = toggles[i];
     toggle.onclick = function(event) {
       var target = event.currentTarget;
-      var id = target.dataset["id"];
+      var id = target.dataset['id'];
       var image = target.children[0];
-      var row = dom.getElementById("tr-additional-" + id);
+      var row = dom.getElementById('tr-additional-' + id);
       if (image.classList.contains('rotate')) {
         image.classList.remove('rotate');
         row.setAttribute('hidden', '');

--- a/crt_portal/static/js/complaint_quick_view.js
+++ b/crt_portal/static/js/complaint_quick_view.js
@@ -1,3 +1,15 @@
 (function(root, dom) {
-  console.log('foo');
+  var toggles = dom.querySelectorAll('.td-toggle');
+  for (var i = 0; i < toggles.length; i++) {
+    var toggle = toggles[i];
+    toggle.onclick = function(event) {
+      var target = event.target;
+      if (target.classList.contains('rotate')) {
+        target.classList.remove('rotate');
+      } else {
+        target.classList.add('rotate');
+      }
+      event.preventDefault();
+    };
+  }
 })(window, document);

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -116,9 +116,9 @@
     }
 
     .td-toggle {
-      width: 100%;
-      height: 100%;
-      padding: 0;
+      width: auto;
+      height: auto;
+      padding: 1rem 0;
 
       img {
         max-width: unset;

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -114,6 +114,22 @@
     .td-link {
       @include clickable-table-cell();
     }
+
+    .td-quickview {
+      font-weight: bold;
+      text-transform: uppercase;
+      margin-bottom: 0.5rem;
+    }
+
+    .td-summary {
+      height: 4rem;
+      max-height: 4rem;
+      overflow-y: auto;
+
+      p:first-child {
+        margin-top: 0;
+      }
+    }
   }
 
   tbody {

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -115,6 +115,21 @@
       @include clickable-table-cell();
     }
 
+    .td-toggle {
+      width: 100%;
+      height: 100%;
+      padding: 0;
+
+      img {
+        max-width: unset;
+      }
+
+      .rotate {
+        transform: rotate(90deg);
+        transition-duration: 120ms;
+      }
+    }
+
     .td-quickview {
       font-weight: bold;
       text-transform: uppercase;
@@ -123,8 +138,9 @@
 
     .td-summary {
       height: 4rem;
-      max-height: 4rem;
+      max-height: 10rem;
       overflow-y: auto;
+      resize: vertical;
 
       p:first-child {
         margin-top: 0;


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/691)

## What does this change?

Adds quick view for report tables (see contact and violation summary at a glance).

## Screenshots (for front-end PR):

![2020-09-03_17-31](https://user-images.githubusercontent.com/3013175/92186325-46513700-ee0b-11ea-9507-700862289a2a.png)

Note that the last two columns are intentionally left empty; long text stretching across the page doesn't look good. So we might want some design feedback for this one.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
