### PR TITLE
Multi-select reports

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1175,6 +1175,14 @@ class PrintActions(Form):
     )
 
 
+class BulkAssign(Form, ActivityStreamUpdater):
+    assigned_to = ModelChoiceField(
+        queryset=User.objects.filter(is_active=True),
+        label="Assigned to",
+        required=True
+    )
+
+
 class ContactEditForm(ModelForm, ActivityStreamUpdater):
     CONTEXT_KEY = 'contact_form'
     SUCCESS_MESSAGE = "Successfully updated contact information."

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
@@ -19,25 +19,43 @@
       <input type="hidden" value="{{ ids }}" name="ids" id="ids" />
       <input type="hidden" value="{{ selected_all }}" name="all" id="all" />
 
-      {{ assign_form }}
+      <div id="assign_section">
+        {{ assign_form }}
 
-      <button class="usa-button"
-              disabled
-              type="submit"
-              name="selected_ids"
-      >
-        Apply changes to {{ ids_count }} records
-      </button>
+        <button class="usa-button"
+                disabled
+                type="submit"
+                name="selected_ids"
+        >
+          Apply changes to {{ ids_count }} records
+        </button>
+
+        {% if selected_all %}
+          <button class="usa-button button--warning display-flex align-center"
+                  id="show_warning_section"
+                  disabled
+          >
+            Apply changes to {{ all_ids_count }} records
+          </button>
+        {% endif %}
+      </div>
 
       {% if selected_all %}
-        <button class="usa-button button--warning display-flex align-center"
-                type="submit"
-                disabled
-                name="all"
-                value="all"
-        >
-          Apply changes to {{ all_ids_count }} records
-        </button>
+        <div id="warning_section" hidden>
+          <p>
+            Are you sure you want to assign {{ all_ids_count }} records to <span id="warning_section_assignee"></span>?
+          </p>
+          <button class="usa-button button--warning display-flex align-center"
+                  name="all"
+                  value="all"
+                  type="submit">
+            Yes
+          </button>
+          <button class="usa-button"
+                  id="cancel_warning_section">
+            No
+          </button>
+        </div>
       {% endif %}
     </form>
   {% else %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
@@ -11,27 +11,31 @@
 {% endblock %}
 
 {% block card_content %}
-  <form class="usa-form" method="post" novalidate>
-    {% csrf_token %}
+  {% if ids_count %}
+    <form class="usa-form" method="post" novalidate>
+      {% csrf_token %}
 
-    {{ assign_form }}
+      {{ assign_form }}
 
-    <button class="usa-button"
-            disabled
-            type="submit"
-            name="selected_ids"
-    >
-      Apply changes to {{ ids | length }} records
-    </button>
-
-    {% if selected_all %}
-      <button class="usa-button button--warning display-flex align-center"
-              type="submit"
+      <button class="usa-button"
               disabled
-              name="all_ids"
+              type="submit"
+              name="selected_ids"
       >
-        Apply changes to {{ all_ids_count }} records
+        Apply changes to {{ ids_count }} records
       </button>
-    {% endif %}
-  </form>
+
+      {% if selected_all %}
+        <button class="usa-button button--warning display-flex align-center"
+                type="submit"
+                disabled
+                name="all_ids"
+        >
+          Apply changes to {{ all_ids_count }} records
+        </button>
+      {% endif %}
+    </form>
+  {% else %}
+    <p>No records were selected.</p>
+  {% endif %}
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
@@ -46,8 +46,8 @@
             Are you sure you want to assign {{ all_ids_count }} records to <span id="warning_section_assignee"></span>?
           </p>
           <button class="usa-button button--warning display-flex align-center"
-                  name="all"
-                  value="all"
+                  name="confirm_all"
+                  value="confirm_all"
                   type="submit">
             Yes
           </button>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
@@ -1,0 +1,37 @@
+{% extends "forms/complaint_view/show/card.html" %}
+
+{% load static %}
+
+{% block title %}Bulk assign{% endblock %}
+
+{% block extra_classes %}crt-actions-card{% endblock %}
+
+{% block icon %}
+  <img src="{% static "img/ic_personcheck-circle.svg" %}" alt="icon" class="icon" />
+{% endblock %}
+
+{% block card_content %}
+  <form class="usa-form" method="post" novalidate>
+    {% csrf_token %}
+
+    {{ assign_form }}
+
+    <button class="usa-button"
+            disabled
+            type="submit"
+            name="selected_ids"
+    >
+      Apply changes to {{ ids | length }} records
+    </button>
+
+    {% if selected_all %}
+      <button class="usa-button button--warning display-flex align-center"
+              type="submit"
+              disabled
+              name="all_ids"
+      >
+        Apply changes to {{ all_ids_count }} records
+      </button>
+    {% endif %}
+  </form>
+{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
@@ -17,6 +17,7 @@
 
       <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
       <input type="hidden" value="{{ ids }}" name="ids" id="ids" />
+      <input type="hidden" value="{{ selected_all }}" name="all" id="all" />
 
       {{ assign_form }}
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
@@ -15,6 +15,9 @@
     <form class="usa-form" method="post" novalidate>
       {% csrf_token %}
 
+      <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
+      <input type="hidden" value="{{ ids }}" name="ids" id="ids" />
+
       {{ assign_form }}
 
       <button class="usa-button"
@@ -29,7 +32,8 @@
         <button class="usa-button button--warning display-flex align-center"
                 type="submit"
                 disabled
-                name="all_ids"
+                name="all"
+                value="all"
         >
           Apply changes to {{ all_ids_count }} records
         </button>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -55,7 +55,7 @@
      defaultValue: '',
      selectElement: document.querySelector('#id_assigned_to'),
      onConfirm: function(what) {
-       var buttons = document.querySelectorAll(".usa-button");
+       var buttons = document.querySelectorAll('.complaint-page .usa-button');
        for(var i = 0; i < buttons.length; i++) {
          var button = buttons[i];
          button.removeAttribute('disabled');
@@ -67,6 +67,7 @@
          var option = options[i];
          if (option.text === what) {
            actualSelectElement.value = option.value;
+           break;
          }
        }
      }

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -25,6 +25,23 @@
           </div>
         </div>
       </div>
+
+      <div class="complaint-page grid-row grid-gap-4">
+        <div class="complaint-actions tablet:grid-col-4 grid-offset-1">
+        <p>
+          {{ ids | length }} complaints are chosen for assignment. Choose who you want to assign them to:
+        </p>
+
+        IDs:
+        <ul>
+          {% for id in ids %}
+            <li>{{ id }}</li>
+          {% endfor %}
+        </ul>
+
+        All IDs chosen? {{ selected_all }}
+        </div>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -50,48 +50,7 @@
 {% block page_js %}
   {{ block.super }}
   <script type="text/javascript" src="{% static 'js/accessible-autocomplete.min.js' %}"></script>
+  <script src="{% static 'js/bulk_assign.js' %}"></script>
   <script nonce="{{request.csp_nonce}}">
-   accessibleAutocomplete.enhanceSelectElement({
-     defaultValue: '',
-     selectElement: document.querySelector('#id_assigned_to'),
-     onConfirm: function(what) {
-       var buttons = document.querySelectorAll('.complaint-page .usa-button');
-       for(var i = 0; i < buttons.length; i++) {
-         var button = buttons[i];
-         button.removeAttribute('disabled');
-       }
-       // work around a bug in the accessible autocomplete library
-       var actualSelectElement = document.getElementById('id_assigned_to-select');
-       var options = actualSelectElement.options;
-       for(var i = 0; i < options.length; i++) {
-         var option = options[i];
-         if (option.text === what) {
-           actualSelectElement.value = option.value;
-           break;
-         }
-       }
-     }
-   });
-
-   var show_warning_section = document.getElementById('show_warning_section');
-   show_warning_section.onclick = function(event) {
-     event.preventDefault();
-     var assign = document.getElementById('assign_section');
-     var section = document.getElementById('warning_section');
-     var assignee = document.getElementById('warning_section_assignee');
-     var selectElement = document.getElementById('id_assigned_to');
-     assign.setAttribute('hidden', 'hidden');
-     section.removeAttribute('hidden');
-     assignee.innerText = selectElement.value;
-   };
-
-   var cancel_warning_section = document.getElementById('cancel_warning_section');
-   cancel_warning_section.onclick = function(event) {
-     event.preventDefault();
-     var assign = document.getElementById('assign_section');
-     var section = document.getElementById('warning_section');
-     assign.removeAttribute('hidden');
-     section.setAttribute('hidden', 'hidden');
-   }
   </script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -73,4 +73,4 @@
      }
    });
   </script>
-{%endblock%}
+{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -1,0 +1,41 @@
+{% extends "forms/complaint_view/intake_base.html" %}
+
+{% load static %}
+
+{% block page_title %}
+  <title>CRT Complaint Records - Actions</title>
+{% endblock %}
+
+{% block head %}
+  <link rel="stylesheet" href="{% static "css/accessible-autocomplete.min.css" %}" />
+{% endblock head %}
+
+{% block content %}
+  <div class="complaint-show-body">
+    <div class="grid-container-widescreen">
+      <div class="grid-row margin-bottom-1">
+        <div class="tablet:grid-col-10 grid-offset-1 padding-left-05">
+          <div class="complaint-filter-navigation display-flex flex-row flex-justify">
+            <div class="display-flex">
+              <a class="outline-button outline-button--dark" href="{% url 'crt_forms:crt-forms-index' %}{{ return_url_args }}">
+                <img src="{% static "img/intake-icons/ic_arrow_forward.svg" %}" alt="back arrow" class="icon">
+                Back to all
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block page_js %}
+  {{ block.super }}
+  <script type="text/javascript" src="{% static 'js/accessible-autocomplete.min.js' %}"></script>
+  <script nonce="{{request.csp_nonce}}">
+   accessibleAutocomplete.enhanceSelectElement({
+     defaultValue: '',
+     selectElement: document.querySelector('#id_assigned_to')
+   });
+  </script>
+{%endblock%}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -53,7 +53,14 @@
   <script nonce="{{request.csp_nonce}}">
    accessibleAutocomplete.enhanceSelectElement({
      defaultValue: '',
-     selectElement: document.querySelector('#id_assigned_to')
+     selectElement: document.querySelector('#id_assigned_to'),
+     onConfirm: function() {
+       var buttons = document.querySelectorAll(".usa-button");
+       for(var i = 0; i < buttons.length; i++) {
+         var button = buttons[i];
+         button.removeAttribute('disabled');
+       }
+     }
    });
   </script>
 {%endblock%}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -51,6 +51,4 @@
   {{ block.super }}
   <script type="text/javascript" src="{% static 'js/accessible-autocomplete.min.js' %}"></script>
   <script src="{% static 'js/bulk_assign.js' %}"></script>
-  <script nonce="{{request.csp_nonce}}">
-  </script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -72,5 +72,26 @@
        }
      }
    });
+
+   var show_warning_section = document.getElementById('show_warning_section');
+   show_warning_section.onclick = function(event) {
+     event.preventDefault();
+     var assign = document.getElementById('assign_section');
+     var section = document.getElementById('warning_section');
+     var assignee = document.getElementById('warning_section_assignee');
+     var selectElement = document.getElementById('id_assigned_to');
+     assign.setAttribute('hidden', 'hidden');
+     section.removeAttribute('hidden');
+     assignee.innerText = selectElement.value;
+   };
+
+   var cancel_warning_section = document.getElementById('cancel_warning_section');
+   cancel_warning_section.onclick = function(event) {
+     event.preventDefault();
+     var assign = document.getElementById('assign_section');
+     var section = document.getElementById('warning_section');
+     assign.removeAttribute('hidden');
+     section.setAttribute('hidden', 'hidden');
+   }
   </script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block page_title %}
-  <title>CRT Complaint Records - Actions</title>
+  <title>CRT Complaint Records - Update multiple records</title>
 {% endblock %}
 
 {% block head %}
@@ -26,20 +26,21 @@
         </div>
       </div>
 
+      <div class="tablet:grid-col-4 grid-offset-1 padding-left-05">
+        <div class="display-flex flex-align-center">
+          <h1 class="h2__display backend-blue">
+            Update multiple records
+          </h1>
+        </div>
+      </div>
+
+      <div id="status-update" class="tablet:grid-col-6">
+        {% include 'partials/messages.html' %}
+      </div>
+
       <div class="complaint-page grid-row grid-gap-4">
         <div class="complaint-actions tablet:grid-col-4 grid-offset-1">
-        <p>
-          {{ ids | length }} complaints are chosen for assignment. Choose who you want to assign them to:
-        </p>
-
-        IDs:
-        <ul>
-          {% for id in ids %}
-            <li>{{ id }}</li>
-          {% endfor %}
-        </ul>
-
-        All IDs chosen? {{ selected_all }}
+          {% include 'forms/complaint_view/actions/bulk_assign.html' %}
         </div>
       </div>
     </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -54,11 +54,20 @@
    accessibleAutocomplete.enhanceSelectElement({
      defaultValue: '',
      selectElement: document.querySelector('#id_assigned_to'),
-     onConfirm: function() {
+     onConfirm: function(what) {
        var buttons = document.querySelectorAll(".usa-button");
        for(var i = 0; i < buttons.length; i++) {
          var button = buttons[i];
          button.removeAttribute('disabled');
+       }
+       // work around a bug in the accessible autocomplete library
+       var actualSelectElement = document.getElementById('id_assigned_to-select');
+       var options = actualSelectElement.options;
+       for(var i = 0; i < options.length; i++) {
+         var option = options[i];
+         if (option.text === what) {
+           actualSelectElement.value = option.value;
+         }
        }
      }
    });

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -13,6 +13,7 @@
 {% block content %}
   <div class="complaint-show-body">
     <div class="grid-container-widescreen">
+
       <div class="grid-row margin-bottom-1">
         <div class="tablet:grid-col-10 grid-offset-1 padding-left-05">
           <div class="complaint-filter-navigation display-flex flex-row flex-justify">
@@ -24,6 +25,9 @@
             </div>
           </div>
         </div>
+        <div id="status-update" class="tablet:grid-col-6 grid-offset-1 padding-left-05">
+          {% include 'partials/messages.html' %}
+        </div>
       </div>
 
       <div class="tablet:grid-col-4 grid-offset-1 padding-left-05">
@@ -32,10 +36,6 @@
             Update multiple records
           </h1>
         </div>
-      </div>
-
-      <div id="status-update" class="tablet:grid-col-6">
-        {% include 'partials/messages.html' %}
       </div>
 
       <div class="complaint-page grid-row grid-gap-4">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -1,136 +1,166 @@
 {% load sortable_table_heading %}
 {% load static %}
-<div class="crt-xscroll">
-<table class="usa-table crt-table sort-table">
-  <thead>
-    <tr>
-      <th></th>
-      {% render_sortable_heading 'Status' sort_state filter_state %}
-      {% render_sortable_heading 'Routed' sort_state filter_state %}
-      {% render_sortable_heading 'Submitted' sort_state filter_state %}
-      {% render_sortable_heading 'Contact Name' sort_state filter_state %}
-      {% render_sortable_heading 'Contact Details' sort_state filter_state %}
-      {% render_sortable_heading 'Incident Location' sort_state filter_state %}
-      {% render_sortable_heading 'Summary' sort_state filter_state %}
-      {% render_sortable_heading 'Incident Date' sort_state filter_state %}
-    </tr>
-  </thead>
-  {% if data_dict %}
-    <tbody>
-    {% for datum in data_dict %}
-      <tr class="tr-status-{{ datum.report.status }} tr--hover{% cycle ' stripe' '' %}">
-        <td>
-          <a data-id="{{ datum.report.id }}" class="td-toggle display-flex" href="#">
-            <img src="{% static "img/intake-icons/ic_chevron-right.svg" %}" alt="show additional information in a new row" class="icon">
-          </a>
-        </td>
-        <td>
-          <a class="td-link display-block" href="{{datum.url}}">
-            <span class="status-tag status-{{ datum.report.status }}">
-              {{ datum.report.status }}
-            </span>
-          </a>
-        </td>
-        <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.assigned_section }}</a></td>
-        <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.create_date|date:"SHORT_DATE_FORMAT" }}</a></td>
-        <td>
-          <a class="td-link display-block" href="{{datum.url}}">
-            {% with last=datum.report.contact_last_name|default:"—" %}
-              {{ last|truncatechars:20 }}{% endwith %}, {% with first=datum.report.contact_first_name|default:"—" %}
-              {{ first|truncatechars:20 }}
-            {% endwith %}
-          </a>
-        </td>
-        <td>
-          <a class="td-link display-block" href="{{datum.url}}">
-            {% with email=datum.report.contact_email|default:"—" %}
-              {{ email|truncatechars:20 }}
-            {% endwith %}
-            <br>
-            {% with phone=datum.report.contact_phone|default:"—"  %}
-              {{ phone|truncatechars:20 }}
-            {% endwith %}
-          </a>
-        </td>
-        <td>
-          <a class="td-link display-block" href="{{datum.url}}">
-              {{ datum.report.location_city_town }}, {{ datum.report.location_state }}
-          </a>
-        </td>
-        <td>
-          <a class="td-link display-block" href="{{datum.url}}">
-            {% with summary=datum.report.get_summary %}
-              {{ summary.note|default:"—"|truncatechars:60 }}
-            {% endwith %}
-          </a>
-        </td>
-        <td>
-          <a class="td-link display-block" href="{{datum.url}}">
-            {{ datum.report.last_incident_month|default:"-" }}/{{datum.report.last_incident_day|default:"-"}}/{{ datum.report.last_incident_year|default:"-" }}
-          </a>
-        </td>
-      </tr>
-      {# this row is hidden by default #}
-      <tr id="tr-additional-{{ datum.report.id }}" hidden>
-        <td></td>
-        <td colspan="2">
-          <div class="td-quickview">
-            Contact
-          </div>
-          <div class="display-flex flex-column">
-            <span>
-              {{ datum.report.contact_last_name|default:"-" }} {{ datum.report.contact_first_name|default:"-" }}
-            </span>
-            <span>
-              {{ datum.report.contact_email|default:"-" }}
-            </span>
-            <span>
-              {{ datum.report.contact_phone|default:"-" }}
-            </span>
-          </div>
-        </td>
-        <td colspan="4">
-          <div class="td-quickview">
-            Personal Description
-          </div>
-          <div class="td-summary">
-            {{ datum.report.violation_summary|linebreaks|default:"-" }}
-          </div>
-        </td>
-        <td colspan="2"></td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  {% endif %}
-</table>
-</div>
+<form class="usa-form"
+      method="post"
+      action="{% url 'crt_forms:crt-forms-actions' %}"
+      novalidate
+>
+  <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
+
+  <div class="crt-xscroll">
+    <table class="usa-table crt-table sort-table">
+      <thead>
+        <tr>
+          <th>
+            <div class="usa-checkbox td-checkbox">
+              <input type="checkbox"
+                     name="actions"
+                     class="usa-checkbox__input"
+                     value="all"
+                     id="checkbox-all"
+              >
+              <label class="crt-checkbox__label" for="checkbox-all"></label>
+            </div>
+          </th>
+          <th></th>
+          {% render_sortable_heading 'Status' sort_state filter_state %}
+          {% render_sortable_heading 'Routed' sort_state filter_state %}
+          {% render_sortable_heading 'Submitted' sort_state filter_state %}
+          {% render_sortable_heading 'Contact Name' sort_state filter_state %}
+          {% render_sortable_heading 'Contact Details' sort_state filter_state %}
+          {% render_sortable_heading 'Incident Location' sort_state filter_state %}
+          {% render_sortable_heading 'Summary' sort_state filter_state %}
+          {% render_sortable_heading 'Incident Date' sort_state filter_state %}
+        </tr>
+      </thead>
+      {% if data_dict %}
+        <tbody>
+          {% for datum in data_dict %}
+            <tr class="tr-status-{{ datum.report.status }} tr--hover{% cycle ' stripe' '' %}">
+              <td>
+                <div class="usa-checkbox td-checkbox">
+                  <input type="checkbox"
+                         name="actions"
+                         class="usa-checkbox__input"
+                         value="{{ datum.report.id }}"
+                         id="checkbox-{{ datum.report.id }}"
+                  >
+                  <label class="crt-checkbox__label" for="checkbox-{{ datum.report.id }}"></label>
+                </div>
+              </td>
+              <td>
+                <a data-id="{{ datum.report.id }}" class="td-toggle display-flex" href="#">
+                  <img src="{% static "img/intake-icons/ic_chevron-right.svg" %}" alt="show additional information in a new row" class="icon">
+                </a>
+              </td>
+              <td>
+                <a class="td-link display-block" href="{{datum.url}}">
+                  <span class="status-tag status-{{ datum.report.status }}">
+                    {{ datum.report.status }}
+                  </span>
+                </a>
+              </td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.assigned_section }}</a></td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.create_date|date:"SHORT_DATE_FORMAT" }}</a></td>
+              <td>
+                <a class="td-link display-block" href="{{datum.url}}">
+                  {% with last=datum.report.contact_last_name|default:"—" %}
+                    {{ last|truncatechars:20 }}{% endwith %}, {% with first=datum.report.contact_first_name|default:"—" %}
+                    {{ first|truncatechars:20 }}
+                    {% endwith %}
+                </a>
+              </td>
+              <td>
+                <a class="td-link display-block" href="{{datum.url}}">
+                  {% with email=datum.report.contact_email|default:"—" %}
+                    {{ email|truncatechars:20 }}
+                  {% endwith %}
+                  <br>
+                  {% with phone=datum.report.contact_phone|default:"—"  %}
+                    {{ phone|truncatechars:20 }}
+                  {% endwith %}
+                </a>
+              </td>
+              <td>
+                <a class="td-link display-block" href="{{datum.url}}">
+                  {{ datum.report.location_city_town }}, {{ datum.report.location_state }}
+                </a>
+              </td>
+              <td>
+                <a class="td-link display-block" href="{{datum.url}}">
+                  {% with summary=datum.report.get_summary %}
+                    {{ summary.note|default:"—"|truncatechars:60 }}
+                  {% endwith %}
+                </a>
+              </td>
+              <td>
+                <a class="td-link display-block" href="{{datum.url}}">
+                  {{ datum.report.last_incident_month|default:"-" }}/{{datum.report.last_incident_day|default:"-"}}/{{ datum.report.last_incident_year|default:"-" }}
+                </a>
+              </td>
+            </tr>
+            {# this row is hidden by default #}
+            <tr id="tr-additional-{{ datum.report.id }}" hidden>
+              <td colspan="2"></td>
+              <td colspan="2">
+                <div class="td-quickview">
+                  Contact
+                </div>
+                <div class="display-flex flex-column">
+                  <span>
+                    {{ datum.report.contact_last_name|default:"-" }} {{ datum.report.contact_first_name|default:"-" }}
+                  </span>
+                  <span>
+                    {{ datum.report.contact_email|default:"-" }}
+                  </span>
+                  <span>
+                    {{ datum.report.contact_phone|default:"-" }}
+                  </span>
+                </div>
+              </td>
+              <td colspan="4">
+                <div class="td-quickview">
+                  Personal Description
+                </div>
+                <div class="td-summary">
+                  {{ datum.report.violation_summary|linebreaks|default:"-" }}
+                </div>
+              </td>
+              <td colspan="2"></td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      {% endif %}
+    </table>
+  </div>
+</form>
 
 {% if not data_dict %}
-<div class="crt-portal-card table-message">
-  <div class="crt-portal-card__content">
-    <div class="grid-container padding-bottom-2">
-      <div class="align-center">
-        <img alt="filter icon" src="{% static 'img/filters.svg' %}" class="margin-top-1" />
-        <p class="margin-bottom-1 margin-top-1" role="status"><b>No records found</b></p>
-        <em>Try adjusting your filters to see more records</em>
+  <div class="crt-portal-card table-message">
+    <div class="crt-portal-card__content">
+      <div class="grid-container padding-bottom-2">
+        <div class="align-center">
+          <img alt="filter icon" src="{% static 'img/filters.svg' %}" class="margin-top-1" />
+          <p class="margin-bottom-1 margin-top-1" role="status"><b>No records found</b></p>
+          <em>Try adjusting your filters to see more records</em>
+        </div>
       </div>
     </div>
   </div>
-</div>
 {% endif %}
 
 {% if not page_format.has_next and data_dict %}
-<div class="crt-portal-card table-message">
-  <div class="crt-portal-card__content">
-    <div class="grid-container padding-bottom-2">
-      <div class="align-center">
-        <p class="margin-bottom-1">
-          <img alt="encouraging coffee icon" src="{% static 'img/coffee.svg' %}" />
-          <b>End of results</b>
-        </p>
-        <em>Try adjusting your filters to see more records</em>
+  <div class="crt-portal-card table-message">
+    <div class="crt-portal-card__content">
+      <div class="grid-container padding-bottom-2">
+        <div class="align-center">
+          <p class="margin-bottom-1">
+            <img alt="encouraging coffee icon" src="{% static 'img/coffee.svg' %}" />
+            <b>End of results</b>
+          </p>
+          <em>Try adjusting your filters to see more records</em>
+        </div>
       </div>
     </div>
   </div>
-</div>
 {% endif %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -15,7 +15,7 @@
           <th>
             <div class="usa-checkbox td-checkbox">
               <input type="checkbox"
-                     name="actions"
+                     name="all"
                      class="usa-checkbox__input"
                      value="all"
                      id="checkbox-all"

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -1,10 +1,11 @@
 {% load sortable_table_heading %}
 {% load static %}
 <form class="usa-form"
-      method="post"
+      method="get"
       action="{% url 'crt_forms:crt-forms-actions' %}"
       novalidate
 >
+  {% csrf_token %}
   <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
 
   <div class="crt-xscroll">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -5,7 +5,6 @@
       action="{% url 'crt_forms:crt-forms-actions' %}"
       novalidate
 >
-  {% csrf_token %}
   <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
 
   <div class="crt-xscroll">
@@ -41,7 +40,7 @@
               <td>
                 <div class="usa-checkbox td-checkbox">
                   <input type="checkbox"
-                         name="actions"
+                         name="id"
                          class="usa-checkbox__input"
                          value="{{ datum.report.id }}"
                          id="checkbox-{{ datum.report.id }}"

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -133,6 +133,18 @@
       {% endif %}
     </table>
   </div>
+
+  <div class="selection-action-notification" hidden>
+    <div class="display-flex">
+      <img src="{% static 'img/ic_successconfirmation.svg' %}" alt="action available on selection" class="icon">
+      <h2>
+        <span id="selection-action-count">1 record</span> selected
+      </h2>
+      <div class="selection-submit">
+        <button type="submit" id="actions" label="actions" class="usa-button">Actions</button>
+      </div>
+    </div>
+  </div>
 </form>
 
 {% if not data_dict %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -19,7 +19,7 @@
                      value="all"
                      id="checkbox-all"
               >
-              <label class="crt-checkbox__label" for="checkbox-all"></label>
+              <label class="crt-checkbox__label" for="checkbox-all" aria-label="select all records"></label>
             </div>
           </th>
           <th></th>
@@ -45,7 +45,7 @@
                          value="{{ datum.report.id }}"
                          id="checkbox-{{ datum.report.id }}"
                   >
-                  <label class="crt-checkbox__label" for="checkbox-{{ datum.report.id }}"></label>
+                  <label class="crt-checkbox__label" for="checkbox-{{ datum.report.id }}" aria-label="select record {{ datum.report.id }}"></label>
                 </div>
               </td>
               <td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -135,8 +135,10 @@
   </div>
 
   <div class="selection-action-notification" hidden>
-    <div class="display-flex">
-      <img src="{% static 'img/ic_successconfirmation.svg' %}" alt="action available on selection" class="icon">
+    <div class="display-flex flex-align-center">
+      <div>
+        <img src="{% static 'img/ic_successconfirmation.svg' %}" alt="action available on selection" class="icon">
+      </div>
       <h2>
         <span id="selection-action-count">1 record</span> selected
       </h2>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -34,6 +34,7 @@
 {{ block.super }}
 <script src="{% static 'js/complaint_quick_view.js' %}"></script>
 <script src="{% static 'js/complaint_view_filters.js' %}"></script>
+<script src="{% static 'js/complaint_actions.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/accessible-autocomplete.min.js' %}"></script>
 <script nonce="{{request.csp_nonce}}">
   accessibleAutocomplete.enhanceSelectElement({

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -7,6 +7,9 @@
 
 {% block content %}
 <div class="intake-content">
+  <div id="status-update" class="grid-col-auto">
+    {% include 'partials/messages.html' %}
+  </div>
   {% include "forms/complaint_view/index/filter-controls.html" with filters=filters form=form %}
   <div class="display-flex margin-top-8">
     {% include "forms/complaint_view/index/active-filters.html" %}

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -421,7 +421,7 @@ class BulkAssignTests(TestCase):
         self.assertTrue("button--warning" in content)
         self.assertTrue(f"Apply changes to {len(ids)} records" in content)
 
-    def post(self, user_id, ids, all_ids=False):
+    def post(self, user_id, ids, all_ids=False, confirm=False):
         params = {
             'next': '?per_page=15',
             'ids': ','.join([str(id) for id in ids]),
@@ -429,6 +429,8 @@ class BulkAssignTests(TestCase):
         }
         if all_ids:
             params['all'] = 'all'
+        if confirm:
+            params['confirm_all'] = 'confirm_all'
         response = self.client.post(reverse('crt_forms:crt-forms-actions'), params, follow=True)
         self.assertEquals(response.status_code, 200)
         return response
@@ -456,10 +458,24 @@ class BulkAssignTests(TestCase):
             self.assertEquals(last_activity.description, 'Updated from "None" to "DELETE_USER"')
             self.assertEquals(last_activity.actor, user)
 
+    def test_post_with_ids_and_all(self):
+        ids = [report.id for report in self.reports[3:5]]
+        user = User.objects.get(username='DELETE_USER')
+        response = self.post(user.id, ids, all_ids=True, confirm=False)
+        content = str(response.content)
+        self.assertTrue('2 records have been assigned to DELETE_USER' in content)
+        self.assertEquals(response.request['PATH_INFO'], reverse('crt_forms:crt-forms-index'))
+        for report_id in ids:
+            report = Report.objects.get(id=report_id)
+            last_activity = list(report.target_actions.all())[-1]
+            self.assertEquals(last_activity.verb, "Assigned to:")
+            self.assertEquals(last_activity.description, 'Updated from "None" to "DELETE_USER"')
+            self.assertEquals(last_activity.actor, user)
+
     def test_post_with_all(self):
         ids = [report.id for report in self.reports]
         user = User.objects.get(username='DELETE_USER')
-        response = self.post(user.id, ids, all_ids=True)
+        response = self.post(user.id, ids, all_ids=True, confirm=True)
         content = str(response.content)
         self.assertTrue('16 records have been assigned to DELETE_USER' in content)
         self.assertEquals(response.request['PATH_INFO'], reverse('crt_forms:crt-forms-index'))

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('view/<int:id>/print', PrintView.as_view(), name='crt-forms-print'),
     path('view/', index_view, name='crt-forms-index'),
     path('new/', ProFormView.as_view([ProForm]), name='crt-pro-form'),
+    path('actions/', ShowView.as_view(), name='crt-forms-actions'),
     path('comment/report/<int:report_id>/', SaveCommentView.as_view(), name='save-report-comment'),
     path('trends/', TrendView.as_view(), name='trends'),
 ]

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from .views import (index_view, ShowView, ProFormView, SaveCommentView,
-                    TrendView, ResponseView, PrintView)
+from .views import (ActionsView, index_view, ShowView, ProFormView,
+                    SaveCommentView, TrendView, ResponseView,
+                    PrintView)
 from .forms import ProForm
 
 app_name = 'crt_forms'
@@ -13,7 +14,7 @@ urlpatterns = [
     path('view/<int:id>/print', PrintView.as_view(), name='crt-forms-print'),
     path('view/', index_view, name='crt-forms-index'),
     path('new/', ProFormView.as_view([ProForm]), name='crt-pro-form'),
-    path('actions/', ShowView.as_view(), name='crt-forms-actions'),
+    path('actions/', ActionsView.as_view(), name='crt-forms-actions'),
     path('comment/report/<int:report_id>/', SaveCommentView.as_view(), name='save-report-comment'),
     path('trends/', TrendView.as_view(), name='trends'),
 ]

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -495,12 +495,13 @@ class ActionsView(LoginRequiredMixin, FormView):
         assign_form = BulkAssign(request.POST)
         return_url_args = request.POST.get('next', '')
         selected_all = request.POST.get('all', '') == 'all'
+        confirm_all = request.POST.get('confirm_all', '') == 'confirm_all'
         ids = request.POST.get('ids', '').split(',')
 
         if assign_form.is_valid():
             assignee = assign_form.cleaned_data['assigned_to']
             requested_query = None
-            if selected_all:
+            if confirm_all:
                 requested_query = self.reconstruct_query(return_url_args)
             else:
                 requested_query = Report.objects.filter(pk__in=ids)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -481,7 +481,7 @@ class ActionsView(LoginRequiredMixin, FormView):
         output = {
             'return_url_args': return_url_args,
             'selected_all': selected_all,
-            'ids': ','.join(ids),
+            'ids': ','.join([id for id in ids]),
             'ids_count': ids_count,
             'all_ids_count': all_ids_count,
             'assign_form': assign_form,
@@ -514,6 +514,9 @@ class ActionsView(LoginRequiredMixin, FormView):
             requested_query = self.reconstruct_query(return_url_args)
             all_ids_count = requested_query.count()
             ids_count = len(ids)
+
+            # preserve the selected all for initial submission
+            selected_all = request.POST.get('all', '') and all_ids_count != ids_count
 
             output = {
                 'return_url_args': return_url_args,

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -291,6 +291,7 @@ def index_view(request):
         'sort_state': sort_state,
         'filter_state': filter_args,
         'filters': query_filters,
+        'return_url_args': all_args_encoded,
     }
 
     return render(request, 'forms/complaint_view/index/index.html', final_data)
@@ -446,6 +447,20 @@ class ShowView(LoginRequiredMixin, View):
                     output.update({form_type: form(instance=report)})
 
             return render(request, 'forms/complaint_view/show/index.html', output)
+
+
+class ActionsView(LoginRequiredMixin, FormView):
+
+    def get(self, request):
+        return_url_args = request.GET.get('next', '');
+        return_url_args = urllib.parse.unquote(return_url_args)
+        output = {
+            'return_url_args': return_url_args,
+        }
+        return render(request, 'forms/complaint_view/actions/index.html', output)
+
+    def post(self, request):
+        pass
 
 
 class SaveCommentView(LoginRequiredMixin, FormView):

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1,5 +1,6 @@
 import os
 import urllib.parse
+import logging
 
 from django import forms
 from django.contrib import messages
@@ -35,6 +36,8 @@ from .model_variables import (COMMERCIAL_OR_PUBLIC_PLACE_DICT,
                               PUBLIC_OR_PRIVATE_SCHOOL_DICT)
 from .models import CommentAndSummary, Report, Trends
 from .page_through import pagination
+
+logger = logging.getLogger(__name__)
 
 SORT_DESC_CHAR = '-'
 
@@ -513,6 +516,9 @@ class ActionsView(LoginRequiredMixin, FormView):
 
             description = f"{number} reports have been assigned to {assignee}"
             messages.add_message(request, messages.SUCCESS, description)
+
+            # log this action for an audit trail.
+            logger.info(f'Bulk updating {number} requests by {request.user} to {assignee}')
 
             url = reverse('crt_forms:crt-forms-index')
             return redirect(f"{url}{return_url_args}")

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -514,7 +514,7 @@ class ActionsView(LoginRequiredMixin, FormView):
 
             number = requested_query.update(assigned_to=assignee)
 
-            description = f"{number} reports have been assigned to {assignee}"
+            description = f"{number} records have been assigned to {assignee}"
             messages.add_message(request, messages.SUCCESS, description)
 
             # log this action for an audit trail.

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -452,10 +452,15 @@ class ShowView(LoginRequiredMixin, View):
 class ActionsView(LoginRequiredMixin, FormView):
 
     def get(self, request):
-        return_url_args = request.GET.get('next', '');
+        return_url_args = request.GET.get('next', '')
         return_url_args = urllib.parse.unquote(return_url_args)
+        selected_all = request.GET.get('all', '') == 'all'
+        ids = request.GET.getlist('actions')
+
         output = {
             'return_url_args': return_url_args,
+            'selected_all': selected_all,
+            'ids': ids,
         }
         return render(request, 'forms/complaint_view/actions/index.html', output)
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -483,7 +483,7 @@ class ActionsView(LoginRequiredMixin, FormView):
 
         output = {
             'return_url_args': return_url_args,
-            'selected_all': selected_all,
+            'selected_all': 'all' if selected_all else '',
             'ids': ','.join([id for id in ids]),
             'ids_count': ids_count,
             'all_ids_count': all_ids_count,
@@ -538,7 +538,7 @@ class ActionsView(LoginRequiredMixin, FormView):
 
             output = {
                 'return_url_args': return_url_args,
-                'selected_all': selected_all,
+                'selected_all': 'all' if selected_all else '',
                 'ids': ids,
                 'ids_count': ids_count,
                 'all_ids_count': all_ids_count,

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -500,7 +500,6 @@ class ActionsView(LoginRequiredMixin, FormView):
 
         if assign_form.is_valid():
             assignee = assign_form.cleaned_data['assigned_to']
-            requested_query = None
             if confirm_all:
                 requested_query = self.reconstruct_query(return_url_args)
             else:

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -502,13 +502,17 @@ class ActionsView(LoginRequiredMixin, FormView):
             else:
                 requested_query = Report.objects.filter(pk__in=ids)
 
+            # update activity log _before_ we update the assignee so
+            # that we have access to the original assignee
+            for report in requested_query:
+                original = report.assigned_to or "None"
+                description = f'Updated from "{original}" to "{assignee}"'
+                add_activity(request.user, "Assigned to:", description, report)
+
             number = requested_query.update(assigned_to=assignee)
 
             description = f"{number} reports have been assigned to {assignee}"
             messages.add_message(request, messages.SUCCESS, description)
-
-            # TODO
-            # add_activity(request.user, "Printed report", description, report)
 
             url = reverse('crt_forms:crt-forms-index')
             return redirect(f"{url}{return_url_args}")

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -527,8 +527,8 @@ class ActionsView(LoginRequiredMixin, FormView):
             all_ids_count = requested_query.count()
             ids_count = len(ids)
 
-            # preserve the selected all for initial submission
-            selected_all = request.POST.get('all', '') and all_ids_count != ids_count
+            # further refine selected_all to ensure < 15 items don't show up.
+            selected_all = selected_all and all_ids_count != ids_count
 
             output = {
                 'return_url_args': return_url_args,

--- a/crt_portal/static/js/bulk_assign.js
+++ b/crt_portal/static/js/bulk_assign.js
@@ -1,0 +1,43 @@
+(function(root, dom) {
+  accessibleAutocomplete.enhanceSelectElement({
+    defaultValue: '',
+    selectElement: document.querySelector('#id_assigned_to'),
+    onConfirm: function(what) {
+      var buttons = document.querySelectorAll('.complaint-page .usa-button');
+      for (var i = 0; i < buttons.length; i++) {
+        var button = buttons[i];
+        button.removeAttribute('disabled');
+      }
+      // work around a bug in the accessible autocomplete library
+      var actualSelectElement = document.getElementById('id_assigned_to-select');
+      var options = actualSelectElement.options;
+      for (var i = 0; i < options.length; i++) {
+        var option = options[i];
+        if (option.text === what) {
+          actualSelectElement.value = option.value;
+          break;
+        }
+      }
+    }
+  });
+
+  var assign_section = document.getElementById('assign_section');
+  var warning_section = document.getElementById('warning_section');
+
+  var show_warning_section = document.getElementById('show_warning_section');
+  show_warning_section.onclick = function(event) {
+    event.preventDefault();
+    var assignee = document.getElementById('warning_section_assignee');
+    var selectElement = document.getElementById('id_assigned_to');
+    assign_section.setAttribute('hidden', 'hidden');
+    warning_section.removeAttribute('hidden');
+    assignee.innerText = selectElement.value;
+  };
+
+  var cancel_warning_section = document.getElementById('cancel_warning_section');
+  cancel_warning_section.onclick = function(event) {
+    event.preventDefault();
+    assign_section.removeAttribute('hidden');
+    warning_section.setAttribute('hidden', 'hidden');
+  };
+})(window, document);

--- a/crt_portal/static/js/bulk_assign.js
+++ b/crt_portal/static/js/bulk_assign.js
@@ -23,7 +23,6 @@
 
   var assign_section = document.getElementById('assign_section');
   var warning_section = document.getElementById('warning_section');
-
   var show_warning_section = document.getElementById('show_warning_section');
   show_warning_section.onclick = function(event) {
     event.preventDefault();

--- a/crt_portal/static/js/bulk_assign.js
+++ b/crt_portal/static/js/bulk_assign.js
@@ -32,7 +32,8 @@
     warning_section.removeAttribute('hidden');
     // work around a bug: if user removes an auto complete field, the
     // selected item is still present, so pull from the actual selection
-    assignee.innerText = actualSelectElement.selectedOptions[0].text;
+    var index = actualSelectElement.selectedIndex;
+    assignee.innerText = actualSelectElement.options[index].text;
   };
 
   var cancel_warning_section = document.getElementById('cancel_warning_section');

--- a/crt_portal/static/js/bulk_assign.js
+++ b/crt_portal/static/js/bulk_assign.js
@@ -27,10 +27,12 @@
   show_warning_section.onclick = function(event) {
     event.preventDefault();
     var assignee = document.getElementById('warning_section_assignee');
-    var selectElement = document.getElementById('id_assigned_to');
+    var actualSelectElement = document.getElementById('id_assigned_to-select');
     assign_section.setAttribute('hidden', 'hidden');
     warning_section.removeAttribute('hidden');
-    assignee.innerText = selectElement.value;
+    // work around a bug: if user removes an auto complete field, the
+    // selected item is still present, so pull from the actual selection
+    assignee.innerText = actualSelectElement.selectedOptions[0].text;
   };
 
   var cancel_warning_section = document.getElementById('cancel_warning_section');

--- a/crt_portal/static/js/bulk_assign.js
+++ b/crt_portal/static/js/bulk_assign.js
@@ -24,22 +24,26 @@
   var assign_section = document.getElementById('assign_section');
   var warning_section = document.getElementById('warning_section');
   var show_warning_section = document.getElementById('show_warning_section');
-  show_warning_section.onclick = function(event) {
-    event.preventDefault();
-    var assignee = document.getElementById('warning_section_assignee');
-    var actualSelectElement = document.getElementById('id_assigned_to-select');
-    assign_section.setAttribute('hidden', 'hidden');
-    warning_section.removeAttribute('hidden');
-    // work around a bug: if user removes an auto complete field, the
-    // selected item is still present, so pull from the actual selection
-    var index = actualSelectElement.selectedIndex;
-    assignee.innerText = actualSelectElement.options[index].text;
-  };
+  if (show_warning_section) {
+    show_warning_section.onclick = function(event) {
+      event.preventDefault();
+      var assignee = document.getElementById('warning_section_assignee');
+      var actualSelectElement = document.getElementById('id_assigned_to-select');
+      assign_section.setAttribute('hidden', 'hidden');
+      warning_section.removeAttribute('hidden');
+      // work around a bug: if user removes an auto complete field, the
+      // selected item is still present, so pull from the actual selection
+      var index = actualSelectElement.selectedIndex;
+      assignee.innerText = actualSelectElement.options[index].text;
+    };
+  }
 
   var cancel_warning_section = document.getElementById('cancel_warning_section');
-  cancel_warning_section.onclick = function(event) {
-    event.preventDefault();
-    assign_section.removeAttribute('hidden');
-    warning_section.setAttribute('hidden', 'hidden');
-  };
+  if (cancel_warning_section) {
+    cancel_warning_section.onclick = function(event) {
+      event.preventDefault();
+      assign_section.removeAttribute('hidden');
+      warning_section.setAttribute('hidden', 'hidden');
+    };
+  }
 })(window, document);

--- a/crt_portal/static/js/complaint_actions.js
+++ b/crt_portal/static/js/complaint_actions.js
@@ -1,4 +1,17 @@
 (function(root, dom) {
+  function update_record_count() {
+    var action_notification_el = dom.querySelector('.selection-action-notification');
+    var count_el = dom.getElementById('selection-action-count');
+    var count = dom.querySelectorAll('td input.usa-checkbox__input:checked').length;
+    if (count === 0) {
+      action_notification_el.setAttribute('hidden', 'hidden');
+    } else {
+      var records_plural = count === 1 ? ' record' : ' records';
+      count_el.innerText = count + records_plural;
+      action_notification_el.removeAttribute('hidden');
+    }
+  }
+
   var all_checkboxes = dom.querySelectorAll('td input.usa-checkbox__input');
   for (var i = 0; i < all_checkboxes.length; i++) {
     var checkbox = all_checkboxes[i];
@@ -10,6 +23,7 @@
       } else {
         parent.classList.remove('selected');
       }
+      update_record_count();
     };
   }
 
@@ -20,6 +34,7 @@
       var checkbox = all_checkboxes[i];
       if (checkbox.checked !== checked) {
         checkbox.click(); // trigger onclick function
+        update_record_count();
       }
     }
   };

--- a/crt_portal/static/js/complaint_actions.js
+++ b/crt_portal/static/js/complaint_actions.js
@@ -12,6 +12,7 @@
     }
   }
 
+  var select_all_checkboxes = dom.getElementById('checkbox-all');
   var all_checkboxes = dom.querySelectorAll('td input.usa-checkbox__input');
   for (var i = 0; i < all_checkboxes.length; i++) {
     var checkbox = all_checkboxes[i];
@@ -22,12 +23,14 @@
         parent.classList.add('selected');
       } else {
         parent.classList.remove('selected');
+        if (select_all_checkboxes.checked) {
+          select_all_checkboxes.checked = false;
+        }
       }
       update_record_count();
     };
   }
 
-  var select_all_checkboxes = dom.getElementById('checkbox-all');
   select_all_checkboxes.onclick = function(event) {
     var checked = event.target.checked;
     for (var i = 0; i < all_checkboxes.length; i++) {

--- a/crt_portal/static/js/complaint_actions.js
+++ b/crt_portal/static/js/complaint_actions.js
@@ -34,7 +34,6 @@
       var checkbox = all_checkboxes[i];
       if (checkbox.checked !== checked) {
         checkbox.click(); // trigger onclick function
-        update_record_count();
       }
     }
   };

--- a/crt_portal/static/js/complaint_actions.js
+++ b/crt_portal/static/js/complaint_actions.js
@@ -1,0 +1,26 @@
+(function(root, dom) {
+  var all_checkboxes = dom.querySelectorAll('td input.usa-checkbox__input');
+  for (var i = 0; i < all_checkboxes.length; i++) {
+    var checkbox = all_checkboxes[i];
+    checkbox.onclick = function(event) {
+      var target = event.target;
+      var parent = target.parentNode.parentNode.parentNode;
+      if (target.checked) {
+        parent.classList.add('selected');
+      } else {
+        parent.classList.remove('selected');
+      }
+    };
+  }
+
+  var select_all_checkboxes = dom.getElementById('checkbox-all');
+  select_all_checkboxes.onclick = function(event) {
+    var checked = event.target.checked;
+    for (var i = 0; i < all_checkboxes.length; i++) {
+      var checkbox = all_checkboxes[i];
+      if (checkbox.checked !== checked) {
+        checkbox.click(); // trigger onclick function
+      }
+    }
+  };
+})(window, document);

--- a/crt_portal/static/js/dropdown.js
+++ b/crt_portal/static/js/dropdown.js
@@ -104,7 +104,10 @@
      * dropdowns
      **/
     var node = hasParentNode(event.target, function(n) {
-      for (i = 0; i < n.classList.length; i++) {
+      if (!n.classList) {
+        return false;
+      }
+      for (var i = 0; i < n.classList.length; i++) {
         if (n.classList[i].indexOf('crt-dropdown') === -1) {
           return false;
         } else {

--- a/crt_portal/static/sass/_uswds-theme-color.scss
+++ b/crt_portal/static/sass/_uswds-theme-color.scss
@@ -38,7 +38,7 @@ $theme-color-base-ink:              'gray-warm-80';
 $theme-color-primary-family:        'blue';
 $theme-color-primary-lightest:      'blue-warm-5';
 $theme-color-primary-lighter:       'blue-warm-10';
-$theme-color-primary-light:         false;
+$theme-color-primary-light:         'blue-warm-20';
 $theme-color-primary:               'blue-warm-70v';
 $theme-color-primary-vivid:         false;
 $theme-color-primary-dark:          'blue-warm-70v';

--- a/crt_portal/static/sass/custom/buttons.scss
+++ b/crt_portal/static/sass/custom/buttons.scss
@@ -3,6 +3,19 @@ button,
   background-color: color($theme-color-primary-darker);
 }
 
+.button--warning {
+  background-color: color($theme-color-secondary);
+  &:before {
+    // background-image: url(../../img/ic_edit.svg);
+    background-image: url(../../img/alerts/warning.svg);
+    background-repeat: no-repeat;
+    content: '';
+    width: 20px;
+    height: 20px;
+    display: inline-block;
+  }
+}
+
 .button--edit {
   background-color: transparent;
   @include text--body-copy__medium();
@@ -10,7 +23,7 @@ button,
   &:before {
     margin-right: 10px;
     background-image: url(../../img/ic_edit.svg);
-    background-repeat: none;
+    background-repeat: no-repeat;
     content: '';
     height: 12px;
     width: 12px;

--- a/crt_portal/static/sass/custom/buttons.scss
+++ b/crt_portal/static/sass/custom/buttons.scss
@@ -6,13 +6,17 @@ button,
 .button--warning {
   background-color: color($theme-color-secondary);
   &:before {
-    // background-image: url(../../img/ic_edit.svg);
+    margin-right: 10px;
     background-image: url(../../img/alerts/warning.svg);
+    background-size: cover;
     background-repeat: no-repeat;
     content: '';
-    width: 20px;
+    width: 30px;
     height: 20px;
     display: inline-block;
+  }
+  &:hover {
+    background-color: color($theme-color-secondary-dark) !important;
   }
 }
 

--- a/crt_portal/static/sass/custom/card.scss
+++ b/crt_portal/static/sass/custom/card.scss
@@ -93,3 +93,9 @@
     margin-bottom: 0;
   }
 }
+
+.crt-actions-card {
+  button {
+    margin-top: 1rem !important;
+  }
+}

--- a/crt_portal/static/sass/custom/card.scss
+++ b/crt_portal/static/sass/custom/card.scss
@@ -98,4 +98,9 @@
   button {
     margin-top: 1rem !important;
   }
+
+  ul.errorlist {
+    color: color($theme-color-secondary);
+    list-style-type: none;
+  }
 }

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -463,6 +463,14 @@ ul.messages {
   margin-bottom: 0;
 }
 
+.intake-content {
+  // reverse padding if we are on the incoming records table
+  ul.messages {
+    margin-top: 0;
+    margin-bottom: 2.3rem;
+  }
+}
+
 .details-date-label {
   color: color($theme-color-base-ink);
   font-size: $theme-text-font-size-sm;

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -78,9 +78,15 @@
 
   tr.stripe {
     td {
-      background-color: color(
-        'gray-2'
-      ); // USWDS system token: https://designsystem.digital.gov/design-tokens/color/system-tokens/
+      background-color: color('gray-2');
+      border-left: 1px solid color('gray-2');
+    }
+  }
+
+  tr.selected {
+    td {
+      background-color: color($theme-color-primary-lighter);
+      border-left: 1px solid color($theme-color-primary-lighter);
     }
   }
 

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -115,6 +115,10 @@
       @include clickable-table-cell();
     }
 
+    .td-checkbox {
+      padding: 1rem 0;
+    }
+
     .td-toggle {
       width: auto;
       height: auto;

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -249,3 +249,22 @@
   display: flex;
   flex-wrap: wrap;
 }
+
+.selection-action-notification {
+  position: fixed;
+  width: 100%;
+  left: 0;
+  bottom: 0;
+  z-index: 100;
+
+  background-color: color($theme-color-primary-light);
+  border-left: 5px solid color($theme-color-primary);
+
+  img, h2 {
+    margin-left: 2rem;
+  }
+
+  .selection-submit {
+    margin: 1rem 2rem;
+  }
+}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/575)

## What does this change?

Allows user to multi-select reports and bulk-assign them.

**Notes**
- The records table being squished is a known issue; we are removing the routed column shortly, which should help.
- I suggest reviewing with [the Github whitespace filter on](https://github.com/usdoj-crt/crt-portal/pull/676/files?diff=unified&w=1) as the complaints table was wrapped in a form
- The accessible autocomplete library is buggy; I have worked around this as much as possible. One known issue that I can't work around: removing the current selection still keeps the previous selection alive (until a new selection is made).

## Screenshots (for front-end PR):

![2020-09-22_11-41](https://user-images.githubusercontent.com/3013175/93923752-a4fe2800-fcc8-11ea-817c-27a5035fd638.png)

![2020-09-22_11-41_1](https://user-images.githubusercontent.com/3013175/93923754-a596be80-fcc8-11ea-9901-51b26da40731.png)

![2020-09-22_11-41_2](https://user-images.githubusercontent.com/3013175/93923755-a62f5500-fcc8-11ea-9448-bf70914be4aa.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
