### PR TITLE
Updated complaint form question text

### DIFF
--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -1161,18 +1161,18 @@ msgid "Please share details like:"
 msgstr "Comparta detalles como:"
 
 #: question_text.py:63
-msgid "Time;"
-msgstr "hora,"
+msgid "Time"
+msgstr "hora"
 
 #: question_text.py:64
-msgid "Names of people involved including witnesses if there are any; and"
+msgid "Names of people involved including witnesses if there are any"
 msgstr ""
 "los nombres de las personas involucradas, incluyendo a testigos, si los "
-"hubiera y"
+"hubiera"
 
 #: question_text.py:65
-msgid "Any supporting materials (please list and describe them)."
-msgstr "Cualquier material de apoyo (haga una lista y describa cada artículo)."
+msgid "Any supporting materials (please list and describe them)"
+msgstr "Cualquier material de apoyo (haga una lista y describa cada artículo)"
 
 #: templates/base.html:22 templates/base.html:40 templates/forms/base.html:19
 #: templates/forms/report_base.html:13

--- a/crt_portal/cts_forms/question_text.py
+++ b/crt_portal/cts_forms/question_text.py
@@ -60,7 +60,7 @@ SUMMARY_QUESTION = _('In your own words, describe what happened')
 SUMMARY_HELPTEXT = {
     'title': _('Please share details like:'),
     'examples': [
-        _('Time;'),
-        _('Names of people involved including witnesses if there are any; and'),
+        _('Time'),
+        _('Names of people involved including witnesses if there are any'),
         _('Any supporting materials (please list and describe them).')],
 }

--- a/crt_portal/cts_forms/question_text.py
+++ b/crt_portal/cts_forms/question_text.py
@@ -62,5 +62,5 @@ SUMMARY_HELPTEXT = {
     'examples': [
         _('Time'),
         _('Names of people involved including witnesses if there are any'),
-        _('Any supporting materials (please list and describe them).')],
+        _('Any supporting materials (please list and describe them)')],
 }


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/687)

## What does this change?
Changes complaint form question text, removes semicolon and the word "and".
## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/66343959/92498906-3483e100-f1c9-11ea-9608-d1a22c85c47c.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
