### PR TITLE
404 page full Spanish translations

### DIFF
--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-16 14:59+0000\n"
+"POT-Creation-Date: 2020-10-16 16:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1223,14 +1223,12 @@ msgid "Skip to main content"
 msgstr "Pasar directamente al contenido principal"
 
 #: templates/base.html:98 templates/forms/base.html:92
-#: templates/forms/errors.html:13 templates/forms/errors.html:53
-#: templates/landing.html:18
+#: templates/forms/errors.html:13 templates/landing.html:18
 msgid "U.S. Department of Justice"
 msgstr "Departamento de Justicia de los EE. UU."
 
 #: templates/base.html:101 templates/forms/base.html:91
-#: templates/forms/errors.html:14 templates/forms/errors.html:54
-#: templates/landing.html:21
+#: templates/forms/errors.html:14 templates/landing.html:21
 msgid "Civil Rights Division"
 msgstr "División de Derechos Civiles"
 
@@ -1511,7 +1509,9 @@ msgstr "Su entrega"
 
 #: templates/forms/errors.html:34
 msgid "If you need to contact us immediately, you can reach us by:"
-msgstr "Intente pinchar en alguno de estos enlaces:"
+msgstr ""
+"Si usted necesita comunicarse con nosotros urgentemente, lo puede hacer "
+"mediante los siguientes modos:"
 
 #: templates/forms/errors.html:38
 msgid "Email"
@@ -1519,7 +1519,7 @@ msgstr ""
 
 #: templates/forms/errors.html:45 templates/partials/footer.html:32
 msgid "(toll-free)"
-msgstr "(gratis)"
+msgstr "(línea gratuita)"
 
 #: templates/forms/errors.html:46 templates/partials/footer.html:33
 msgid "Telephone Device for the Deaf"

--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-13 16:08+0000\n"
+"POT-Creation-Date: 2020-10-16 14:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1223,13 +1223,13 @@ msgid "Skip to main content"
 msgstr "Pasar directamente al contenido principal"
 
 #: templates/base.html:98 templates/forms/base.html:92
-#: templates/forms/errors.html:13 templates/forms/errors.html:52
+#: templates/forms/errors.html:13 templates/forms/errors.html:53
 #: templates/landing.html:18
 msgid "U.S. Department of Justice"
 msgstr "Departamento de Justicia de los EE. UU."
 
 #: templates/base.html:101 templates/forms/base.html:91
-#: templates/forms/errors.html:14 templates/forms/errors.html:53
+#: templates/forms/errors.html:14 templates/forms/errors.html:54
 #: templates/landing.html:21
 msgid "Civil Rights Division"
 msgstr "División de Derechos Civiles"
@@ -1509,23 +1509,39 @@ msgstr ""
 msgid "Your submission"
 msgstr "Su entrega"
 
+#: templates/forms/errors.html:34
+msgid "If you need to contact us immediately, you can reach us by:"
+msgstr "Intente pinchar en alguno de estos enlaces:"
+
 #: templates/forms/errors.html:38
 msgid "Email"
 msgstr ""
 
-#: templates/forms/errors.html:45 templates/partials/footer.html:33
+#: templates/forms/errors.html:45 templates/partials/footer.html:32
+msgid "(toll-free)"
+msgstr "(gratis)"
+
+#: templates/forms/errors.html:46 templates/partials/footer.html:33
 msgid "Telephone Device for the Deaf"
 msgstr "Dispositivo telefónico para sordos"
 
-#: templates/forms/errors.html:46 templates/partials/footer.html:34
+#: templates/forms/errors.html:47 templates/partials/footer.html:34
 msgid "(TTY)"
 msgstr "Teletipo (TTY por sus siglas en inglés)"
 
-#: templates/forms/errors.html:60 templates/landing.html:125
+#: templates/forms/errors.html:59
+msgid "Other information"
+msgstr "Información adicional"
+
+#: templates/forms/errors.html:60
+msgid "File a complaint"
+msgstr "Presentar una querella"
+
+#: templates/forms/errors.html:61 templates/landing.html:125
 msgid "About the Civil Rights Division"
 msgstr "Acerca de la División de Derechos Civiles"
 
-#: templates/forms/errors.html:61 templates/landing.html:108
+#: templates/forms/errors.html:62 templates/landing.html:108
 msgid ""
 "If you or someone else is in immediate danger, <a href=\"tel:911\">please "
 "call 911 or local police.</a>"
@@ -1707,8 +1723,8 @@ msgstr "Informe sobre una vulneración"
 msgid "Already submitted?"
 msgstr "¿Ya nos informó de una vulneración?"
 
-#: templates/landing.html:59 templates/partials/footer.html:9 views.py:809
-#: views.py:865 views.py:884
+#: templates/landing.html:59 templates/partials/footer.html:9 views.py:808
+#: views.py:864 views.py:883
 msgid "Contact"
 msgstr "Contacto"
 
@@ -2073,10 +2089,6 @@ msgstr ""
 #: templates/landing.html:371
 msgid "Image attributions"
 msgstr ""
-
-#: templates/partials/footer.html:32
-msgid "(toll-free)"
-msgstr "(gratis)"
 
 #: templates/partials/footer.html:47
 msgid "Availability of Language Assistance Services"
@@ -2595,19 +2607,19 @@ msgstr "No autorizado"
 msgid "This page is off limits to unauthorized users."
 msgstr "Usuario no autorizados no podrán acceder a esta página"
 
+#: views.py:74
+msgid "404 | Page not found"
+msgstr "404 | Página no encontrada"
+
 #: views.py:75
 msgid "We can't find the page you are looking for"
 msgstr "No encontramos la página que usted está buscando"
 
-#: views.py:76
-msgid "Try returning to the previous page"
-msgstr "Intente volver a la página anterior"
-
-#: views.py:87
+#: views.py:86
 msgid "There's a problem loading this page"
 msgstr "Hay un problema para cargar esta página"
 
-#: views.py:88
+#: views.py:87
 msgid ""
 "There's a technical problem loading this page. Try refreshing this page or "
 "going to another page. If that doesn't work, try again later."
@@ -2615,20 +2627,20 @@ msgstr ""
 "Hay un problema técnico para cargar esta página. Intente actualizar esta "
 "página o ir a otra página. Si eso no funciona, intente más tarde."
 
-#: views.py:99
+#: views.py:98
 msgid "Not implemented"
 msgstr "No implementado"
 
-#: views.py:100
+#: views.py:99
 msgid "There seems to be a problem with this request. Try refreshing the page."
 msgstr ""
 "Parece que hay un problema con esta solicitud. Intente actualizar la página."
 
-#: views.py:111
+#: views.py:110
 msgid "Bad gateway"
 msgstr "Portal incorrecto"
 
-#: views.py:112
+#: views.py:111
 msgid ""
 "This problem is due to poor IP communication between back-end computers, "
 "possibly including our web server. Try clearing your browser cache "
@@ -2640,11 +2652,11 @@ msgstr ""
 "borrar completamente el caché de su navegador. Puede que haya algún problema "
 "con su conexión interna a Internet o su cortafuegos."
 
-#: views.py:123
+#: views.py:122
 msgid "Service Unavailable"
 msgstr "Servicio no disponible"
 
-#: views.py:124
+#: views.py:123
 msgid ""
 "Our web server is either closed for repair, upgrades or is rebooting. Please "
 "try again later."
@@ -2652,11 +2664,11 @@ msgstr ""
 "Nuestro servidor de web está cerrado para unos arreglos, actualizaciones o "
 "se está reinicializando. Se ruega que lo intente nuevamente más tarde."
 
-#: views.py:135
+#: views.py:134
 msgid "Your browser couldn't create a secure cookie"
 msgstr "Su navegador no pudo crear una cookie segura"
 
-#: views.py:136
+#: views.py:135
 msgid ""
 "We use security cookies to protect your information from attackers. Make "
 "sure you allow cookies for this site. Having the page open for long periods "
@@ -2670,56 +2682,59 @@ msgstr ""
 "acceder a esta página en otra pestaña o ventana en su navegador. Eso le "
 "creará otra cookie de seguridad y debería resolver el problema."
 
-#: views.py:684 views.py:912
+#: views.py:683 views.py:911
 msgid "word remaining"
 msgstr "palabra restante"
 
-#: views.py:685 views.py:913
+#: views.py:684 views.py:912
 msgid " words remaining"
 msgstr "palabras restantes"
 
-#: views.py:686 views.py:914
+#: views.py:685 views.py:913
 msgid " word limit reached"
 msgstr "límite de palabras alcanzado"
 
-#: views.py:810 views.py:866 views.py:867 views.py:885 views.py:886
-#: views.py:921
+#: views.py:809 views.py:865 views.py:866 views.py:884 views.py:885
+#: views.py:920
 msgid "Primary concern"
 msgstr "Motivo principal de preocupación"
 
-#: views.py:811 views.py:868 views.py:869 views.py:870 views.py:871
-#: views.py:872 views.py:873
+#: views.py:810 views.py:867 views.py:868 views.py:869 views.py:870
+#: views.py:871 views.py:872
 msgid "Location"
 msgstr "Lugar"
 
-#: views.py:812 views.py:874 views.py:893
+#: views.py:811 views.py:873 views.py:892
 msgid "Personal characteristics"
 msgstr "Características personales"
 
-#: views.py:813 views.py:875 views.py:894
+#: views.py:812 views.py:874 views.py:893
 msgid "Date"
 msgstr "Fecha"
 
-#: views.py:814 views.py:876 views.py:895
+#: views.py:813 views.py:875 views.py:894
 msgid "Personal description"
 msgstr "Descripción personal"
 
-#: views.py:815 views.py:877 views.py:926
+#: views.py:814 views.py:876 views.py:925
 msgid "Review"
 msgstr "Repasar"
 
-#: views.py:887 views.py:888 views.py:889 views.py:890 views.py:891
-#: views.py:892
+#: views.py:886 views.py:887 views.py:888 views.py:889 views.py:890
+#: views.py:891
 msgid "Location details"
 msgstr "Datos de lugar"
 
-#: views.py:896
+#: views.py:895
 msgid "Review your report"
 msgstr "Revise su informe"
 
-#: views.py:924
+#: views.py:923
 msgid "Please select if any that apply to your situation (optional)"
 msgstr "Favor de elegir esta opción si"
+
+#~ msgid "Try returning to the previous page"
+#~ msgstr "Intente volver a la página anterior"
 
 #~ msgid "Have you or someone you know experienced unlawful discrimination?"
 #~ msgstr ""

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -31,7 +31,7 @@
             <span>{{ message }}</span>
             <span class="help-text__small">{{ helptext }}</span>
           </div>
-          <h2 class="error-subheading">If you need to contact us immediately, you can reach us by:</h2>
+          <h2 class="error-subheading">{% trans 'If you need to contact us immediately, you can reach us by:' %}</h2>
           <div class="crt-error-box">
             <img src="{% static "img/at-sign.svg" %}" />
             <span>
@@ -56,8 +56,8 @@
               <li>Washington, D.C. 20530-0001</li>
             </span>
           </div>
-          <h2 class="error-subheading">Other information</h2>
-          <p><a href="https://civilrights.justice.gov/report">File a complaint</a><p>
+          <h2 class="error-subheading">{% trans 'Other information' %}</h2>
+          <p><a href="https://civilrights.justice.gov/report">{%trans 'File a complaint' %}</a><p>
           <p><a href="https://civilrights.justice.gov/#about-the-division">{% trans 'About the Civil Rights Division' %}</a><p>
           <p>{% trans 'If you or someone else is in immediate danger, <a href="tel:911">please call 911 or local police.</a>' %}</p>
         </div>

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -50,8 +50,8 @@
           <div class="crt-error-box">
             <img src="{% static "img/mail_70.svg" %}" />
             <span class="display-flex flex-column">
-              <li>{% trans 'U.S. Department of Justice' %}</li>
-              <li>{% trans 'Civil Rights Division' %}</li>
+              <li>U.S. Department of Justice</li>
+              <li>Civil Rights Division</li>
               <li>950 Pennsylvania Avenue, NW</li>
               <li>Washington, D.C. 20530-0001</li>
             </span>

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -71,7 +71,7 @@ def error_404(request, exception=None):
     return render(
         request,
         'forms/errors.html', {
-            'status': '404 | Page not found ',
+            'status': _("404 | Page not found"),
             'message': _("We can't find the page you are looking for")
         },
         status=404


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/705)

## What does this change?
Adding new Spanish Translations for 404 page

## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/66343959/96286772-e673b180-0fae-11eb-99df-6fcd348b4b87.png)

## Checklist:

### Author
hakhalid11

+ [X] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [X] Check for [accessibility](/docs/a11y_plan.md).
+ [X] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
