### PR TITLE
bulk update: warn if more than 15 records are affected

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_assign.html
@@ -22,7 +22,8 @@
       <div id="assign_section">
         {{ assign_form }}
 
-        <button class="usa-button"
+        <button class="usa-button{% if show_warning %} button--warning display-flex align-center{% endif %}"
+                {% if show_warning %}id="show_warning_section_partial"{% endif %}
                 disabled
                 type="submit"
                 name="selected_ids"
@@ -40,12 +41,16 @@
         {% endif %}
       </div>
 
-      {% if selected_all %}
+      {% if display_warning or selected_all %}
         <div id="warning_section" hidden>
           <p>
-            Are you sure you want to assign {{ all_ids_count }} records to <span id="warning_section_assignee"></span>?
+            Are you sure you want to assign
+            <span id="warning_count_all">{{ all_ids_count }}</span>
+            <span id="warning_count_partial">{{ ids_count }}</span>
+            records to <span id="warning_section_assignee"></span>?
           </p>
           <button class="usa-button button--warning display-flex align-center"
+                  id="confirm_button"
                   name="confirm_all"
                   value="confirm_all"
                   type="submit">

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -522,6 +522,7 @@ class ActionsView(LoginRequiredMixin, FormView):
             'selected_all': 'all' if selected_all else '',
             'ids': ','.join([id for id in ids]),
             'ids_count': ids_count,
+            'show_warning': ids_count > 15,
             'all_ids_count': all_ids_count,
             'assign_form': assign_form,
         }
@@ -577,6 +578,7 @@ class ActionsView(LoginRequiredMixin, FormView):
                 'selected_all': 'all' if selected_all else '',
                 'ids': ids,
                 'ids_count': ids_count,
+                'show_warning': ids_count > 15,
                 'all_ids_count': all_ids_count,
                 'assign_form': assign_form,
             }

--- a/crt_portal/static/js/bulk_assign.js
+++ b/crt_portal/static/js/bulk_assign.js
@@ -23,18 +23,43 @@
 
   var assign_section = document.getElementById('assign_section');
   var warning_section = document.getElementById('warning_section');
+  var warning_count_partial = document.getElementById('warning_count_partial');
+  var warning_count_all = document.getElementById('warning_count_all');
+  var confirm_button = document.getElementById('confirm_button');
+
+  var update_warning = function(is_partial) {
+    var assignee = document.getElementById('warning_section_assignee');
+    var actualSelectElement = document.getElementById('id_assigned_to-select');
+    assign_section.setAttribute('hidden', 'hidden');
+    warning_section.removeAttribute('hidden');
+    if (is_partial) {
+      warning_count_all.setAttribute('hidden', 'hidden');
+      warning_count_partial.removeAttribute('hidden');
+      confirm_button.setAttribute('value', 'none');
+    } else {
+      warning_count_all.removeAttribute('hidden');
+      warning_count_partial.setAttribute('hidden', 'hidden');
+      confirm_button.setAttribute('value', 'confirm_all');
+    }
+    // work around a bug: if user removes an auto complete field, the
+    // selected item is still present, so pull from the actual selection
+    var index = actualSelectElement.selectedIndex;
+    assignee.innerText = actualSelectElement.options[index].text;
+  };
+
   var show_warning_section = document.getElementById('show_warning_section');
   if (show_warning_section) {
     show_warning_section.onclick = function(event) {
       event.preventDefault();
-      var assignee = document.getElementById('warning_section_assignee');
-      var actualSelectElement = document.getElementById('id_assigned_to-select');
-      assign_section.setAttribute('hidden', 'hidden');
-      warning_section.removeAttribute('hidden');
-      // work around a bug: if user removes an auto complete field, the
-      // selected item is still present, so pull from the actual selection
-      var index = actualSelectElement.selectedIndex;
-      assignee.innerText = actualSelectElement.options[index].text;
+      update_warning(false);
+    };
+  }
+
+  var show_warning_section_partial = document.getElementById('show_warning_section_partial');
+  if (show_warning_section_partial) {
+    show_warning_section_partial.onclick = function(event) {
+      event.preventDefault();
+      update_warning(true);
     };
   }
 


### PR DESCRIPTION
[Zenhub issue](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/726) which is also part of [Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/723)

## What does this change?

- If the user wants to change more than 15 records, the button changes to a warning button and a secondary confirm button is _also_ needed. Note that the "all" button and functionality is also kept as-is.

## Screenshots (for front-end PR):

![2020-09-29_13-26](https://user-images.githubusercontent.com/3013175/94612071-713a7980-0257-11eb-88e0-7233bcd903ea.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
