### PR TITLE
736: Added code changes to show location name and complaint number to…

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -126,7 +126,22 @@
                   {{ datum.report.violation_summary|linebreaks|default:"-" }}
                 </div>
               </td>
-              <td colspan="2"></td>
+              <td>
+                <div class="td-quickview">
+                  Location Name
+                </div>
+                <div class="td-summary">
+                  {{ datum.report.location_name|default:"-" }}
+                </div>
+              </td>
+              <td>
+                <div class="td-quickview">
+                  Complaint ID
+                </div>
+                <div class="td-summary">
+                  {{ datum.report.public_id|default:"-" }}
+                </div>
+              </td>
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
… quick view.

[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/736)

## What does this change?
When you click on quick view down arrow of particular record, you will be able to see Location Name and Complaint ID
changes in 1 file, 
 cts_forms\templates\forms\complaint_view\index\complaints_table.html

## Screenshots (for front-end PR):
![736- Code changes to show location and complaint number to quick view](https://user-images.githubusercontent.com/72465349/95797291-24c25580-0cbd-11eb-9963-76121d13db0a.PNG)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
