### PR TITLE
713: Added unit test for complaint action forms.

### DIFF
--- a/crt_portal/cts_forms/tests/test_data.py
+++ b/crt_portal/cts_forms/tests/test_data.py
@@ -17,3 +17,10 @@ SAMPLE_RESPONSE_TEMPLATE = {
     'subject': 'test data with record {{ record_locator }}',
     'body': 'test template with record {{ record_locator }}',
 }
+
+SAMPLE_COMPLAINT = {
+    'assigned_section': 'ADM',
+    'status': 'new',
+    'primary_statute': '144',
+    'district': '1'
+}

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -12,6 +12,7 @@ from ..forms import ComplaintActions, ReportEditForm
 from ..model_variables import PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES
 from ..models import CommentAndSummary, Report, ResponseTemplate
 from .test_data import SAMPLE_REPORT, SAMPLE_RESPONSE_TEMPLATE
+from .test_data import SAMPLE_REPORT, SAMPLE_RESPONSE_TEMPLATE, SAMPLE_COMPLAINT
 
 
 class ActionTests(TestCase):
@@ -109,6 +110,18 @@ class CommentActionTests(TestCase):
         content = str(response.content)
         self.assertTrue('Could not save comment' in content)
         self.assertEquals(response.status_code, 200)
+
+class ComplaintActionsTests(TestCase):    
+    def setUp(self):
+        self.complaint_data = SAMPLE_COMPLAINT.copy()
+        self.complaint = Report.objects.create(**self.complaint_data)
+    
+    def test_changed_data_assigned_section(self):
+        data = self.complaint_data.copy()
+        data.update({'assigned_section': 'APP'})
+        form = ComplaintActions(data, instance=self.complaint)
+        self.assertTrue(form.is_valid())
+        self.assertTrue('assigned_section' in form.changed_data)
 
 
 class ReportEditFormTests(TestCase):

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -118,10 +118,15 @@ class ComplaintActionsTests(TestCase):
     
     def test_changed_data_assigned_section(self):
         data = self.complaint_data.copy()
-        data.update({'assigned_section': 'APP'})
+        old_assigned_section = data['assigned_section']
+        new_assigned_section = 'APP'
+        data.update({'assigned_section': new_assigned_section})
         form = ComplaintActions(data, instance=self.complaint)
         self.assertTrue(form.is_valid())
         self.assertTrue('assigned_section' in form.changed_data)
+        for verb, description in form.get_actions():
+            self.assertTrue("Assigned section:" == verb)
+            self.assertTrue(f'Updated from "{old_assigned_section}" to "{new_assigned_section}"' == description)
 
 
 class ReportEditFormTests(TestCase):


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/713)

## What does this change?

Unit test for Complaint.Action.testcase.test, Smaller change of code in test_forms.py

## Checklist:
ran tests with changes multiple times

### Author
kmanubhai

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
