### PR TITLE
Bugfix: updating assigned_to shows id of original user

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1100,7 +1100,9 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
             changed = self.cleaned_data[field]
             # fix bug where id was showing up instead of user name
             if field == 'assigned_to':
-                original = User.objects.get(id=original)
+                if original is None:
+                    yield f"{name}:", f'To "{changed}"'
+            original = User.objects.get(id=original)
             yield f"{name}:", f'Updated from "{original}" to "{changed}"'
         if self.report_closed:
             yield "Report closed and Assignee removed", f"Date closed updated to {self.instance.closed_date.strftime('%m/%d/%y %H:%M:%M %p')}"

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1101,9 +1101,10 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
             # fix bug where id was showing up instead of user name
             if field == 'assigned_to':
                 if original is None:
-                    yield f"{name}:", f'To "{changed}"'
-            original = User.objects.get(id=original)
-            yield f"{name}:", f'Updated from "{original}" to "{changed}"'
+                    yield f"{name}:", f'"{changed}"'
+                else:
+                    original = User.objects.get(id=original)
+                    yield f"{name}:", f'Updated from "{original}" to "{changed}"'
         if self.report_closed:
             yield "Report closed and Assignee removed", f"Date closed updated to {self.instance.closed_date.strftime('%m/%d/%y %H:%M:%M %p')}"
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1096,7 +1096,12 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
             # rename primary statute if applicable
             if field == 'primary_statute':
                 name = 'Primary classification'
-            yield f"{name}:", f'Updated from "{self.initial[field]}" to "{self.cleaned_data[field]}"'
+            original = self.initial[field]
+            changed = self.cleaned_data[field]
+            # fix bug where id was showing up instead of user name
+            if field == 'assigned_to':
+                original = User.objects.get(id=original)
+            yield f"{name}:", f'Updated from "{original}" to "{changed}"'
         if self.report_closed:
             yield "Report closed and Assignee removed", f"Date closed updated to {self.instance.closed_date.strftime('%m/%d/%y %H:%M:%M %p')}"
 

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -21,10 +21,6 @@ class ActionTests(TestCase):
         self.user1 = User.objects.create_user('USER_1', 'user1@example.com', self.test_pass)
         self.user2 = User.objects.create_user('USER_2', 'user2@example.com', self.test_pass)
 
-        self.report = Report.objects.create(**SAMPLE_REPORT)
-        self.report.assigned_to = self.user1
-        self.report.save()
-
     def test_valid(self):
         form = ComplaintActions(data={
             'assigned_section': 'ADM',

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -61,17 +61,22 @@ class ActionTests(TestCase):
                 'status': 'new',
                 'primary_statute': '144',
                 'district': '1',
+                'assigned_to': None,
             },
             data={
                 'assigned_section': 'ADM',
                 'status': 'new',
                 'primary_statute': '144',
                 'district': '1',
-                'assigned_to': None,
+                'assigned_to': self.user2.pk,
             }
         )
 
         self.assertTrue(form.is_valid())
+
+        # Running the code to check error. No output to test.
+        for action in form.get_actions():
+            pass
 
 
 class CommentActionTests(TestCase):

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -74,7 +74,7 @@ class ActionTests(TestCase):
 
         self.assertTrue(form.is_valid())
 
-        # Running the code to check error. No output to test.
+        # Running the code to check error.
         for action in form.get_actions():
             self.assertEqual(action[0], 'Assigned to:')
             self.assertEqual(action[1], f'"{self.user2.username}"')

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -16,7 +16,6 @@ from .test_data import SAMPLE_REPORT, SAMPLE_RESPONSE_TEMPLATE
 
 class ActionTests(TestCase):
     def setUp(self):
-        self.client = Client()
         self.test_pass = secrets.token_hex(32)
 
         self.user1 = User.objects.create_user('USER_1', 'user1@example.com', self.test_pass)

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -76,7 +76,8 @@ class ActionTests(TestCase):
 
         # Running the code to check error. No output to test.
         for action in form.get_actions():
-            pass
+            self.assertEqual(action[0], 'Assigned to:')
+            self.assertEqual(action[1], f'"{self.user2.username}"')
 
 
 class CommentActionTests(TestCase):

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -54,6 +54,25 @@ class ActionTests(TestCase):
             self.assertEqual(action[0], 'Assigned to:')
             self.assertEqual(action[1], f'Updated from "{self.user1.username}" to "{self.user2.username}"')
 
+    def test_user_new_assignment(self):
+        form = ComplaintActions(
+            initial={
+                'assigned_section': 'ADM',
+                'status': 'new',
+                'primary_statute': '144',
+                'district': '1',
+            },
+            data={
+                'assigned_section': 'ADM',
+                'status': 'new',
+                'primary_statute': '144',
+                'district': '1',
+                'assigned_to': None,
+            }
+        )
+
+        self.assertTrue(form.is_valid())
+
 
 class CommentActionTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/713)

## What does this change?

Fixes a bug where updating the assignee shows the id of the original user, which is not helpful. See screenshot below (bottom is older behavior, top is newer behavior).

## Screenshots (for front-end PR):

![2020-09-21_11-51](https://user-images.githubusercontent.com/3013175/93808493-ea572280-fc00-11ea-90ad-dd19dc72e35b.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
