### PR TITLE
Added more CI/CD periodic tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,18 +12,6 @@ install-cf7: &install-cf7
       rm cf7.deb
       cf7 api https://api.fr.cloud.gov
 
-run-common-tasks: &run-common-tasks
-# these common tasks run on all spaces: dev, staging and prod
-  steps:
-    - run:
-      # Refresh the materialized view table for trends
-        name: Refresh trends view
-        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
-      # Clear expired sessions in session table
-    - run:
-        name: Clear expired sessoins
-        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
-
 version: 2
 jobs:
   build_and_test: # runs not using Workflows must have a `build` job as entry point
@@ -325,7 +313,14 @@ jobs:
           name: Login to cloud.gov Production
           command: cf login -u ${CRT_USERNAME_PROD} -p ${CRT_PASSWORD_PROD} -o doj-crtportal -s ${CF_SPACE}
       # Run common tasks (e.g. refresh trends, clear expired sessions)
-      - *run-common-tasks
+      - run:
+      # Refresh the materialized view table for trends
+        name: Refresh trends view in prod
+        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
+      # Clear expired sessions in session table
+      - run:
+        name: Clear expired sessoins in prod
+        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
 
   staging-maintenance-tasks:
     docker:
@@ -342,7 +337,14 @@ jobs:
           name: Login to cloud.gov Staging
           command: cf login -u ${CRT_USERNAME_STAGE} -p ${CRT_PASSWORD_STAGE} -o doj-crtportal -s ${CF_SPACE}
       # Run common tasks (e.g. refresh trends, clear expired sessions)
-      - *run-common-tasks
+      - run:
+      # Refresh the materialized view table for trends
+        name: Refresh trends view in staging
+        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
+      # Clear expired sessions in session table
+      - run:
+        name: Clear expired sessoins in staging
+        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
 
   dev-maintenance-tasks:
     docker:
@@ -359,7 +361,14 @@ jobs:
           name: Login to cloud.gov Dev
           command: cf login -u ${CRT_USERNAME_DEV} -p ${CRT_PASSWORD_DEV} -o doj-crtportal -s ${CF_SPACE}
       # Run common tasks (e.g. refresh trends, clear expired sessions)
-      - *run-common-tasks
+      - run:
+      # Refresh the materialized view table for trends
+        name: Refresh trends view in dev
+        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
+      # Clear expired sessions in session table
+      - run:
+        name: Clear expired sessoins dev
+        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,7 @@ jobs:
       - *install-cf7
       # login to Cloud.gov dev space
       - run:
-          name: Login to cloud.gov Staging
+          name: Login to cloud.gov Dev
           command: cf login -u ${CRT_USERNAME_DEV} -p ${CRT_PASSWORD_DEV} -o doj-crtportal -s ${CF_SPACE}
       # Run common tasks (e.g. refresh trends, clear expired sessions)
       - *run-common-tasks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,15 +312,14 @@ jobs:
       - run:
           name: Login to cloud.gov Production
           command: cf login -u ${CRT_USERNAME_PROD} -p ${CRT_PASSWORD_PROD} -o doj-crtportal -s ${CF_SPACE}
-      # Run common tasks (e.g. refresh trends, clear expired sessions)
+      # Refresh the trend view in staging
       - run:
-      # Refresh the materialized view table for trends
-        name: Refresh trends view
-        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
-      # Clear expired sessions in session table
+          name: Refresh trends view
+          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
+      # Clear expired sessions in staging session table
       - run:
-        name: Clear expired sessoins
-        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
+          name: clearsessions management command
+          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
 
   staging-maintenance-tasks:
     docker:
@@ -336,15 +335,14 @@ jobs:
       - run:
           name: Login to cloud.gov Staging
           command: cf login -u ${CRT_USERNAME_STAGE} -p ${CRT_PASSWORD_STAGE} -o doj-crtportal -s ${CF_SPACE}
-      # Run common tasks (e.g. refresh trends, clear expired sessions)
+      # Refresh the trend view in staging
       - run:
-      # Refresh the materialized view table for trends
-        name: Refresh trends view
-        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
-      # Clear expired sessions in session table
+          name: Refresh trends view
+          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
+      # Clear expired sessions in staging session table
       - run:
-        name: Clear expired sessoins
-        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
+          name: clearsessions management command
+          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
 
   dev-maintenance-tasks:
     docker:
@@ -360,15 +358,14 @@ jobs:
       - run:
           name: Login to cloud.gov Dev
           command: cf login -u ${CRT_USERNAME_DEV} -p ${CRT_PASSWORD_DEV} -o doj-crtportal -s ${CF_SPACE}
-      # Run common tasks (e.g. refresh trends, clear expired sessions)
+      # Refresh the trend view in staging
       - run:
-      # Refresh the materialized view table for trends
-        name: Refresh trends view
-        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
-      # Clear expired sessions in session table
+          name: Refresh trends view
+          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
+      # Clear expired sessions in staging session table
       - run:
-        name: Clear expired sessoins
-        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
+          name: clearsessions management command
+          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
 
 workflows:
   version: 2
@@ -415,6 +412,7 @@ workflows:
           filters:
             branches:
               only: master
+
   # Scheduled maintenance jobs for portal
   # Dev scheduled jobs
   periodic-tasks-dev:
@@ -426,6 +424,7 @@ workflows:
           filters:
             branches:
               only: develop
+
   # Staging scheduled jobs
   periodic-tasks-staging:
     jobs:
@@ -436,6 +435,7 @@ workflows:
           filters:
             branches:
               only: /^release.*/
+
   # prod scheduled jobs
   periodic-tasks-prod:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,11 +315,11 @@ jobs:
       # Run common tasks (e.g. refresh trends, clear expired sessions)
       - run:
       # Refresh the materialized view table for trends
-        name: Refresh trends view in prod
+        name: Refresh trends view
         command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
       # Clear expired sessions in session table
       - run:
-        name: Clear expired sessoins in prod
+        name: Clear expired sessoins
         command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
 
   staging-maintenance-tasks:
@@ -339,11 +339,11 @@ jobs:
       # Run common tasks (e.g. refresh trends, clear expired sessions)
       - run:
       # Refresh the materialized view table for trends
-        name: Refresh trends view in staging
+        name: Refresh trends view
         command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
       # Clear expired sessions in session table
       - run:
-        name: Clear expired sessoins in staging
+        name: Clear expired sessoins
         command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
 
   dev-maintenance-tasks:
@@ -363,11 +363,11 @@ jobs:
       # Run common tasks (e.g. refresh trends, clear expired sessions)
       - run:
       # Refresh the materialized view table for trends
-        name: Refresh trends view in dev
+        name: Refresh trends view
         command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
       # Clear expired sessions in session table
       - run:
-        name: Clear expired sessoins dev
+        name: Clear expired sessoins
         command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,18 @@ install-cf7: &install-cf7
       rm cf7.deb
       cf7 api https://api.fr.cloud.gov
 
+run-common-tasks: &run-common-tasks
+# these common tasks run on all spaces: dev, staging and prod
+  steps:
+    - run:
+      # Refresh the materialized view table for trends
+        name: Refresh trends view
+        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
+      # Clear expired sessions in session table
+    - run:
+        name: Clear expired sessoins
+        command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
+
 version: 2
 jobs:
   build_and_test: # runs not using Workflows must have a `build` job as entry point
@@ -308,18 +320,12 @@ jobs:
     steps:
       # Install cloud foundry tools
       - *install-cf7
-      # login into cloud.gov
+      # login into cloud.gov prod space
       - run:
           name: Login to cloud.gov Production
           command: cf login -u ${CRT_USERNAME_PROD} -p ${CRT_PASSWORD_PROD} -o doj-crtportal -s ${CF_SPACE}
-      # Refresh the trend view once logged in to cloud.gov
-      - run:
-          name: Refresh trends view
-          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
-      # Clear expired sessions from portal sessions table
-      - run:
-          name: clearsessions management command
-          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
+      # Run common tasks (e.g. refresh trends, clear expired sessions)
+      - *run-common-tasks
 
   staging-maintenance-tasks:
     docker:
@@ -331,18 +337,12 @@ jobs:
     steps:
       # Install cloud foundry tools
       - *install-cf7
-      # login to Staging Cloud.gov environment
+      # login to Staging Cloud.gov space
       - run:
           name: Login to cloud.gov Staging
           command: cf login -u ${CRT_USERNAME_STAGE} -p ${CRT_PASSWORD_STAGE} -o doj-crtportal -s ${CF_SPACE}
-      # Refresh the trend view in staging
-      - run:
-          name: Refresh trends view
-          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
-      # Clear expired sessions in staging session table
-      - run:
-          name: clearsessions management command
-          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
+      # Run common tasks (e.g. refresh trends, clear expired sessions)
+      - *run-common-tasks
 
   dev-maintenance-tasks:
     docker:
@@ -354,18 +354,12 @@ jobs:
     steps:
       # Install cloud foundry tools
       - *install-cf7
-      # login to Staging Cloud.gov environment
+      # login to Cloud.gov dev space
       - run:
           name: Login to cloud.gov Staging
           command: cf login -u ${CRT_USERNAME_DEV} -p ${CRT_PASSWORD_DEV} -o doj-crtportal -s ${CF_SPACE}
-      # Refresh the trend view in staging
-      - run:
-          name: Refresh trends view
-          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
-      # Clear expired sessions in staging session table
-      - run:
-          name: clearsessions management command
-          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
+      # Run common tasks (e.g. refresh trends, clear expired sessions)
+      - *run-common-tasks
 
 workflows:
   version: 2
@@ -413,13 +407,33 @@ workflows:
             branches:
               only: master
   # Scheduled maintenance jobs for portal
+  # Dev scheduled jobs
   periodic-tasks-dev:
     jobs:
-      - dev-maintenance-tasks #run the development env jobs only
-
+      - dev-maintenance-tasks #run on dev
     triggers:
       - schedule:
-          cron: "0 0 * * *" # run past midnight every night
+          cron: "0 0 * * *" # run past 8pm every night EST
           filters:
             branches:
               only: develop
+  # Staging scheduled jobs
+  periodic-tasks-staging:
+    jobs:
+      - staging-maintenance-tasks #run on stage
+    triggers:
+      - schedule:
+          cron: "0 4 * * *" # run past midnight every night EST
+          filters:
+            branches:
+              only: /^release.*/
+  # prod scheduled jobs
+  periodic-tasks-prod:
+    jobs:
+      - prod-maintenance-tasks #run on prod
+    triggers:
+      - schedule:
+          cron: "0 4 * * *" # run past midnight every night EST
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/686)

## What does this change?
Added periodic task schedule for staging and prod
Organize common periodic tasks in one single place.


## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
