### PR TITLE
Allow `clear all` to remove String filters

### DIFF
--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -135,14 +135,20 @@
    * @param {Object} updates The properties of the filter state to be updated
    */
   function mutateFilterDataWithUpdates(state, updates) {
-    for (var key in updates) {
+    for (const [key, value] of Object.entries(updates)) {
       if (state.hasOwnProperty(key)) {
-        var decoded_keys = updates[key].map(function(elem) {
-          return decodeURIComponent(elem);
-        });
-        state[key] = decoded_keys;
+        state[key] = decodeFormData(value);
       }
     }
+  }
+
+  function decodeFormData(data) {
+    if (Array.isArray(data)) {
+      return data.map(function(x) {
+        return decodeURIComponent(x);
+      });
+    }
+    return decodeURIComponent(data);
   }
 
   /**

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -144,9 +144,7 @@
 
   function decodeFormData(data) {
     if (Array.isArray(data)) {
-      return data.map(function(x) {
-        return decodeURIComponent(x);
-      });
+      return data.map(decodeURIComponent);
     }
     return decodeURIComponent(data);
   }


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/750)

## What does this change?
Remediate `clear all` javascript functionality to handle filter sets containing String objects and return ability for folks to consistently remove all applied filters.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
