### PR TITLE
[WIP] new 404 error page

### DIFF
--- a/crt_portal/cts_forms/templates/forms/error_404.html
+++ b/crt_portal/cts_forms/templates/forms/error_404.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block page_header %}
+<header class="confirmation-header">
+  <div class="grid-container">
+    <div class="grid-row grid-gap flex-child">
+      <div class="tablet:grid-col-9 tablet:grid-offset-1">
+        <div class="doj-brand display-flex flex-align-center font-serif-lg">
+          <img src="{% static "img/doj-logo-footer.svg" %}" alt="" height="38" class="margin-right-105" />
+          <span>United States Department of Justice<span>
+        </div>
+        <h1 class="padding-top-2 padding-bottom-1 margin-0 title">
+          Civil Rights Division
+        </h1>
+      </div>
+    </div>
+  </div>
+</header>
+{% endblock %}
+
+{% block content %}
+<section class="grid-container">
+  <div class="grid-row">
+  <div class="tablet:grid-col-8 tablet:grid-offset-2">
+    <div class="crt-success-card">
+      <div class="crt-success-card__content">
+          <h2>404 | Page not found <img src="{% static 'img/alerts/error-red.svg' %}" alt="Error indicator with exclamation mark in red circle" width="50px" height="50px" class="padding-top-3"></h2>
+          <h3>We can't find the page you are looking for</h3>  
+          <p>Try one of these links:</p>
+          <div class="padding-left-1"><a href="../report/">File a complaint</a></div>
+          <div class="padding-left-1"><a href="mailto:Ask.CRT@crt.usdoj.gov">email</a>, <a href="../#contact-crt">phone or mail</a></div>
+          <div class="padding-left-1"><a href="../#about-the-division">About the Civil Rights Division</a></div>
+          <p>if you or someone else is in immediate danger, please call 911 or your local police.</p>
+      </div>
+      </div>
+    </div>
+  </div>
+  </div>
+</section>
+{% endblock %}
+

--- a/crt_portal/cts_forms/tests/tests.py
+++ b/crt_portal/cts_forms/tests/tests.py
@@ -179,7 +179,7 @@ class Complaint_Show_View_404(TestCase):
         response = self.client.get(reverse('crt_forms:crt-forms-show', kwargs={'id': '1'}))
         self.assertEqual(response.status_code, 404)
         # test for custom message
-        self.assertTrue("We can&#39;t find the page you are looking for" in str(response.content))
+        self.assertTrue("404 | Page not found" in str(response.content))
 
 
 class Complaint_Show_View_Valid(TestCase):

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -70,11 +70,7 @@ def error_403(request, exception=None):
 def error_404(request, exception=None):
     return render(
         request,
-        'forms/errors.html', {
-            'status': 404,
-            'message': _("We can't find the page you are looking for"),
-            'helptext': _("Try returning to the previous page")
-        },
+        'forms/error_404.html',
         status=404
     )
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/705)

## What does this change?
This changes application 404 error page to include new content items such as links and text.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [X] Check for [accessibility](/docs/a11y_plan.md).
+ [X] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
