### PR TITLE
Added test cases for complaint actions form

### DIFF
--- a/crt_portal/cts_forms/tests/test_data.py
+++ b/crt_portal/cts_forms/tests/test_data.py
@@ -17,3 +17,10 @@ SAMPLE_RESPONSE_TEMPLATE = {
     'subject': 'test data with record {{ record_locator }}',
     'body': 'test template with record {{ record_locator }}',
 }
+
+SAMPLE_COMPLAINT = {
+    'assigned_section': 'ADM',
+    'status': 'new',
+    'primary_statute': '144',
+    'district': '1'
+}


### PR DESCRIPTION
Currently working on Resolving to Merge Conflict

[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/713)

## What does this change?
Unit test for Complaint.Action.testcase.test, Smaller change of code in test_forms.py

## Checklist:
ran tests with changes multiple times

### Author
kmanubhai

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
