### PR TITLE
New housing bullet with Spanish translation

### DIFF
--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -299,6 +299,13 @@ msgstr ""
 "Hostigamiento por parte de un propietario u otro inquilino, lo que incluye "
 "el acoso sexual"
 
+#: model_variables.py:52
+msgid ""
+"Challenges with terminating a lease due to military status change"
+msgstr ""
+"Retos con la rescisión de un contrato de arrendamiento debido a "
+"un cambio de estatus militar"
+
 #: model_variables.py:54
 msgid "Harassment based on race, sex, national origin, disability, or religion"
 msgstr ""

--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-11 21:58+0000\n"
+"POT-Creation-Date: 2020-09-24 16:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,19 +17,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:154 forms.py:1125
+#: forms.py:155 forms.py:1184
 msgid " - Select - "
 msgstr " - Elija - "
 
 #. Translators: This is help text for the question asking if someone is a service member
-#: forms.py:166
+#: forms.py:167
 msgid ""
 "If you’re reporting on behalf of someone else, please select their status."
 msgstr ""
 "Si usted está presentando la querella en nombre de otra persona, elija el "
 "estatus de tal persona."
 
-#: forms.py:183 templates/forms/report_contact_info.html:8
+#: forms.py:184 templates/forms/report_contact_info.html:8
 msgid ""
 "If you believe you or someone else has experienced a civil rights violation, "
 "please tell us what happened."
@@ -37,7 +37,7 @@ msgstr ""
 "Si usted cree que usted u otra persona ha sido víctima de una vulneración de "
 "sus derechos civiles, cuéntenos lo que pasó."
 
-#: forms.py:209
+#: forms.py:210
 msgid ""
 "Select the reason that best describes your concern. Each reason lists "
 "examples of civil rights violations that may relate to your incident. In "
@@ -50,11 +50,11 @@ msgstr ""
 "su preocupación en sus propias palabras."
 
 #. Translators: notes that this page is the same form step as the page before
-#: forms.py:232
+#: forms.py:233
 msgid "Continued"
 msgstr "Continuado"
 
-#: forms.py:288
+#: forms.py:289
 msgid ""
 "Examples: Name of business, school, intersection, prison, polling place, "
 "website, etc."
@@ -62,11 +62,11 @@ msgstr ""
 "Ejemplos: Nombre de la empresa, escuela, intersección, cárcel, sede de "
 "votación, página web, etc."
 
-#: forms.py:310 question_text.py:29
+#: forms.py:311 question_text.py:29
 msgid "Where did this happen?"
 msgstr "¿Dónde sucedió esto?"
 
-#: forms.py:322
+#: forms.py:323
 msgid ""
 "Please tell us the city, state, and name of the location where this incident "
 "took place. This ensures your report is reviewed by the right people within "
@@ -76,7 +76,7 @@ msgstr ""
 "incidente. Esto asegura que su informe sea revisado por las personas "
 "indicadas dentro de la División de Derechos Civiles."
 
-#: forms.py:385
+#: forms.py:386
 msgid ""
 "Public employers include organizations funded by the government like the "
 "military, post office, fire department, courthouse, DMV, or public school. "
@@ -87,7 +87,7 @@ msgstr ""
 "juzgados, departamentos de vehículos motorizados o escuelas públicas. Esto "
 "podría ser al nivel local o estatal."
 
-#: forms.py:386
+#: forms.py:387
 msgid ""
 "Private employers are business or non-profits not funded by the government "
 "such as retail stores, banks, or restaurants."
@@ -97,11 +97,11 @@ msgstr ""
 "bancos o restaurantes."
 
 #. Translators: describe the "other" option for commercial or public place question
-#: forms.py:432
+#: forms.py:433
 msgid "Please describe"
 msgstr "Favor de describirlo"
 
-#: forms.py:499
+#: forms.py:500
 msgid ""
 "Includes schools, educational programs, or educational activities, like "
 "training programs, sports teams, clubs, or other school-sponsored activities"
@@ -110,11 +110,11 @@ msgstr ""
 "programas de capacitación, equipos deportivos, clubes u otras actividades "
 "patrocinadas por una escuela."
 
-#: forms.py:510
+#: forms.py:511
 msgid "Please select the type of school or educational program."
 msgstr "Elija el tipo de escuela o programa educativo."
 
-#: forms.py:533
+#: forms.py:534
 msgid ""
 "There are federal and state laws that protect people from discrimination "
 "based on their personal characteristics. Here is a list of the most common "
@@ -127,11 +127,11 @@ msgstr ""
 "Elija cualquiera que se aplique a su incidente."
 
 #. Translators: This is to explain an "other" choice for personal characteristics
-#: forms.py:538
+#: forms.py:539
 msgid "Please describe \"Other reason\""
 msgstr "Favor de describir \"Otro motivo\""
 
-#: forms.py:620
+#: forms.py:621
 msgid ""
 "It is important for us to know how recently this incident happened so we can "
 "take the appropriate action. If this happened over a period of time or is "
@@ -145,20 +145,30 @@ msgstr ""
 msgid "Primary classification"
 msgstr "Clasificación principal"
 
-#: forms.py:895
+#: forms.py:897
 msgid "Assigned to"
 msgstr "Asignado a"
+
+#: forms.py:1000
+#, fuzzy
+#| msgid "Date can not be in the future."
+msgid "Create date cannot be in the future."
+msgstr "La fecha no puede ser en el futuro."
+
+#: forms.py:1141
+msgid "Comment cannot be empty"
+msgstr ""
 
 #. Translators: This is used as a an empty selection default for drop down menus
 #: model_variables.py:6
 msgid "- Select -"
 msgstr "- Elija -"
 
-#: model_variables.py:9 model_variables.py:104 model_variables.py:190
+#: model_variables.py:9 model_variables.py:105 model_variables.py:206
 msgid "Yes"
 msgstr "Sí"
 
-#: model_variables.py:10 model_variables.py:105 model_variables.py:189
+#: model_variables.py:10 model_variables.py:106 model_variables.py:205
 msgid "No"
 msgstr "No"
 
@@ -300,30 +310,29 @@ msgstr ""
 "el acoso sexual"
 
 #: model_variables.py:52
-msgid ""
-"Challenges with terminating a lease due to military status change"
+msgid "Challenges with terminating a lease due to military status change"
 msgstr ""
-"Retos con la rescisión de un contrato de arrendamiento debido a "
-"un cambio de estatus militar"
+"Retos con la rescisión de un contrato de arrendamiento debido a un cambio de "
+"estatus militar"
 
-#: model_variables.py:54
+#: model_variables.py:55
 msgid "Harassment based on race, sex, national origin, disability, or religion"
 msgstr ""
 "Hostigamiento por motivos de raza, género, origen nacional, discapacidad o "
 "religión"
 
-#: model_variables.py:55
+#: model_variables.py:56
 msgid "Denied admission or segregated in an education program or activity"
 msgstr ""
 "Denegado/a la admisión o segregado en una actividad o un programa educativo"
 
-#: model_variables.py:56
+#: model_variables.py:57
 msgid "Denied educational accommodations for a disability or language barrier"
 msgstr ""
 "Denegado/a acomodos educativos por motivos de una discapacidad o barrera "
 "lingüística"
 
-#: model_variables.py:59
+#: model_variables.py:60
 msgid ""
 "Obstacles to registering to vote, obtaining or submitting a ballot, having "
 "your ballot counted, or entering a polling place to vote"
@@ -331,7 +340,7 @@ msgstr ""
 "Obstáculos a inscribirse a votar, a obtener o emitir un voto, a tener su "
 "voto contado o a entrar en una sede de votación para votar"
 
-#: model_variables.py:60
+#: model_variables.py:61
 msgid ""
 "Denied adequate voting assistance or accommodations for a disability at a "
 "polling place"
@@ -339,7 +348,7 @@ msgstr ""
 "Denegado/a asistencia adecuada para votar o acomodos para una discapacidad "
 "en una sede de votación"
 
-#: model_variables.py:61
+#: model_variables.py:62
 msgid ""
 "Restricted or prevented from participating in an election, including voting, "
 "becoming a candidate, or being elected for office"
@@ -347,7 +356,7 @@ msgstr ""
 "Limitado/a o prevenido/a a la hora de participar en una elección, lo que "
 "incluye votar, ser candidato o ser elegido a un puesto"
 
-#: model_variables.py:64
+#: model_variables.py:65
 msgid ""
 "Police brutality or use of excessive force, including patterns of police "
 "misconduct"
@@ -355,7 +364,7 @@ msgstr ""
 "Brutalidad policial o uso de fuerza excesiva, lo que incluye patrones de "
 "conducta impropia por la policía"
 
-#: model_variables.py:65
+#: model_variables.py:66
 msgid ""
 "Searched and arrested under false pretenses, including racial or other "
 "discriminatory profiling"
@@ -363,11 +372,11 @@ msgstr ""
 "Registrado/a y detenido/a de manera fraudulenta, lo que incluye la "
 "caracterización racial u otro tipo de caracterización discriminatoria"
 
-#: model_variables.py:66
+#: model_variables.py:67
 msgid "Denied rights while arrested or incarcerated"
 msgstr "Denegado/a derechos estando detenido/a o encarcelado/a"
 
-#: model_variables.py:67
+#: model_variables.py:68
 msgid ""
 "Denied access to safe living conditions or accommodations for a disability, "
 "language barrier, or religious practice while incarcerated"
@@ -375,13 +384,13 @@ msgstr ""
 "Denegado/a acceso a condiciones de vida seguras o acomodos para una "
 "discapacidad, barrera lingüística o práctica religiosa estando encarcelado/a"
 
-#: model_variables.py:70
+#: model_variables.py:71
 msgid ""
 "A physical or online location that does not provide disability accommodations"
 msgstr ""
 "Un lugar físico o en Internet que no ofrece acomodos para discapacidades"
 
-#: model_variables.py:71
+#: model_variables.py:72
 msgid ""
 "Denied service or entry because of a perceived personal characteristic like "
 "race, sex, or religion"
@@ -389,7 +398,7 @@ msgstr ""
 "Denegado/a un servicio o la entrada por motivos de una característica "
 "personal como raza, género o religión"
 
-#: model_variables.py:77
+#: model_variables.py:78
 msgid ""
 "Physical attack causing injury, or an attempt to cause injury with a "
 "dangerous weapon, because of the above characteristics"
@@ -398,7 +407,7 @@ msgstr ""
 "un arma peligrosa por motivos de las características mencionadas "
 "anteriormente"
 
-#: model_variables.py:78
+#: model_variables.py:79
 msgid ""
 "Attacks, threats of violence, or destruction of property at place of worship "
 "(ie: shooting, arson, bombing, smashing windows, writing slurs)"
@@ -407,7 +416,7 @@ msgstr ""
 "culto (p. ej. tiroteos, incendios provocados, bombardeos, ruptura de "
 "cristales, escritura de calumnias)"
 
-#: model_variables.py:81
+#: model_variables.py:82
 msgid ""
 "Coerced into working through threats of harm or deportation, psychological "
 "manipulation, debt manipulation, document confiscation, or confinement"
@@ -416,7 +425,7 @@ msgstr ""
 "manipulación psicológica, ser manipulado por motivos de una deuda, el "
 "decomiso de documentos o el confinamiento"
 
-#: model_variables.py:82
+#: model_variables.py:83
 msgid ""
 "Forced into sex work for profit through physical abuse or assault, sexual "
 "abuse or assault, other threats of harm, or confinement"
@@ -424,25 +433,25 @@ msgstr ""
 "Obligado al trabajo sexual mediante a cambio de dinero mediante el abuso "
 "físico o acoso, otras amenazas de daño o el confiamiento."
 
-#: model_variables.py:87 model_variables.py:196
+#: model_variables.py:88 model_variables.py:212
 msgid "Federal"
 msgstr "Federal"
 
-#: model_variables.py:88
+#: model_variables.py:89
 msgid "State or local"
 msgstr "Estatal o local"
 
 #. Translators: Both state, federal and local elections
-#: model_variables.py:90
+#: model_variables.py:91
 msgid "Both"
 msgstr "Ambas"
 
-#: model_variables.py:91 model_variables.py:198 model_variables.py:213
-#: model_variables.py:221 model_variables.py:238
+#: model_variables.py:92 model_variables.py:214 model_variables.py:229
+#: model_variables.py:237 model_variables.py:254
 msgid "I'm not sure"
 msgstr "No estoy seguro/a"
 
-#: model_variables.py:97
+#: model_variables.py:98
 msgid ""
 "Physical harm or threats of violence based on race, color, national origin, "
 "religion, gender, sexual orientation, gender identity, or disability"
@@ -451,7 +460,7 @@ msgstr ""
 "origen nacional, religión, género, orientación sexual, identidad de género o "
 "discapacidad"
 
-#: model_variables.py:98
+#: model_variables.py:99
 msgid ""
 "Threatened, forced, and held against your will for the purposes of "
 "performing work or commercial sex acts. This could include threats of "
@@ -463,72 +472,72 @@ msgstr ""
 "físico, la retención de sueldos prometidos o la retención bajo un contrato "
 "laboral falso"
 
-#: model_variables.py:112 templates/landing.html:252
+#: model_variables.py:113 templates/landing.html:252
 msgid "Age"
 msgstr "Edad"
 
-#: model_variables.py:113
+#: model_variables.py:114
 msgid "Disability (including temporary or recovery)"
 msgstr ""
 "Discapacidad (lo que incluye discapacidades temporales o la recuperación de "
 "una discapacidad)"
 
-#: model_variables.py:114
+#: model_variables.py:115
 msgid "Family, marital, or parental status"
 msgstr "Estado familiar, civil o parental"
 
-#: model_variables.py:115
+#: model_variables.py:116
 msgid "Gender identity (including gender stereotypes)"
 msgstr "Identidad de género (incluyendo estereotipos de género)"
 
-#: model_variables.py:116
+#: model_variables.py:117
 msgid "Genetic information (including family medical history)"
 msgstr "Información genética (incluyendo el historial médico familiar)"
 
-#: model_variables.py:117
+#: model_variables.py:118
 msgid ""
 "Immigration/citizenship status (choosing this will not share your status)"
 msgstr ""
 "Estatus migratorio/de ciudadanía (su selección no hará que se comparta su "
 "estatus)"
 
-#: model_variables.py:118
+#: model_variables.py:119
 msgid "Language"
 msgstr "Idioma"
 
-#: model_variables.py:119
+#: model_variables.py:120
 msgid "National origin (including ancestry and ethnicity)"
 msgstr "Origen nacional (incluyendo ascendencia y etnia)"
 
-#: model_variables.py:120
+#: model_variables.py:121
 msgid "Pregnancy"
 msgstr "Embarazo"
 
-#: model_variables.py:121 templates/landing.html:245
+#: model_variables.py:122 templates/landing.html:245
 msgid "Race/color"
 msgstr "Raza/color de piel"
 
-#: model_variables.py:122 templates/landing.html:247
+#: model_variables.py:123 templates/landing.html:247
 msgid "Religion"
 msgstr "Religión"
 
-#: model_variables.py:123
+#: model_variables.py:124
 msgid "Sex"
 msgstr "Género"
 
-#: model_variables.py:124
+#: model_variables.py:125
 msgid "Sexual orientation"
 msgstr "Orientación sexual"
 
-#: model_variables.py:125
+#: model_variables.py:126
 msgid "None of these apply to me"
 msgstr "Ninguna de estas opciones se aplica a mi caso"
 
-#: model_variables.py:126
+#: model_variables.py:127
 msgid "Other reason"
 msgstr "Otro motivo"
 
-#: model_variables.py:135
+#: model_variables.py:136
 msgid ""
 "Please make a selection to continue. If none of these apply to your "
 "situation, please select “None of these apply to me” or \"Other reason\"and "
@@ -538,31 +547,31 @@ msgstr ""
 "\"Ninguna de estas opciones se aplica a mí\" u \"Otro motivo\" y proporcione "
 "una explicación."
 
-#: model_variables.py:161
+#: model_variables.py:177
 msgid "Place of worship or about a place of worship"
 msgstr "Lugar de culto o acerca de un lugar de culto"
 
-#: model_variables.py:162
+#: model_variables.py:178
 msgid "Commercial or retail building"
 msgstr "Edificio comercial o de tiendas de venta al por menor"
 
-#: model_variables.py:163 model_variables.py:174
+#: model_variables.py:179 model_variables.py:190
 msgid "Healthcare facility"
 msgstr "Centro de atención médica"
 
-#: model_variables.py:164 model_variables.py:175
+#: model_variables.py:180 model_variables.py:191
 msgid "Financial institution"
 msgstr "Institución financiera"
 
-#: model_variables.py:165
+#: model_variables.py:181
 msgid "Public space"
 msgstr "Lugar público"
 
-#: model_variables.py:166 templatetags/commercial_public_space_view.py:17
+#: model_variables.py:182 templatetags/commercial_public_space_view.py:17
 msgid "Other"
 msgstr "Otro"
 
-#: model_variables.py:169
+#: model_variables.py:185
 msgid ""
 "Please select the type of location. If none of these apply to your "
 "situation, please select \"Other\"."
@@ -570,27 +579,27 @@ msgstr ""
 "Favor de elegir el tipo de localización. Si ninguno de estos se aplica a su "
 "situación, elija \"Otro\""
 
-#: model_variables.py:172
+#: model_variables.py:188
 msgid "Place of worship"
 msgstr "Lugar de culto"
 
-#: model_variables.py:173
+#: model_variables.py:189
 msgid "Commercial"
 msgstr "Comercial"
 
-#: model_variables.py:176
+#: model_variables.py:192
 msgid "Public outdoor space"
 msgstr "Lugar público al aire libre"
 
-#: model_variables.py:180
+#: model_variables.py:196
 msgid "Church, synagogue, temple, religious community center"
 msgstr "Iglesia, sinagoga, templo, centro religioso comunitario"
 
-#: model_variables.py:181
+#: model_variables.py:197
 msgid "Store, restaurant, bar, hotel, theater"
 msgstr "Tienda, restaurante, bar, hotel, teatro"
 
-#: model_variables.py:182
+#: model_variables.py:198
 msgid ""
 "Hospital or clinic (including inpatient and outpatient programs), "
 "reproductive care clinic, state developmental institution, nursing home"
@@ -599,11 +608,11 @@ msgstr ""
 "clínica de servicios de salud reproductiva, institución estatal de "
 "desarrollo, residencia de tercera edad"
 
-#: model_variables.py:183
+#: model_variables.py:199
 msgid "Bank, credit union, loan services"
 msgstr "Servicios de préstamo, cooperativa de crédito y bancarios"
 
-#: model_variables.py:184
+#: model_variables.py:200
 msgid ""
 "Park, sidewalk, street, other public buildings (courthouse, DMV, city "
 "library)"
@@ -611,353 +620,353 @@ msgstr ""
 "Parque, acera, calle, otros edificios comerciales (juzgado, Departamento de "
 "Vehículos Motorizados, biblioteca municipal)"
 
-#: model_variables.py:195
+#: model_variables.py:211
 msgid "State/local"
 msgstr "Estatal/local"
 
-#: model_variables.py:197
+#: model_variables.py:213
 msgid "Private"
 msgstr "Privado"
 
-#: model_variables.py:203
+#: model_variables.py:219
 msgid "Outside of prison"
 msgstr "Fuera de la cárcel"
 
-#: model_variables.py:205
+#: model_variables.py:221
 msgid "Prison (Federal)"
 msgstr "Cárcel (Federal)"
 
-#: model_variables.py:206
+#: model_variables.py:222
 msgid "Prison (Private)"
 msgstr "Cárcel (Privada)"
 
-#: model_variables.py:207
+#: model_variables.py:223
 msgid "Prison (I'm not sure)"
 msgstr "Cárcel (No estoy seguro/a)"
 
-#: model_variables.py:211
+#: model_variables.py:227
 msgid "Public employer"
 msgstr "Empleador público"
 
-#: model_variables.py:212
+#: model_variables.py:228
 msgid "Private employer"
 msgstr "Empleador privado"
 
-#: model_variables.py:216
+#: model_variables.py:232
 msgid "Please select what type of employer this is."
 msgstr "Elija el tipo de empleador del que se trata."
 
-#: model_variables.py:219
+#: model_variables.py:235
 msgid "Fewer than 15 employees"
 msgstr "Menos de 15 empleados"
 
-#: model_variables.py:220
+#: model_variables.py:236
 msgid "15 or more employees"
 msgstr "15 empleados o más"
 
-#: model_variables.py:224
+#: model_variables.py:240
 msgid "Please select how large the employer is."
 msgstr "Indique el tamaño del empleador"
 
-#: model_variables.py:236
+#: model_variables.py:252
 msgid "Public school or educational program"
 msgstr "Escuela pública o programa educativo"
 
-#: model_variables.py:237
+#: model_variables.py:253
 msgid "Private school or educational program"
 msgstr "Escuela privada o programa educativo"
 
-#: model_variables.py:243
+#: model_variables.py:259
 msgid "Alabama"
 msgstr "Alabama"
 
-#: model_variables.py:244
+#: model_variables.py:260
 msgid "Alaska"
 msgstr "Alaska"
 
-#: model_variables.py:245
+#: model_variables.py:261
 msgid "Arizona"
 msgstr "Arizona"
 
-#: model_variables.py:246
+#: model_variables.py:262
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: model_variables.py:247
+#: model_variables.py:263
 msgid "California"
 msgstr "California"
 
-#: model_variables.py:248
+#: model_variables.py:264
 msgid "Colorado"
 msgstr "Colorado"
 
-#: model_variables.py:249
+#: model_variables.py:265
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#: model_variables.py:250
+#: model_variables.py:266
 msgid "Delaware"
 msgstr "Delaware"
 
-#: model_variables.py:251
+#: model_variables.py:267
 msgid "District of Columbia"
 msgstr "District of Columbia"
 
-#: model_variables.py:252
+#: model_variables.py:268
 msgid "Florida"
 msgstr "Florida"
 
-#: model_variables.py:253
+#: model_variables.py:269
 msgid "Georgia"
 msgstr "Georgia"
 
-#: model_variables.py:254
+#: model_variables.py:270
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#: model_variables.py:255
+#: model_variables.py:271
 msgid "Idaho"
 msgstr "Idaho"
 
-#: model_variables.py:256
+#: model_variables.py:272
 msgid "Illinois"
 msgstr "Illinois"
 
-#: model_variables.py:257
+#: model_variables.py:273
 msgid "Indiana"
 msgstr "Indiana"
 
-#: model_variables.py:258
+#: model_variables.py:274
 msgid "Iowa"
 msgstr "Iowa"
 
-#: model_variables.py:259
+#: model_variables.py:275
 msgid "Kansas"
 msgstr "Kansas"
 
-#: model_variables.py:260
+#: model_variables.py:276
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#: model_variables.py:261
+#: model_variables.py:277
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#: model_variables.py:262
+#: model_variables.py:278
 msgid "Maine"
 msgstr "Maine"
 
-#: model_variables.py:263
+#: model_variables.py:279
 msgid "Maryland"
 msgstr "Maryland"
 
-#: model_variables.py:264
+#: model_variables.py:280
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: model_variables.py:265
+#: model_variables.py:281
 msgid "Michigan"
 msgstr "Michigan"
 
-#: model_variables.py:266
+#: model_variables.py:282
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#: model_variables.py:267
+#: model_variables.py:283
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#: model_variables.py:268
+#: model_variables.py:284
 msgid "Missouri"
 msgstr "Missouri"
 
-#: model_variables.py:269
+#: model_variables.py:285
 msgid "Montana"
 msgstr "Montana"
 
-#: model_variables.py:270
+#: model_variables.py:286
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#: model_variables.py:271
+#: model_variables.py:287
 msgid "Nevada"
 msgstr "Nevada"
 
-#: model_variables.py:272
+#: model_variables.py:288
 msgid "New Hampshire"
 msgstr "New Hampshire"
 
-#: model_variables.py:273
+#: model_variables.py:289
 msgid "New Jersey"
 msgstr "New Jersey"
 
-#: model_variables.py:274
+#: model_variables.py:290
 msgid "New Mexico"
 msgstr "New México"
 
-#: model_variables.py:275
+#: model_variables.py:291
 msgid "New York"
 msgstr "New York"
 
-#: model_variables.py:276
+#: model_variables.py:292
 msgid "North Carolina"
 msgstr "North Carolina"
 
-#: model_variables.py:277
+#: model_variables.py:293
 msgid "North Dakota"
 msgstr "North Dakota"
 
-#: model_variables.py:278
+#: model_variables.py:294
 msgid "Ohio"
 msgstr "Ohio"
 
-#: model_variables.py:279
+#: model_variables.py:295
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#: model_variables.py:280
+#: model_variables.py:296
 msgid "Oregon"
 msgstr "Oregón"
 
-#: model_variables.py:281
+#: model_variables.py:297
 msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
-#: model_variables.py:282
+#: model_variables.py:298
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-#: model_variables.py:283
+#: model_variables.py:299
 msgid "South Carolina"
 msgstr "South Carolina"
 
-#: model_variables.py:284
+#: model_variables.py:300
 msgid "South Dakota"
 msgstr "South Dakota"
 
-#: model_variables.py:285
+#: model_variables.py:301
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#: model_variables.py:286
+#: model_variables.py:302
 msgid "Texas"
 msgstr "Texas"
 
-#: model_variables.py:287
+#: model_variables.py:303
 msgid "Utah"
 msgstr "Utah"
 
-#: model_variables.py:288
+#: model_variables.py:304
 msgid "Vermont"
 msgstr "Vermont"
 
-#: model_variables.py:289
+#: model_variables.py:305
 msgid "Virginia"
 msgstr "Virginia"
 
-#: model_variables.py:290
+#: model_variables.py:306
 msgid "Washington"
 msgstr "Washington"
 
-#: model_variables.py:291
+#: model_variables.py:307
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#: model_variables.py:292
+#: model_variables.py:308
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#: model_variables.py:293
+#: model_variables.py:309
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#: model_variables.py:294
+#: model_variables.py:310
 msgid "American Samoa"
 msgstr "American Samoa"
 
-#: model_variables.py:295
+#: model_variables.py:311
 msgid "Guam"
 msgstr "Guam"
 
-#: model_variables.py:296
+#: model_variables.py:312
 msgid "Northern Mariana Islands"
 msgstr "Northern Mariana Islands"
 
-#: model_variables.py:297
+#: model_variables.py:313
 msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
-#: model_variables.py:298
+#: model_variables.py:314
 msgid "Virgin Islands"
 msgstr "Virgin Islands"
 
-#: model_variables.py:299
+#: model_variables.py:315
 msgid "Armed Forces Africa"
 msgstr "Armed Forces Africa"
 
-#: model_variables.py:300
+#: model_variables.py:316
 msgid "Armed Forces Americas"
 msgstr "Armed Forces Americas"
 
-#: model_variables.py:301
+#: model_variables.py:317
 msgid "Armed Forces Canada"
 msgstr "Armed Forces Canada"
 
-#: model_variables.py:302
+#: model_variables.py:318
 msgid "Armed Forces Europe"
 msgstr "Armed Forces Europe"
 
-#: model_variables.py:303
+#: model_variables.py:319
 msgid "Armed Forces Middle East"
 msgstr "Armed Forces Middle East"
 
-#: model_variables.py:304
+#: model_variables.py:320
 msgid "Armed Forces Pacific"
 msgstr "Armed Forces Pacific"
 
-#: model_variables.py:307
+#: model_variables.py:323
 msgid "Please provide description to continue"
 msgstr "Para continuar, proporcione una descripción"
 
-#: model_variables.py:308
+#: model_variables.py:324
 msgid "Please select a primary reason to continue."
 msgstr "Para continuar, elija un motivo principal."
 
-#: model_variables.py:311
+#: model_variables.py:327
 msgid "Please enter the name of the location where this took place."
 msgstr "Introduzca el nombre del lugar dónde esto sucedió."
 
-#: model_variables.py:312
+#: model_variables.py:328
 msgid "Please enter the city or town where this took place."
 msgstr "Introduzca el nombre de la ciudad o el pueblo dónde esto sucedió."
 
-#: model_variables.py:313
+#: model_variables.py:329
 msgid "Please select the state where this took place."
 msgstr "Elija el estado dónde esto sucedió."
 
-#: model_variables.py:317
+#: model_variables.py:333
 msgid "Please select where this occurred"
 msgstr "Elija dónde esto sucedió"
 
-#: model_variables.py:318
+#: model_variables.py:334
 msgid "Please select the type of location"
 msgstr "Elija el tipo de lugar"
 
-#: model_variables.py:330
+#: model_variables.py:346
 msgid "You must enter a month and year. Please use the format MM/DD/YYYY."
 msgstr ""
 "Debe introducir un mes y un año. Favor de seguir el formato MM/DD/AAAA."
 
-#: model_variables.py:333
+#: model_variables.py:349
 msgid "Please enter a month."
 msgstr "Introduzca un mes."
 
-#: model_variables.py:334
+#: model_variables.py:350
 msgid "Please enter a valid month. Month must be between 1 and 12."
 msgstr ""
 "Introduzca un mes válido. El mes tiene que caer entre las cifras 1 y 12."
 
-#: model_variables.py:335
+#: model_variables.py:351
 msgid ""
 "Please enter a valid day of the month. Day must be between 1 and the last "
 "day of the month."
@@ -965,27 +974,27 @@ msgstr ""
 "Introduzca un día válido del mes. El día tiene que caer entre el 1 y el "
 "último día del mes."
 
-#: model_variables.py:336
+#: model_variables.py:352
 msgid "Please enter a year."
 msgstr "Introduzca el año."
 
-#: model_variables.py:337
+#: model_variables.py:353
 msgid "Date can not be in the future."
 msgstr "La fecha no puede ser en el futuro."
 
-#: model_variables.py:338
+#: model_variables.py:354
 msgid "Please enter a year after 1900."
 msgstr "Introduzca un año después de 1900"
 
-#: model_variables.py:339
+#: model_variables.py:355
 msgid "Please enter a valid date. Use format MM/DD/YYYY."
 msgstr "Introduzca una fecha válida. Utilice el formato MM/DD/AAAA."
 
-#: model_variables.py:342
+#: model_variables.py:358
 msgid "Please select the type of election or voting activity."
 msgstr "Elija el tipo de elecciones o actividad relacionada con el voto"
 
-#: model_variables.py:382
+#: model_variables.py:398
 msgid ""
 "If you submit a phone number, please make sure to include between 7 and 15 "
 "digits. The characters \"+\", \")\", \"(\", \"-\", and \".\" are allowed. "
@@ -1181,14 +1190,14 @@ msgstr ""
 msgid "Any supporting materials (please list and describe them)"
 msgstr "Cualquier material de apoyo (haga una lista y describa cada artículo)"
 
-#: templates/base.html:22 templates/base.html:40 templates/forms/base.html:19
+#: templates/base.html:22 templates/base.html:47 templates/forms/base.html:19
 #: templates/forms/report_base.html:13
 msgid "Contact the Civil Rights Division | Department of Justice"
 msgstr ""
 "Comuníquese con la División de Derechos Civiles | Departamento de Justicia"
 
 #  Meta tag description of site
-#: templates/base.html:28
+#: templates/base.html:35
 msgid ""
 "Have you or someone you know experienced unlawful discrimination? The Civil "
 "Rights Division may be able to help. Civil rights laws can protect you from "
@@ -1202,16 +1211,16 @@ msgstr ""
 "variedad de entornos como la vivienda, el lugar de trabajo, la escuela, la "
 "votación, los negocios, la atención médica, los espacios públicos y más."
 
-#: templates/base.html:48 templates/forms/base.html:28
+#: templates/base.html:55 templates/forms/base.html:28
 msgid "Skip to main content"
 msgstr "Pasar directamente al contenido principal"
 
-#: templates/base.html:91 templates/forms/base.html:92
+#: templates/base.html:98 templates/forms/base.html:92
 #: templates/landing.html:18
 msgid "U.S. Department of Justice"
 msgstr "Departamento de Justicia de los EE. UU."
 
-#: templates/base.html:94 templates/forms/base.html:91
+#: templates/base.html:101 templates/forms/base.html:91
 #: templates/landing.html:21
 msgid "Civil Rights Division"
 msgstr "División de Derechos Civiles"
@@ -1664,8 +1673,8 @@ msgstr "Informe sobre una vulneración"
 msgid "Already submitted?"
 msgstr "¿Ya nos informó de una vulneración?"
 
-#: templates/landing.html:59 templates/partials/footer.html:9 views.py:561
-#: views.py:617 views.py:636
+#: templates/landing.html:59 templates/partials/footer.html:9 views.py:670
+#: views.py:726 views.py:745
 msgid "Contact"
 msgstr "Contacto"
 
@@ -2647,54 +2656,54 @@ msgstr ""
 "acceder a esta página en otra pestaña o ventana en su navegador. Eso le "
 "creará otra cookie de seguridad y debería resolver el problema."
 
-#: views.py:436 views.py:664
+#: views.py:545 views.py:773
 msgid "word remaining"
 msgstr "palabra restante"
 
-#: views.py:437 views.py:665
+#: views.py:546 views.py:774
 msgid " words remaining"
 msgstr "palabras restantes"
 
-#: views.py:438 views.py:666
+#: views.py:547 views.py:775
 msgid " word limit reached"
 msgstr "límite de palabras alcanzado"
 
-#: views.py:562 views.py:618 views.py:619 views.py:637 views.py:638
-#: views.py:673
+#: views.py:671 views.py:727 views.py:728 views.py:746 views.py:747
+#: views.py:782
 msgid "Primary concern"
 msgstr "Motivo principal de preocupación"
 
-#: views.py:563 views.py:620 views.py:621 views.py:622 views.py:623
-#: views.py:624 views.py:625
+#: views.py:672 views.py:729 views.py:730 views.py:731 views.py:732
+#: views.py:733 views.py:734
 msgid "Location"
 msgstr "Lugar"
 
-#: views.py:564 views.py:626 views.py:645
+#: views.py:673 views.py:735 views.py:754
 msgid "Personal characteristics"
 msgstr "Características personales"
 
-#: views.py:565 views.py:627 views.py:646
+#: views.py:674 views.py:736 views.py:755
 msgid "Date"
 msgstr "Fecha"
 
-#: views.py:566 views.py:628 views.py:647
+#: views.py:675 views.py:737 views.py:756
 msgid "Personal description"
 msgstr "Descripción personal"
 
-#: views.py:567 views.py:629 views.py:678
+#: views.py:676 views.py:738 views.py:787
 msgid "Review"
 msgstr "Repasar"
 
-#: views.py:639 views.py:640 views.py:641 views.py:642 views.py:643
-#: views.py:644
+#: views.py:748 views.py:749 views.py:750 views.py:751 views.py:752
+#: views.py:753
 msgid "Location details"
 msgstr "Datos de lugar"
 
-#: views.py:648
+#: views.py:757
 msgid "Review your report"
 msgstr "Revise su informe"
 
-#: views.py:676
+#: views.py:785
 msgid "Please select if any that apply to your situation (optional)"
 msgstr "Favor de elegir esta opción si"
 

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -49,6 +49,7 @@ PRIMARY_COMPLAINT_CHOICES_TO_EXAMPLES = {
         _('Denied housing, a permit, or a loan based on personal characteristics like race, sex, and/or having children under 18 years old'),
         _('Denied an accommodation for a disability, including not being allowed to have a service animal'),
         _('Harassment by a landlord or another tenant, including sexual harassment'),
+        _('Challenges with terminating a lease due to military status change'),
     ],
     'education': [
         _('Harassment based on race, sex, national origin, disability, or religion'),


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/704)

## What does this change?
This adds a new bullet for the housing primary complaint examples. It also adds Spanish translation for the requested bullet

## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/66343959/94031138-8b261900-fd8c-11ea-93b9-f0921cacc09b.png)

![image](https://user-images.githubusercontent.com/66343959/94031201-9da05280-fd8c-11ea-8e5f-8c94952eb3aa.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
