### PR TITLE
Customer facing Error page

### DIFF
--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-23 15:32+0000\n"
+"POT-Creation-Date: 2020-10-23 17:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:160 forms.py:1458
+#: forms.py:160 forms.py:1464
 msgid " - Select - "
 msgstr " - Elija - "
 
@@ -1292,7 +1292,7 @@ msgstr ""
 "oficial y que cualquier información que usted presente sea encriptada y "
 "transmitida de manera segura."
 
-#: templates/forms/complaint_view/actions/bulk_actions.html:67
+#: templates/forms/complaint_view/actions/bulk_actions.html:78
 #: templates/forms/grouped_questions.html:6
 #: templates/forms/question_cards/commercial_public_location.html:5
 #: templates/forms/question_cards/police_location.html:4
@@ -1515,6 +1515,10 @@ msgstr "Lo siento, se ha producido un error"
 msgid "We hope to fix this issue shortly"
 msgstr "Esperamos tenerlo arreglado en breve"
 
+#: templates/forms/errors.html:32
+msgid "Error: "
+msgstr "Error: "
+
 #: templates/forms/errors.html:34
 msgid "If you need to contact us immediately, you can reach us by:"
 msgstr ""
@@ -1731,8 +1735,8 @@ msgstr "Informe sobre una vulneración"
 msgid "Already submitted?"
 msgstr "¿Ya nos informó de una vulneración?"
 
-#: templates/landing.html:59 templates/partials/footer.html:9 views.py:796
-#: views.py:852 views.py:871
+#: templates/landing.html:59 templates/partials/footer.html:9 views.py:799
+#: views.py:855 views.py:874
 msgid "Contact"
 msgstr "Contacto"
 
@@ -2622,54 +2626,54 @@ msgstr ""
 "acceder a esta página en otra pestaña o ventana en su navegador. Eso le "
 "creará otra cookie de seguridad y debería resolver el problema."
 
-#: views.py:671 views.py:899
+#: views.py:674 views.py:902
 msgid "word remaining"
 msgstr "palabra restante"
 
-#: views.py:672 views.py:900
+#: views.py:675 views.py:903
 msgid " words remaining"
 msgstr "palabras restantes"
 
-#: views.py:673 views.py:901
+#: views.py:676 views.py:904
 msgid " word limit reached"
 msgstr "límite de palabras alcanzado"
 
-#: views.py:797 views.py:853 views.py:854 views.py:872 views.py:873
-#: views.py:908
+#: views.py:800 views.py:856 views.py:857 views.py:875 views.py:876
+#: views.py:911
 msgid "Primary concern"
 msgstr "Motivo principal de preocupación"
 
-#: views.py:798 views.py:855 views.py:856 views.py:857 views.py:858
-#: views.py:859 views.py:860
+#: views.py:801 views.py:858 views.py:859 views.py:860 views.py:861
+#: views.py:862 views.py:863
 msgid "Location"
 msgstr "Lugar"
 
-#: views.py:799 views.py:861 views.py:880
+#: views.py:802 views.py:864 views.py:883
 msgid "Personal characteristics"
 msgstr "Características personales"
 
-#: views.py:800 views.py:862 views.py:881
+#: views.py:803 views.py:865 views.py:884
 msgid "Date"
 msgstr "Fecha"
 
-#: views.py:801 views.py:863 views.py:882
+#: views.py:804 views.py:866 views.py:885
 msgid "Personal description"
 msgstr "Descripción personal"
 
-#: views.py:802 views.py:864 views.py:913
+#: views.py:805 views.py:867 views.py:916
 msgid "Review"
 msgstr "Repasar"
 
-#: views.py:874 views.py:875 views.py:876 views.py:877 views.py:878
-#: views.py:879
+#: views.py:877 views.py:878 views.py:879 views.py:880 views.py:881
+#: views.py:882
 msgid "Location details"
 msgstr "Datos de lugar"
 
-#: views.py:883
+#: views.py:886
 msgid "Review your report"
 msgstr "Revise su informe"
 
-#: views.py:911
+#: views.py:914
 msgid "Please select if any that apply to your situation (optional)"
 msgstr "Favor de elegir esta opción si"
 

--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-16 16:49+0000\n"
+"POT-Creation-Date: 2020-10-23 15:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:160 forms.py:1446
+#: forms.py:160 forms.py:1458
 msgid " - Select - "
 msgstr " - Elija - "
 
@@ -1507,6 +1507,14 @@ msgstr ""
 msgid "Your submission"
 msgstr "Su entrega"
 
+#: templates/forms/errors.html:30
+msgid "We're sorry, something went wrong"
+msgstr "Lo siento, se ha producido un error"
+
+#: templates/forms/errors.html:31
+msgid "We hope to fix this issue shortly"
+msgstr "Esperamos tenerlo arreglado en breve"
+
 #: templates/forms/errors.html:34
 msgid "If you need to contact us immediately, you can reach us by:"
 msgstr ""
@@ -1723,8 +1731,8 @@ msgstr "Informe sobre una vulneración"
 msgid "Already submitted?"
 msgstr "¿Ya nos informó de una vulneración?"
 
-#: templates/landing.html:59 templates/partials/footer.html:9 views.py:808
-#: views.py:864 views.py:883
+#: templates/landing.html:59 templates/partials/footer.html:9 views.py:796
+#: views.py:852 views.py:871
 msgid "Contact"
 msgstr "Contacto"
 
@@ -2588,87 +2596,19 @@ msgstr ""
 "(25-5-2017).\n"
 "                "
 
-#: views.py:51
-msgid "Bad request"
-msgstr "Solicitud incorrecta"
-
-#: views.py:52
-msgid ""
-"It seems your browser is not responding properly. Try refreshing this page."
-msgstr ""
-"Parece que su navegador no está respondiendo de manera adecuada. Intente "
-"actualizar esta página."
-
-#: views.py:63
-msgid "Unauthorized"
-msgstr "No autorizado"
-
-#: views.py:64
-msgid "This page is off limits to unauthorized users."
-msgstr "Usuario no autorizados no podrán acceder a esta página"
-
-#: views.py:74
+#: views.py:70
 msgid "404 | Page not found"
 msgstr "404 | Página no encontrada"
 
-#: views.py:75
+#: views.py:71
 msgid "We can't find the page you are looking for"
 msgstr "No encontramos la página que usted está buscando"
 
-#: views.py:86
-msgid "There's a problem loading this page"
-msgstr "Hay un problema para cargar esta página"
-
-#: views.py:87
-msgid ""
-"There's a technical problem loading this page. Try refreshing this page or "
-"going to another page. If that doesn't work, try again later."
-msgstr ""
-"Hay un problema técnico para cargar esta página. Intente actualizar esta "
-"página o ir a otra página. Si eso no funciona, intente más tarde."
-
-#: views.py:98
-msgid "Not implemented"
-msgstr "No implementado"
-
-#: views.py:99
-msgid "There seems to be a problem with this request. Try refreshing the page."
-msgstr ""
-"Parece que hay un problema con esta solicitud. Intente actualizar la página."
-
-#: views.py:110
-msgid "Bad gateway"
-msgstr "Portal incorrecto"
-
-#: views.py:111
-msgid ""
-"This problem is due to poor IP communication between back-end computers, "
-"possibly including our web server. Try clearing your browser cache "
-"completely. You may have a problem with your internal internet connection or "
-"firewall."
-msgstr ""
-"Este problema se debe a una falta de comunicación IP entre las computadoras "
-"back end, lo que posiblemente incluye nuestro servidor de web. Intente "
-"borrar completamente el caché de su navegador. Puede que haya algún problema "
-"con su conexión interna a Internet o su cortafuegos."
-
 #: views.py:122
-msgid "Service Unavailable"
-msgstr "Servicio no disponible"
-
-#: views.py:123
-msgid ""
-"Our web server is either closed for repair, upgrades or is rebooting. Please "
-"try again later."
-msgstr ""
-"Nuestro servidor de web está cerrado para unos arreglos, actualizaciones o "
-"se está reinicializando. Se ruega que lo intente nuevamente más tarde."
-
-#: views.py:134
 msgid "Your browser couldn't create a secure cookie"
 msgstr "Su navegador no pudo crear una cookie segura"
 
-#: views.py:135
+#: views.py:123
 msgid ""
 "We use security cookies to protect your information from attackers. Make "
 "sure you allow cookies for this site. Having the page open for long periods "
@@ -2682,56 +2622,115 @@ msgstr ""
 "acceder a esta página en otra pestaña o ventana en su navegador. Eso le "
 "creará otra cookie de seguridad y debería resolver el problema."
 
-#: views.py:683 views.py:911
+#: views.py:671 views.py:899
 msgid "word remaining"
 msgstr "palabra restante"
 
-#: views.py:684 views.py:912
+#: views.py:672 views.py:900
 msgid " words remaining"
 msgstr "palabras restantes"
 
-#: views.py:685 views.py:913
+#: views.py:673 views.py:901
 msgid " word limit reached"
 msgstr "límite de palabras alcanzado"
 
-#: views.py:809 views.py:865 views.py:866 views.py:884 views.py:885
-#: views.py:920
+#: views.py:797 views.py:853 views.py:854 views.py:872 views.py:873
+#: views.py:908
 msgid "Primary concern"
 msgstr "Motivo principal de preocupación"
 
-#: views.py:810 views.py:867 views.py:868 views.py:869 views.py:870
-#: views.py:871 views.py:872
+#: views.py:798 views.py:855 views.py:856 views.py:857 views.py:858
+#: views.py:859 views.py:860
 msgid "Location"
 msgstr "Lugar"
 
-#: views.py:811 views.py:873 views.py:892
+#: views.py:799 views.py:861 views.py:880
 msgid "Personal characteristics"
 msgstr "Características personales"
 
-#: views.py:812 views.py:874 views.py:893
+#: views.py:800 views.py:862 views.py:881
 msgid "Date"
 msgstr "Fecha"
 
-#: views.py:813 views.py:875 views.py:894
+#: views.py:801 views.py:863 views.py:882
 msgid "Personal description"
 msgstr "Descripción personal"
 
-#: views.py:814 views.py:876 views.py:925
+#: views.py:802 views.py:864 views.py:913
 msgid "Review"
 msgstr "Repasar"
 
-#: views.py:886 views.py:887 views.py:888 views.py:889 views.py:890
-#: views.py:891
+#: views.py:874 views.py:875 views.py:876 views.py:877 views.py:878
+#: views.py:879
 msgid "Location details"
 msgstr "Datos de lugar"
 
-#: views.py:895
+#: views.py:883
 msgid "Review your report"
 msgstr "Revise su informe"
 
-#: views.py:923
+#: views.py:911
 msgid "Please select if any that apply to your situation (optional)"
 msgstr "Favor de elegir esta opción si"
+
+#~ msgid "Bad request"
+#~ msgstr "Solicitud incorrecta"
+
+#~ msgid ""
+#~ "It seems your browser is not responding properly. Try refreshing this "
+#~ "page."
+#~ msgstr ""
+#~ "Parece que su navegador no está respondiendo de manera adecuada. Intente "
+#~ "actualizar esta página."
+
+#~ msgid "Unauthorized"
+#~ msgstr "No autorizado"
+
+#~ msgid "This page is off limits to unauthorized users."
+#~ msgstr "Usuario no autorizados no podrán acceder a esta página"
+
+#~ msgid "There's a problem loading this page"
+#~ msgstr "Hay un problema para cargar esta página"
+
+#~ msgid ""
+#~ "There's a technical problem loading this page. Try refreshing this page "
+#~ "or going to another page. If that doesn't work, try again later."
+#~ msgstr ""
+#~ "Hay un problema técnico para cargar esta página. Intente actualizar esta "
+#~ "página o ir a otra página. Si eso no funciona, intente más tarde."
+
+#~ msgid "Not implemented"
+#~ msgstr "No implementado"
+
+#~ msgid ""
+#~ "There seems to be a problem with this request. Try refreshing the page."
+#~ msgstr ""
+#~ "Parece que hay un problema con esta solicitud. Intente actualizar la "
+#~ "página."
+
+#~ msgid "Bad gateway"
+#~ msgstr "Portal incorrecto"
+
+#~ msgid ""
+#~ "This problem is due to poor IP communication between back-end computers, "
+#~ "possibly including our web server. Try clearing your browser cache "
+#~ "completely. You may have a problem with your internal internet connection "
+#~ "or firewall."
+#~ msgstr ""
+#~ "Este problema se debe a una falta de comunicación IP entre las "
+#~ "computadoras back end, lo que posiblemente incluye nuestro servidor de "
+#~ "web. Intente borrar completamente el caché de su navegador. Puede que "
+#~ "haya algún problema con su conexión interna a Internet o su cortafuegos."
+
+#~ msgid "Service Unavailable"
+#~ msgstr "Servicio no disponible"
+
+#~ msgid ""
+#~ "Our web server is either closed for repair, upgrades or is rebooting. "
+#~ "Please try again later."
+#~ msgstr ""
+#~ "Nuestro servidor de web está cerrado para unos arreglos, actualizaciones "
+#~ "o se está reinicializando. Se ruega que lo intente nuevamente más tarde."
 
 #~ msgid "Try returning to the previous page"
 #~ msgstr "Intente volver a la página anterior"

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -29,7 +29,7 @@
           <div class="display-flex flex-column padding-bottom-3">
             <h1 class=".h1__display">{% block error_heading %}We're sorry, something went wrong{% endblock %}</h1>
             <span class="crt-error_message">{% block error_message %}We hope to fix this issue shortly{% endblock %}</span>
-            <span class="help-text__small">{{ helptext }}</span>
+            <span class="help-text__small">{% block error_helptext %}Error: {{ status }}{% endblock %}</span>
           </div>
           <h2 class="error-subheading">{% trans 'If you need to contact us immediately, you can reach us by:' %}</h2>
           <div class="crt-error-box">

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -27,8 +27,8 @@
       <div class="crt-error-card">
         <div class="crt-error-card__content">
           <div class="display-flex flex-column padding-bottom-3">
-            <h1 class=".h1__display">{{ status }}</h1>
-            <span>{{ message }}</span>
+            <h1 class=".h1__display">{% block error_heading %}We're sorry, something went wrong{% endblock %}</h1>
+            <span class="crt-error_message">{% block error_message %}We hope to fix this issue shortly{% endblock %}</span>
             <span class="help-text__small">{{ helptext }}</span>
           </div>
           <h2 class="error-subheading">If you need to contact us immediately, you can reach us by:</h2>

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -57,8 +57,8 @@
             </span>
           </div>
           <h2 class="error-subheading">{% trans 'Other information' %}</h2>
-          <p><a href="https://civilrights.justice.gov/report">{%trans 'File a complaint' %}</a><p>
-          <p><a href="https://civilrights.justice.gov/#about-the-division">{% trans 'About the Civil Rights Division' %}</a><p>
+          <p><a href="https://civilrights.justice.gov/report">{%trans 'File a complaint' %}</a></p>
+          <p><a href="https://civilrights.justice.gov/#about-the-division">{% trans 'About the Civil Rights Division' %}</a></p>
           <p>{% trans 'If you or someone else is in immediate danger, <a href="tel:911">please call 911 or local police.</a>' %}</p>
         </div>
       </div>

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -29,7 +29,7 @@
           <div class="display-flex flex-column padding-bottom-3">
             <h1 class=".h1__display">{% block error_heading %}{% trans "We're sorry, something went wrong" %}{% endblock %}</h1>
             <span class="crt-error_message">{% block error_message %}{% trans "We hope to fix this issue shortly" %}{% endblock %}</span>
-            <span class="help-text__small">{% block error_helptext %}Error: {{ status }}{% endblock %}</span>
+            <span class="help-text__small">{% block error_helptext %}{%trans "Error: " %}{{ status }}{% endblock %}</span>
           </div>
           <h2 class="error-subheading">{% trans 'If you need to contact us immediately, you can reach us by:' %}</h2>
           <div class="crt-error-box">

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -27,8 +27,8 @@
       <div class="crt-error-card">
         <div class="crt-error-card__content">
           <div class="display-flex flex-column padding-bottom-3">
-            <h1 class=".h1__display">{% block error_heading %}We're sorry, something went wrong{% endblock %}</h1>
-            <span class="crt-error_message">{% block error_message %}We hope to fix this issue shortly{% endblock %}</span>
+            <h1 class=".h1__display">{% block error_heading %}{% trans "We're sorry, something went wrong" %}{% endblock %}</h1>
+            <span class="crt-error_message">{% block error_message %}{% trans "We hope to fix this issue shortly" %}{% endblock %}</span>
             <span class="help-text__small">{% block error_helptext %}Error: {{ status }}{% endblock %}</span>
           </div>
           <h2 class="error-subheading">{% trans 'If you need to contact us immediately, you can reach us by:' %}</h2>

--- a/crt_portal/cts_forms/templates/forms/errors_404.html
+++ b/crt_portal/cts_forms/templates/forms/errors_404.html
@@ -1,0 +1,8 @@
+{% extends "forms/errors.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block error_heading %}{{ status }}{% endblock %}
+
+{% block error_message %}{{ message }}{% endblock %}
+

--- a/crt_portal/cts_forms/templates/forms/errors_heading.html
+++ b/crt_portal/cts_forms/templates/forms/errors_heading.html
@@ -3,6 +3,6 @@
 {% load static %}
 
 {% block error_heading %}{{ status }}{% endblock %}
-
 {% block error_message %}{{ message }}{% endblock %}
+{% block error_helptext %}{{ helptext }}{% endblock %}
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -70,7 +70,7 @@ def error_403(request, exception=None):
 def error_404(request, exception=None):
     return render(
         request,
-        'forms/errors.html', {
+        'forms/errors_404.html', {
             'status': '404 | Page not found ',
             'message': _("We can't find the page you are looking for")
         },
@@ -82,9 +82,7 @@ def error_500(request, exception=None):
     return render(
         request,
         'forms/errors.html', {
-            'status': "We're sorry, something went wrong",
-            'message': "We hope to fix this issue shortly",
-            'helptext': "Error: 500"
+            'helptext': 'Error: 500'
         },
         status=500
     )

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -82,9 +82,9 @@ def error_500(request, exception=None):
     return render(
         request,
         'forms/errors.html', {
-            'status': 500,
-            'message': _("There's a problem loading this page"),
-            'helptext': _("There's a technical problem loading this page. Try refreshing this page or going to another page. If that doesn't work, try again later.")
+            'status': "We're sorry, something went wrong",
+            'message': "We hope to fix this issue shortly",
+            'helptext': "Error: 500"
         },
         status=500
     )

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -48,8 +48,6 @@ def error_400(request, exception=None):
         request,
         'forms/errors.html', {
             'status': 400,
-            'message': _("Bad request"),
-            'helptext': _("It seems your browser is not responding properly. Try refreshing this page.")
         },
         status=400
     )
@@ -60,8 +58,6 @@ def error_403(request, exception=None):
         request,
         'forms/errors.html', {
             'status': 403,
-            'message': _("Unauthorized"),
-            'helptext': _("This page is off limits to unauthorized users.")
         },
         status=403
     )
@@ -70,7 +66,7 @@ def error_403(request, exception=None):
 def error_404(request, exception=None):
     return render(
         request,
-        'forms/errors_404.html', {
+        'forms/errors_heading.html', {
             'status': _("404 | Page not found"),
             'message': _("We can't find the page you are looking for")
         },
@@ -82,7 +78,7 @@ def error_500(request, exception=None):
     return render(
         request,
         'forms/errors.html', {
-            'helptext': 'Error: 500'
+            'status': 500
         },
         status=500
     )
@@ -93,8 +89,6 @@ def error_501(request, exception=None):
         request,
         'forms/errors.html', {
             'status': 501,
-            'message': _("Not implemented"),
-            'helptext': _("There seems to be a problem with this request. Try refreshing the page.")
         },
         status=501
     )
@@ -105,8 +99,6 @@ def error_502(request, exception=None):
         request,
         'forms/errors.html', {
             'status': 502,
-            'message': _("Bad gateway"),
-            'helptext': _("This problem is due to poor IP communication between back-end computers, possibly including our web server. Try clearing your browser cache completely. You may have a problem with your internal internet connection or firewall.")
         },
         status=502
     )
@@ -117,8 +109,6 @@ def error_503(request, exception=None):
         request,
         'forms/errors.html', {
             'status': 503,
-            'message': _("Service Unavailable"),
-            'helptext': _("Our web server is either closed for repair, upgrades or is rebooting. Please try again later.")
         },
         status=503
     )
@@ -127,7 +117,7 @@ def error_503(request, exception=None):
 def csrf_failure(request, reason=""):
     return render(
         request,
-        'forms/errors.html', {
+        'forms/errors_heading.html', {
             'status': "Problem with security cookie",
             'message': _("Your browser couldn't create a secure cookie"),
             'helptext': _("We use security cookies to protect your information from attackers. Make sure you allow cookies for this site. Having the page open for long periods can also cause this problem. If you know cookies are allowed and you are having this issue, try going to this page in new browser tab or window. That will make you a new security cookie and should resolve the problem.")

--- a/crt_portal/static/sass/custom/error.scss
+++ b/crt_portal/static/sass/custom/error.scss
@@ -12,6 +12,10 @@
   }
 }
 
+.crt-error_message{
+  font-size: 1.3rem;
+}
+
 .error-subheading {
   margin: 0;
   font-weight: $theme-font-weight-bold;

--- a/crt_portal/static/sass/custom/error.scss
+++ b/crt_portal/static/sass/custom/error.scss
@@ -1,7 +1,7 @@
 .crt-error-box {
   display: flex;
   align-items: flex-start;
-  padding: 1rem;
+  padding: .75rem 1rem;
 
   span {
     padding: 0 .5rem;


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/707undefined)

## What does this change?
Handles 500 error or any other subsequent error status other than error 404. Modified templating to handle 404 page and any other error message heading (Can be used for maintenance page card). Removed unused error message data being passed to template (only exception is error_404 and csrf_failure). **This page is not fully translated in Spanish specifically the card headings**.

## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/66343959/96601353-ebdb3f80-12bf-11eb-9623-bf935d5bc025.png)

## Checklist:

### Author
hakhalid11

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
