### PR TITLE
Change FOIA link in footer

### DIFF
--- a/crt_portal/cts_forms/templates/partials/footer.html
+++ b/crt_portal/cts_forms/templates/partials/footer.html
@@ -71,7 +71,7 @@
           <a href="{% url 'privacy_policy' %}">
             {% trans "Privacy policy" %}
           </a>
-          <a href="https://www.justice.gov/oip">
+          <a href="https://www.justice.gov/crt/freedom-information-act-0">
             {% trans "FOIA" %}
           </a>
           <a href="https://www.justice.gov/accessibility/accessibility-information">


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/711)

## What does this change?
Changes FOIA link in footer (It currently goes to https://www.justice.gov/oip) to https://www.justice.gov/crt/freedom-information-act-0
## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/66343959/94158288-3a77f400-fe50-11ea-8ec9-55057c19db33.png)

## Checklist:

### Author

+ [X] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [X] Check for [accessibility](/docs/a11y_plan.md).
+ [X] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
