### PR TITLE
bugfix: swap activity/actions and add empty clause

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/comments.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/comments.html
@@ -8,6 +8,8 @@
   <ul class="activity-stream-print activity-stream-list usa-list usa-list--unstyled">
     {% for comment in print_comments %}
       {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=comment %}
+    {% empty %}
+      No actions.
     {% endfor %}
   </ul>
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -101,11 +101,11 @@
             {% include 'forms/complaint_view/show/actions/comment_summary.html' with id_name="comment" is_summary=False button_text='Save' button_aria_label='save comment' label='New comment' comment_box=comments.note %}
           </div>
         </div>
-        {% include 'forms/complaint_view/print/comments.html' with activity=print_comments %}
+        {% include 'forms/complaint_view/print/activities.html' with activity=print_actions %}
 
         {% include 'forms/complaint_view/print/summary.html' with summary=summary %}
 
-        {% include 'forms/complaint_view/print/activities.html' with activity=print_actions %}
+        {% include 'forms/complaint_view/print/comments.html' with activity=print_comments %}
       </div>
       <div class="complaint-information tablet:grid-col-6">
         {% include 'forms/complaint_view/show/correspondent_info.html' with data=data %}

--- a/crt_portal/static/js/print_report.js
+++ b/crt_portal/static/js/print_report.js
@@ -4,9 +4,9 @@
     id_options_0: '.crt-correspondent-card',
     id_options_1: '.crt-report-card',
     id_options_2: '.crt-description-card',
-    id_options_3: '.crt-comments-card',
+    id_options_3: '.crt-activities-card',
     id_options_4: '.crt-summary-card',
-    id_options_5: '.crt-activities-card'
+    id_options_5: '.crt-comments-card'
   };
 
   var modal = document.getElementById('print_report');


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/709)

## What does this change?

Bugfix: activity and actions (comments) were getting mixed up. Also added an empty clause for comments for clarification (so it's not just a blank section).

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
