### PR TITLE
Hotfix/702bugfix - value error for empty index fixed

### DIFF
--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -186,6 +186,9 @@ def setup_filter_parameters(report, querydict):
     return_url_args = querydict.get('next', '')
     index = querydict.get('index', None)
 
+    if index == '':
+        index = None
+
     if return_url_args and index is not None:
         querydict = QueryDict(return_url_args)
         report_query, _ = report_filter(querydict)


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/702)

## What does this change?
Replacement for #673 

> This checks for empty index value to mitigate error 500.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
