### PR TITLE
Cherry pick bulk action tweaks

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1354,6 +1354,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         if 'assigned_section' in updates:
             updates['assigned_to'] = ''
             updates['status'] = 'new'
+        updates.pop('district', None)  # district is currently disabled (read-only)
         return updates
 
     def get_update_description(self):

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1357,7 +1357,8 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         """
         Given a submitted form, emit a textual description of what was updated.
         """
-        labels = {key: self.fields[key].label or key for key in self.get_updates()}
+        updates = self.get_updates()
+        labels = {key: self.fields[key].label or key for key in updates}
         labels.pop('comment', None)  # required, so we can omit
         default_string = '{what} set to {item}'
         custom_strings = {
@@ -1367,7 +1368,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         descriptions = []
         for (key, value) in labels.items():
             what = value.lower()
-            item = self.cleaned_data[key]
+            item = updates[key]
             string = custom_strings.get(what, default_string)
             description = string.format(**{'what': what, 'item': item or "''"})
             descriptions.append(description)
@@ -1380,7 +1381,8 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         Parse incoming changed data for activity stream entry (tweaked for
         bulk update)
         """
-        for field in self.changed_data:
+        updates = self.get_updates()
+        for field in updates:
             name = ' '.join(field.split('_')).capitalize()
             # rename primary statute if applicable
             if field == 'primary_statute':
@@ -1388,7 +1390,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
             if field in ['summary', 'comment']:
                 continue
             initial = getattr(report, field, 'None')
-            yield f"{name}:", f'Updated from "{initial}" to "{self.cleaned_data[field]}"'
+            yield f"{name}:", f'Updated from "{initial}" to "{updates[field]}"'
 
     def update_activity_stream(self, user, report):
         """

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1290,7 +1290,10 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
     district = ChoiceField(
         label='Judicial district',
         widget=ComplaintSelect(
-            attrs={'class': 'text-uppercase crt-dropdown__data'},
+            attrs={
+                'class': 'text-uppercase crt-dropdown__data',
+                'disabled': 'disabled'
+            },
         ),
         choices=_add_empty_choice(DISTRICT_CHOICES, default_string=EMPTY_CHOICE),
         required=False

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1345,13 +1345,19 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
             self.fields[key].initial = initial_value
 
     def get_updates(self):
-        return {field: self.cleaned_data[field] for field in self.changed_data}
+        updates = {field: self.cleaned_data[field] for field in self.changed_data}
+        # if section is changed, override assignee and status
+        # explicitly, even if they are set by the user.
+        if 'assigned_section' in updates:
+            updates['assigned_to'] = ''
+            updates['status'] = 'new'
+        return updates
 
     def get_update_description(self):
         """
         Given a submitted form, emit a textual description of what was updated.
         """
-        labels = {key: self.fields[key].label or key for key in self.changed_data}
+        labels = {key: self.fields[key].label or key for key in self.get_updates()}
         labels.pop('comment', None)  # required, so we can omit
         default_string = '{what} set to {item}'
         custom_strings = {

--- a/crt_portal/cts_forms/templates/forms/widgets/complaint_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/complaint_select.html
@@ -1,4 +1,4 @@
-<select id="{{widget.attrs.id}}" name="{{widget.name}}" class="usa-select text-bold {{widget.attrs.class}}">
+<select id="{{widget.attrs.id}}" name="{{widget.name}}" class="usa-select text-bold {{widget.attrs.class}}" {% if widget.attrs.disabled %}disabled="{{ widget.attrs.disabled }}"{% endif %}>
   {% for group_name, group_choices, group_index in widget.optgroups %}
     {% for option in group_choices %}
       {% include option.template_name with option=option %}

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -452,8 +452,7 @@ class BulkActionsTests(TestCase):
 
     def test_post_with_ids(self):
         ids = [report.id for report in self.reports[3:5]]
-        user = User.objects.get(username='DELETE_USER')
-        response = self.post(ids, assigned_to=user.id, comment='a comment', assigned_section='ADM', status='new')
+        response = self.post(ids, assigned_to=self.user.id, comment='a comment', assigned_section='ADM', status='new')
         content = str(response.content)
         self.assertTrue('2 records have been updated: assigned to DELETE_USER' in content)
         self.assertEquals(response.request['PATH_INFO'], reverse('crt_forms:crt-forms-index'))
@@ -462,12 +461,11 @@ class BulkActionsTests(TestCase):
             last_activity = list(report.target_actions.all())[-1]
             self.assertEquals(last_activity.verb, "Assigned to:")
             self.assertEquals(last_activity.description, 'Updated from "None" to "DELETE_USER"')
-            self.assertEquals(last_activity.actor, user)
+            self.assertEquals(last_activity.actor, self.user)
 
     def test_post_with_section_status_and_assignee(self):
         ids = [report.id for report in self.reports[3:5]]
-        user = User.objects.get(username='DELETE_USER')
-        response = self.post(ids, assigned_to=user.id, comment='a comment', assigned_section='VOT', status='closed')
+        response = self.post(ids, assigned_to=self.user.id, comment='a comment', assigned_section='VOT', status='closed')
         content = str(response.content)
         self.assertTrue(escape("2 records have been updated: section set to VOT, status set to new, and assigned to ''") in content)
         self.assertEquals(response.request['PATH_INFO'], reverse('crt_forms:crt-forms-index'))
@@ -476,11 +474,10 @@ class BulkActionsTests(TestCase):
             last_activity = list(report.target_actions.all())[-1]
             self.assertEquals(last_activity.verb, "Assigned section:")
             self.assertEquals(last_activity.description, 'Updated from "ADM" to "VOT"')
-            self.assertEquals(last_activity.actor, user)
+            self.assertEquals(last_activity.actor, self.user)
 
     def test_post_with_ids_and_all(self):
         ids = [report.id for report in self.reports[3:5]]
-        user = User.objects.get(username='DELETE_USER')
         response = self.post(ids, all_ids=True, confirm=False, status='closed', comment='a comment', assigned_section='ADM')
         content = str(response.content)
         self.assertTrue('2 records have been updated: status set to closed' in content)
@@ -490,11 +487,10 @@ class BulkActionsTests(TestCase):
             last_activity = list(report.target_actions.all())[-1]
             self.assertEquals(last_activity.verb, "Status:")
             self.assertEquals(last_activity.description, 'Updated from "new" to "closed"')
-            self.assertEquals(last_activity.actor, user)
+            self.assertEquals(last_activity.actor, self.user)
 
     def test_post_with_all(self):
         ids = [report.id for report in self.reports]
-        user = User.objects.get(username='DELETE_USER')
         response = self.post(ids, all_ids=True, confirm=True, summary='summary', comment='a comment', assigned_section='ADM', status='new')
         content = str(response.content)
         self.assertTrue('16 records have been updated: summary updated' in content)
@@ -504,7 +500,7 @@ class BulkActionsTests(TestCase):
             last_activity = list(report.target_actions.all())[-1]
             self.assertEquals(last_activity.verb, "Added comment: ")
             self.assertEquals(last_activity.description, 'a comment')
-            self.assertEquals(last_activity.actor, user)
+            self.assertEquals(last_activity.actor, self.user)
 
 
 class BulkActionsFormTests(TestCase):

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -464,6 +464,20 @@ class BulkActionsTests(TestCase):
             self.assertEquals(last_activity.description, 'Updated from "None" to "DELETE_USER"')
             self.assertEquals(last_activity.actor, user)
 
+    def test_post_with_section_status_and_assignee(self):
+        ids = [report.id for report in self.reports[3:5]]
+        user = User.objects.get(username='DELETE_USER')
+        response = self.post(ids, assigned_to=user.id, comment='a comment', assigned_section='VOT', status='closed')
+        content = str(response.content)
+        self.assertTrue(escape("2 records have been updated: section set to VOT, status set to new, and assigned to ''") in content)
+        self.assertEquals(response.request['PATH_INFO'], reverse('crt_forms:crt-forms-index'))
+        for report_id in ids:
+            report = Report.objects.get(id=report_id)
+            last_activity = list(report.target_actions.all())[-1]
+            self.assertEquals(last_activity.verb, "Assigned section:")
+            self.assertEquals(last_activity.description, 'Updated from "ADM" to "VOT"')
+            self.assertEquals(last_activity.actor, user)
+
     def test_post_with_ids_and_all(self):
         ids = [report.id for report in self.reports[3:5]]
         user = User.objects.get(username='DELETE_USER')


### PR DESCRIPTION
No Zenhub issue 

## What does this change?

Cherry picks bulk action tweaks back to the develop branch

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
