### PR TITLE
Bulk actions prefill

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -756,12 +756,12 @@ class ProForm(
         Contact.__init__(self, *args, **kwargs)
         # CRT views only
         self.fields['intake_format'] = ChoiceField(
-            choices=_add_empty_choice((
+            choices=(
                 ('letter', 'letter'),
                 ('phone', 'phone'),
                 ('fax', 'fax'),
                 ('email', 'email'),
-            )),
+            ),
             widget=UsaRadioSelect,
             required=False,
         )

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1262,7 +1262,7 @@ class PrintActions(Form):
     )
 
 
-class BulkActions(Form, ActivityStreamUpdater):
+class BulkActionsForm(Form, ActivityStreamUpdater):
     assigned_section = ChoiceField(
         label='Section',
         widget=ComplaintSelect(

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1263,7 +1263,7 @@ class PrintActions(Form):
 
 
 class BulkActionsForm(Form, ActivityStreamUpdater):
-    EMPTY_CHOICE ='Multiple'
+    EMPTY_CHOICE = 'Multiple'
     assigned_section = ChoiceField(
         label='Section',
         widget=ComplaintSelect(

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1158,7 +1158,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
                     'class': 'text-uppercase crt-dropdown__data',
                 },
             ),
-            choices=_add_empty_choice(STATUTE_CHOICES),
+            choices=_add_empty_choice(STATUTE_CHOICES, default_string=''),
             required=False
         )
         self.fields['district'] = ChoiceField(
@@ -1168,7 +1168,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
                     'class': 'text-uppercase crt-dropdown__data',
                 },
             ),
-            choices=_add_empty_choice(DISTRICT_CHOICES),
+            choices=_add_empty_choice(DISTRICT_CHOICES, default_string=''),
             required=False
         )
         self.fields['assigned_to'].widget.label = 'Assigned to'

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1329,9 +1329,12 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         singular value within that query. Used to set initial fields
         for bulk update forms.
         """
+        # make sure the queryset does not order by anything, otherwise
+        # we will have difficulty getting distinct results.
+        query = record_query.order_by()
         for key in keys:
-            values = record_query.values_list(key, flat=True)
-            if len(set(values)) == 1:
+            values = query.order_by().values_list(key, flat=True).distinct()
+            if values.count() == 1:
                 yield key, values[0]
 
     def __init__(self, query, *args, **kwargs):

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1333,7 +1333,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         # we will have difficulty getting distinct results.
         query = record_query.order_by()
         for key in keys:
-            values = query.order_by().values_list(key, flat=True).distinct()
+            values = query.values_list(key, flat=True).distinct()
             if values.count() == 1:
                 yield key, values[0]
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1327,9 +1327,8 @@ class BulkActions(Form, ActivityStreamUpdater):
         Form.__init__(self)
         keys = ['assigned_section', 'status', 'primary_statute', 'district']
         values = query.values_list(*keys)
-        initial_values = list(zip(*values))
-        for index, key in enumerate(keys):
-            initial = initial_values[index]
+        initial_values = zip(*values)
+        for key, initial in zip(keys, initial_values):
             if len(set(initial)) == 1:
                 self.fields[key].initial = initial[0]
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1323,6 +1323,16 @@ class BulkActions(Form, ActivityStreamUpdater):
         ),
     )
 
+    def __init__(self, query):
+        Form.__init__(self)
+        keys = ['assigned_section', 'status', 'primary_statute', 'district']
+        values = query.values_list(*keys)
+        initial_values = list(zip(*values))
+        for index, key in enumerate(keys):
+            initial = initial_values[index]
+            if len(set(initial)) == 1:
+                self.fields[key].initial = initial[0]
+
     def get_updates(self):
         return {field: self.cleaned_data[field] for field in self.changed_data}
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1329,11 +1329,10 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         singular value within that query. Used to set initial fields
         for bulk update forms.
         """
-        values = record_query.values_list(*keys)
-        initial_values = zip(*values)
-        for key, initial in zip(keys, initial_values):
-            if len(set(initial)) == 1:
-                yield key, initial[0]
+        for key in keys:
+            values = record_query.values_list(key, flat=True)
+            if len(set(values)) == 1:
+                yield key, values[0]
 
     def __init__(self, query, *args, **kwargs):
         Form.__init__(self, *args, **kwargs)

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1263,7 +1263,6 @@ class PrintActions(Form):
 
 
 class BulkActions(Form, ActivityStreamUpdater):
-
     assigned_section = ChoiceField(
         label='Section',
         widget=ComplaintSelect(
@@ -1323,8 +1322,8 @@ class BulkActions(Form, ActivityStreamUpdater):
         ),
     )
 
-    def __init__(self, query):
-        Form.__init__(self)
+    def __init__(self, query, *args, **kwargs):
+        Form.__init__(self, *args, **kwargs)
         keys = ['assigned_section', 'status', 'primary_statute', 'district']
         values = query.values_list(*keys)
         initial_values = zip(*values)
@@ -1351,7 +1350,7 @@ class BulkActions(Form, ActivityStreamUpdater):
             what = value.lower()
             item = self.cleaned_data[key]
             string = custom_strings.get(what, default_string)
-            description = string.format(**{'what': what, 'item': item})
+            description = string.format(**{'what': what, 'item': item or "''"})
             descriptions.append(description)
         if len(descriptions) > 1:
             descriptions[-1] = f'and {descriptions[-1]}'

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1263,19 +1263,20 @@ class PrintActions(Form):
 
 
 class BulkActionsForm(Form, ActivityStreamUpdater):
+    EMPTY_CHOICE ='Multiple'
     assigned_section = ChoiceField(
         label='Section',
         widget=ComplaintSelect(
             attrs={'class': 'usa-select text-bold text-uppercase crt-dropdown__data'},
         ),
-        choices=_add_empty_choice(SECTION_CHOICES, default_string='Multiple'),
+        choices=_add_empty_choice(SECTION_CHOICES, default_string=EMPTY_CHOICE),
         required=False
     )
     status = ChoiceField(
         widget=ComplaintSelect(
             attrs={'class': 'crt-dropdown__data'},
         ),
-        choices=_add_empty_choice(STATUS_CHOICES, default_string='Multiple'),
+        choices=_add_empty_choice(STATUS_CHOICES, default_string=EMPTY_CHOICE),
         required=False
     )
     primary_statute = ChoiceField(
@@ -1283,7 +1284,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         widget=ComplaintSelect(
             attrs={'class': 'text-uppercase crt-dropdown__data'},
         ),
-        choices=_add_empty_choice(STATUTE_CHOICES, default_string='Multiple'),
+        choices=_add_empty_choice(STATUTE_CHOICES, default_string=EMPTY_CHOICE),
         required=False
     )
     district = ChoiceField(
@@ -1291,7 +1292,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         widget=ComplaintSelect(
             attrs={'class': 'text-uppercase crt-dropdown__data'},
         ),
-        choices=_add_empty_choice(DISTRICT_CHOICES, default_string='Multiple'),
+        choices=_add_empty_choice(DISTRICT_CHOICES, default_string=EMPTY_CHOICE),
         required=False
     )
     assigned_to = ModelChoiceField(

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -61,11 +61,11 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-def _add_empty_choice(choices):
+def _add_empty_choice(choices, default_string=EMPTY_CHOICE):
     """Add an empty option to list of choices"""
     if isinstance(choices, list):
         choices = tuple(choices)
-    return (EMPTY_CHOICE,) + choices
+    return (('', default_string),) + choices
 
 
 def add_activity(user, verb, description, instance):
@@ -756,12 +756,12 @@ class ProForm(
         Contact.__init__(self, *args, **kwargs)
         # CRT views only
         self.fields['intake_format'] = ChoiceField(
-            choices=(
+            choices=_add_empty_choice((
                 ('letter', 'letter'),
                 ('phone', 'phone'),
                 ('fax', 'fax'),
                 ('email', 'email'),
-            ),
+            )),
             widget=UsaRadioSelect,
             required=False,
         )
@@ -1263,19 +1263,20 @@ class PrintActions(Form):
 
 
 class BulkActions(Form, ActivityStreamUpdater):
+
     assigned_section = ChoiceField(
         label='Section',
         widget=ComplaintSelect(
             attrs={'class': 'usa-select text-bold text-uppercase crt-dropdown__data'},
         ),
-        choices=_add_empty_choice(SECTION_CHOICES),
+        choices=_add_empty_choice(SECTION_CHOICES, default_string='Multiple'),
         required=False
     )
     status = ChoiceField(
         widget=ComplaintSelect(
             attrs={'class': 'crt-dropdown__data'},
         ),
-        choices=_add_empty_choice(STATUS_CHOICES),
+        choices=_add_empty_choice(STATUS_CHOICES, default_string='Multiple'),
         required=False
     )
     primary_statute = ChoiceField(
@@ -1283,7 +1284,7 @@ class BulkActions(Form, ActivityStreamUpdater):
         widget=ComplaintSelect(
             attrs={'class': 'text-uppercase crt-dropdown__data'},
         ),
-        choices=_add_empty_choice(STATUTE_CHOICES),
+        choices=_add_empty_choice(STATUTE_CHOICES, default_string='Multiple'),
         required=False
     )
     district = ChoiceField(
@@ -1291,7 +1292,7 @@ class BulkActions(Form, ActivityStreamUpdater):
         widget=ComplaintSelect(
             attrs={'class': 'text-uppercase crt-dropdown__data'},
         ),
-        choices=_add_empty_choice(DISTRICT_CHOICES),
+        choices=_add_empty_choice(DISTRICT_CHOICES, default_string='Multiple'),
         required=False
     )
     assigned_to = ModelChoiceField(

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -3,7 +3,7 @@
 from django.utils.translation import gettext_lazy as _
 
 # Translators: This is used as a an empty selection default for drop down menus
-EMPTY_CHOICE = ('', _('- Select -'))
+EMPTY_CHOICE = _('- Select -')
 
 SERVICEMEMBER_CHOICES = (
     ('yes', _('Yes')),

--- a/crt_portal/cts_forms/templates/forms/widgets/multi_select_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/multi_select_option.html
@@ -1,3 +1,3 @@
 <option value="{{option.value}}" {% if option.selected is not False %}selected{% endif %}>
-  {{option.value|title}}
+  {{option.value|default:option.label|title}}
 </option>

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -492,6 +492,7 @@ class BulkActionsTests(TestCase):
             self.assertEquals(last_activity.description, 'a comment')
             self.assertEquals(last_activity.actor, user)
 
+
 class BulkActionsFormTests(TestCase):
     def test_bulk_actions_initial_empty(self):
         queryset = Report.objects.all()

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -8,7 +8,7 @@ from django.test.client import Client
 from django.urls import reverse
 from django.utils.html import escape
 
-from ..forms import ComplaintActions, ReportEditForm
+from ..forms import ComplaintActions, ReportEditForm, BulkActionsForm
 from ..model_variables import PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES
 from ..models import CommentAndSummary, Report, ResponseTemplate
 from .test_data import SAMPLE_REPORT, SAMPLE_RESPONSE_TEMPLATE
@@ -375,7 +375,7 @@ class PrintActionTests(TestCase):
         self.assertTrue(escape('Selected correspondent, activity') in content)
 
 
-class BulkActionTests(TestCase):
+class BulkActionsTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.test_pass = secrets.token_hex(32)
@@ -491,3 +491,16 @@ class BulkActionTests(TestCase):
             self.assertEquals(last_activity.verb, "Added comment: ")
             self.assertEquals(last_activity.description, 'a comment')
             self.assertEquals(last_activity.actor, user)
+
+class BulkActionsFormTests(TestCase):
+    def test_bulk_actions_initial_empty(self):
+        queryset = Report.objects.all()
+        result = list(BulkActionsForm.get_initial_values(queryset, []))
+        self.assertEquals(result, [])
+
+    def test_bulk_actions_initial(self):
+        [Report.objects.create(**SAMPLE_REPORT) for _ in range(4)]
+        queryset = Report.objects.all()
+        keys = ['assigned_section', 'status', 'id']
+        result = list(BulkActionsForm.get_initial_values(queryset, keys))
+        self.assertEquals(result, [('assigned_section', 'ADM'), ('status', 'new')])

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -453,7 +453,7 @@ class BulkActionTests(TestCase):
     def test_post_with_ids(self):
         ids = [report.id for report in self.reports[3:5]]
         user = User.objects.get(username='DELETE_USER')
-        response = self.post(ids, assigned_to=user.id, comment='a comment')
+        response = self.post(ids, assigned_to=user.id, comment='a comment', assigned_section='ADM', status='new')
         content = str(response.content)
         self.assertTrue('2 records have been updated: assigned to DELETE_USER' in content)
         self.assertEquals(response.request['PATH_INFO'], reverse('crt_forms:crt-forms-index'))
@@ -467,7 +467,7 @@ class BulkActionTests(TestCase):
     def test_post_with_ids_and_all(self):
         ids = [report.id for report in self.reports[3:5]]
         user = User.objects.get(username='DELETE_USER')
-        response = self.post(ids, all_ids=True, confirm=False, status='closed', comment='a comment')
+        response = self.post(ids, all_ids=True, confirm=False, status='closed', comment='a comment', assigned_section='ADM')
         content = str(response.content)
         self.assertTrue('2 records have been updated: status set to closed' in content)
         self.assertEquals(response.request['PATH_INFO'], reverse('crt_forms:crt-forms-index'))
@@ -481,7 +481,7 @@ class BulkActionTests(TestCase):
     def test_post_with_all(self):
         ids = [report.id for report in self.reports]
         user = User.objects.get(username='DELETE_USER')
-        response = self.post(ids, all_ids=True, confirm=True, summary='summary', comment='a comment')
+        response = self.post(ids, all_ids=True, confirm=True, summary='summary', comment='a comment', assigned_section='ADM', status='new')
         content = str(response.content)
         self.assertTrue('16 records have been updated: summary updated' in content)
         self.assertEquals(response.request['PATH_INFO'], reverse('crt_forms:crt-forms-index'))

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -546,7 +546,7 @@ class ActionsView(LoginRequiredMixin, FormView):
         else:
             requested_query = Report.objects.filter(pk__in=ids)
 
-        bulk_actions_form = BulkActions(request.POST, requested_query)
+        bulk_actions_form = BulkActions(requested_query, request.POST)
 
         if bulk_actions_form.is_valid():
             number = bulk_actions_form.update(requested_query, request.user)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -17,7 +17,7 @@ from django.views.decorators.cache import never_cache
 from formtools.wizard.views import SessionWizardView
 
 from .filters import report_filter
-from .forms import (BulkActions, CommentActions, ComplaintActions,
+from .forms import (BulkActionsForm, CommentActions, ComplaintActions,
                     ResponseActions, PrintActions, ContactEditForm,
                     Filters, ReportEditForm, Review, add_activity,
                     ProfileForm)
@@ -517,7 +517,7 @@ class ActionsView(LoginRequiredMixin, FormView):
         ids = request.GET.getlist('id')
         ids_count = len(ids)
 
-        bulk_actions_form = BulkActions(requested_query)
+        bulk_actions_form = BulkActionsForm(requested_query)
 
         # the select all option only applies if 1. user hits the
         # select all button and 2. we have more records in the query
@@ -546,7 +546,7 @@ class ActionsView(LoginRequiredMixin, FormView):
         else:
             requested_query = Report.objects.filter(pk__in=ids)
 
-        bulk_actions_form = BulkActions(requested_query, request.POST)
+        bulk_actions_form = BulkActionsForm(requested_query, request.POST)
 
         if bulk_actions_form.is_valid():
             number = bulk_actions_form.update(requested_query, request.user)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -511,18 +511,23 @@ class ActionsView(LoginRequiredMixin, FormView):
         return_url_args = request.GET.get('next', '')
         return_url_args = urllib.parse.unquote(return_url_args)
 
-        requested_query = self.reconstruct_query(return_url_args)
-        all_ids_count = requested_query.count()
-
         ids = request.GET.getlist('id')
-        ids_count = len(ids)
-
-        bulk_actions_form = BulkActionsForm(requested_query)
-
         # the select all option only applies if 1. user hits the
         # select all button and 2. we have more records in the query
         # than the ids passed in
-        selected_all = request.GET.get('all', '') == 'all' and all_ids_count != ids_count
+        selected_all = request.GET.get('all', '') == 'all'
+
+        if selected_all:
+            requested_query = self.reconstruct_query(return_url_args)
+        else:
+            requested_query = Report.objects.filter(pk__in=ids)
+
+        bulk_actions_form = BulkActionsForm(requested_query)
+        all_ids_count = requested_query.count()
+        ids_count = len(ids)
+
+        # further refine selected_all to ensure < 15 items don't show up.
+        selected_all = selected_all and all_ids_count != ids_count
 
         output = {
             'return_url_args': return_url_args,


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/728)

## What does this change?

- Pre-fills bulk action form iff the queryset has same values.

## Screenshots (for front-end PR):

![2020-10-07_13-52_1](https://user-images.githubusercontent.com/3013175/95386648-77a6a200-08a4-11eb-8114-6e2180fa0c59.png)
![2020-10-07_13-52](https://user-images.githubusercontent.com/3013175/95386653-79706580-08a4-11eb-8ec7-efb37f163d41.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
