### PR TITLE
Allow OR searches for the violation_summary field

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -1,8 +1,10 @@
 # Class to handle filtering Reports by supplied query params,
 # provided they are valid filterable model properties.
-from datetime import datetime
-import urllib.parse
 import logging
+import urllib.parse
+from datetime import datetime
+
+from django.contrib.postgres.search import SearchQuery, SearchVector
 
 from .models import Report
 
@@ -51,6 +53,7 @@ def _get_date_field_from_param(field):
 def report_filter(querydict):
     kwargs = {}
     filters = {}
+    qs = Report.objects.filter()
     for field in filter_options.keys():
         filter_list = querydict.getlist(field)
 
@@ -87,7 +90,15 @@ def report_filter(querydict):
             elif filter_options[field] == '__gte':
                 kwargs[field] = querydict.getlist(field)
             elif filter_options[field] == 'violation_summary':
-                kwargs[field] = querydict.getlist(field)
+                combined_or_search = _combine_term_searches_with_or(filter_list)
+                qs = qs.annotate(search=SearchVector('violation_summary')).filter(search=combined_or_search)
+    qs = qs.filter(**kwargs)
+    return qs, filters
 
-    # returns a filtered query, and a dictionary that we can use to keep track of the filters we apply
-    return Report.objects.filter(**kwargs), filters
+
+def _combine_term_searches_with_or(terms):
+    """Create a CombinedSearchQuery of all received search terms"""
+    combined_search = SearchQuery(terms.pop())
+    for term in terms:
+        combined_search = combined_search | SearchQuery(term)
+    return combined_search

--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -18,7 +18,7 @@ filter_options = {
     'contact_last_name': '__contains',
     'contact_email': '__search',
     'other_class': '__search',
-    'violation_summary': '__search',
+    'violation_summary': 'violation_summary',
     'location_name': '__contains',
     'location_city_town': '__contains',
     'location_address_line_1': '__search',
@@ -53,6 +53,7 @@ def report_filter(querydict):
     filters = {}
     for field in filter_options.keys():
         filter_list = querydict.getlist(field)
+
         if len(filter_list) > 0:
             filters[field] = querydict.getlist(field)
             if filter_options[field] == '__in':
@@ -85,5 +86,8 @@ def report_filter(querydict):
                 kwargs[field] = querydict.getlist(field)[0]
             elif filter_options[field] == '__gte':
                 kwargs[field] = querydict.getlist(field)
+            elif filter_options[field] == 'violation_summary':
+                kwargs[field] = querydict.getlist(field)
+
     # returns a filtered query, and a dictionary that we can use to keep track of the filters we apply
     return Report.objects.filter(**kwargs), filters

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -1,6 +1,10 @@
-from django.test import SimpleTestCase
-
 from cts_forms.filters import _get_date_field_from_param
+from django.http import QueryDict
+from django.test import SimpleTestCase, TestCase
+
+from ..filters import report_filter
+from ..models import Report
+from .test_data import SAMPLE_REPORT
 
 
 class FilterTests(SimpleTestCase):
@@ -9,3 +13,27 @@ class FilterTests(SimpleTestCase):
         self.assertEquals(_get_date_field_from_param('create_date_start'), 'create_date')
         self.assertEquals(_get_date_field_from_param('closed_date_end'), 'closed_date')
         self.assertEquals(_get_date_field_from_param('modified_date_start'), 'modified_date')
+
+
+class ReportFilterTests(TestCase):
+    def setUp(self):
+        test_data = SAMPLE_REPORT.copy()
+        test_data['violation_summary'] = 'plane'
+        Report.objects.create(**test_data)
+        test_data['violation_summary'] = 'truck'
+        Report.objects.create(**test_data)
+
+    def test_no_filters(self):
+        """Returns all reports when no filters provided"""
+        reports, _ = report_filter(QueryDict(''))
+        self.assertEquals(reports.count(), Report.objects.count())
+
+    def test_or_search_for_violation_summary(self):
+        """
+        Returns queryset responsive to N terms provided as OR search
+        """
+        reports, _ = report_filter(QueryDict('violation_summary=plane'))
+        self.assertEquals(reports.count(), 1)
+
+        reports, _ = report_filter(QueryDict('violation_summary=plane&violation_summary=truck'))
+        self.assertEquals(reports.count(), 2)


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/689)

## What does this change?
Backend changes allowing users to pass multiple search terms as URL Query parameters to effect a full text search OR search for each term within the `violation_summary` field.

Implementation notes:
We're creating a CombinedSearchQuery by combing `SearchyQuery` instances per the [django docs](https://docs.djangoproject.com/en/2.2/ref/contrib/postgres/search/#searchquery)

As currently configured there's a 4096 character limit for query parameters. If a user searches for a string, or combination of strings that exceeds that limit they'll get a `400 bad request` error.

Paired with @ilodidoj on this one! 

## Screenshots (for front-end PR):
* No UI included for this functionality but the provided search terms will render on the page.
![Screen Shot 2020-09-04 at 12 12 43 PM](https://user-images.githubusercontent.com/3485564/92261754-02f8d600-eea8-11ea-8f31-2eb7420418bc.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
