### PR TITLE
Rename summary quickview column

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -91,7 +91,7 @@
         </td>
         <td colspan="4">
           <div class="td-quickview">
-            Summary
+            Personal Description
           </div>
           <div class="td-summary">
             {{ datum.report.violation_summary|linebreaks|default:"-" }}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/691)

## What does this change?
Uses `Personal Description` as column header in Report quickview table row.
<img width="1341" alt="Screen Shot 2020-09-09 at 9 30 39 AM" src="https://user-images.githubusercontent.com/3485564/92609914-18457a00-f285-11ea-9b04-f83cdf49fad4.png">

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
