### PR TITLE
bugfix: don't duplicate filter params per sort param

### DIFF
--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -241,21 +241,25 @@ def IndexView(request):
     sort_state = {}
     # make sure the links for this page have the same paging, sorting, filtering etc.
     page_args = f'?per_page={per_page}'
-    filter_args = ''
 
+    # process filter query params
+    filter_args = ''
     for query_item in query_filters.keys():
         arg = query_item
         for item in query_filters[query_item]:
             filter_args = filter_args + f'&{arg}={item}'
+    page_args += filter_args
 
+    # process sort query params
+    sort_args = ''
     for sort_item in sort:
         if sort_item[0] == SORT_DESC_CHAR:
             sort_state.update({sort_item[1::]: True})
         else:
             sort_state.update({sort_item: False})
 
-        # all query params except info about what page we are on
-        page_args = page_args + f'&sort={sort_item}{filter_args}'
+        sort_args += f'&sort={sort_item}'
+    page_args += sort_args
 
     all_args_encoded = urllib.parse.quote(f'{page_args}&page={page}')
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/693)

## What does this change?

For each sort param we had, we were inadvertently duplicating filter params. Fixed.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
