### PR TITLE
updated 404 page error text

### DIFF
--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -42,6 +42,7 @@
             <img src="{% static "img/phone_70.svg" %}" />
             <span class="display-flex flex-column">
               <li>(202) 514-0716</li>
+              <li>1-855-514-0716 {% trans '(toll-free)' %}</li>
               <li>{% trans 'Telephone Device for the Deaf' %}</li>
               <li>{% trans '(TTY)' %} (202) 514-0716</li>
             </span>

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -41,8 +41,8 @@
           <div class="crt-error-box">
             <img src="{% static "img/phone_70.svg" %}" />
             <span class="display-flex flex-column">
-              <li>(202) 514-0716</li>
-              <li>1-855-514-0716 {% trans '(toll-free)' %}</li>
+              <li><a href="tel:202-514-3847">(202) 514-0716</a></li>
+              <li><a href="tel:1-855-856-1247">1-855-514-0716</a> {% trans '(toll-free)' %}</li>
               <li>{% trans 'Telephone Device for the Deaf' %}</li>
               <li>{% trans '(TTY)' %} (202) 514-0716</li>
             </span>

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -52,7 +52,7 @@
             <span class="display-flex flex-column">
               <li>{% trans 'U.S. Department of Justice' %}</li>
               <li>{% trans 'Civil Rights Division' %}</li>
-              <li>950 Pennsylvannia Avenue, NW</li>
+              <li>950 Pennsylvania Avenue, NW</li>
               <li>Washington, D.C. 20530-0001</li>
             </span>
           </div>

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -41,10 +41,10 @@
           <div class="crt-error-box">
             <img src="{% static "img/phone_70.svg" %}" />
             <span class="display-flex flex-column">
-              <li><a href="tel:202-514-3847">(202) 514-0716</a></li>
-              <li><a href="tel:1-855-856-1247">1-855-514-0716</a> {% trans '(toll-free)' %}</li>
+              <li><a href="tel:202-514-3847">(202) 514-3847</a></li>
+              <li><a href="tel:1-855-856-1247">1-855-856-1247</a> {% trans '(toll-free)' %}</li>
               <li>{% trans 'Telephone Device for the Deaf' %}</li>
-              <li>{% trans '(TTY)' %} (202) 514-0716</li>
+              <li>{% trans '(TTY)' %} <a href="tel:202-514-0716">(202) 514-0716</a></li>
             </span>
           </div>
           <div class="crt-error-box">

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import (ActionsView, index_view, error_404, ShowView, ProFormView,
+from .views import (ActionsView, index_view, ShowView, ProFormView,
                     SaveCommentView, TrendView, ResponseView,
                     PrintView, ProfileView)
 from .forms import ProForm
@@ -18,5 +18,4 @@ urlpatterns = [
     path('actions/', ActionsView.as_view(), name='crt-forms-actions'),
     path('comment/report/<int:report_id>/', SaveCommentView.as_view(), name='save-report-comment'),
     path('trends/', TrendView.as_view(), name='trends'),
-    path('errors/', error_404, name='errors'),
 ]

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import (ActionsView, index_view, ShowView, ProFormView,
+from .views import (ActionsView, index_view, error_404, ShowView, ProFormView,
                     SaveCommentView, TrendView, ResponseView,
                     PrintView, ProfileView)
 from .forms import ProForm
@@ -18,4 +18,5 @@ urlpatterns = [
     path('actions/', ActionsView.as_view(), name='crt-forms-actions'),
     path('comment/report/<int:report_id>/', SaveCommentView.as_view(), name='save-report-comment'),
     path('trends/', TrendView.as_view(), name='trends'),
+    path('errors/', error_404, name='errors'),
 ]

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -72,8 +72,7 @@ def error_404(request, exception=None):
         request,
         'forms/errors.html', {
             'status': '404 | Page not found ',
-            'message': _("We can't find the page you are looking for"),
-            'helptext': _("Try returning to the previous page")
+            'message': _("We can't find the page you are looking for")
         },
         status=404
     )


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/705)

## What does this change?
Based on feedback from product owner this change updates the 404 page error text. Feedback can be found on the ZenHub card, in the comments section.
## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/66343959/95872559-ed938900-0d3c-11eb-93c6-a27159560fe8.png)
## Checklist:

### Author
hakhalid11

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
