### PR TITLE
Rename IndexView to index_view

### DIFF
--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import (IndexView, ShowView, ProFormView, SaveCommentView,
+from .views import (index_view, ShowView, ProFormView, SaveCommentView,
                     TrendView, ResponseView, PrintView)
 from .forms import ProForm
 
@@ -11,7 +11,7 @@ urlpatterns = [
     path('view/<int:id>/', ShowView.as_view(), name='crt-forms-show'),
     path('view/<int:id>/response', ResponseView.as_view(), name='crt-forms-response'),
     path('view/<int:id>/print', PrintView.as_view(), name='crt-forms-print'),
-    path('view/', IndexView, name='crt-forms-index'),
+    path('view/', index_view, name='crt-forms-index'),
     path('new/', ProFormView.as_view([ProForm]), name='crt-pro-form'),
     path('comment/report/<int:report_id>/', SaveCommentView.as_view(), name='save-report-comment'),
     path('trends/', TrendView.as_view(), name='trends'),

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -221,7 +221,7 @@ def setup_filter_parameters(report, querydict):
 
 
 @login_required
-def IndexView(request):
+def index_view(request):
     report_query, query_filters = report_filter(request.GET)
 
     # Sort data based on request from params, default to `created_date` of complaint


### PR DESCRIPTION
No Zenhub issue

## What does this change?
Renames `IndexView` to `index_view`. 
This is a [function based view](https://docs.djangoproject.com/en/2.2/topics/http/views/#a-simple-view), renaming it to conform with Django naming conventions.

## Checklist:

### Author

+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
