### PR TITLE
Maintenance mode

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -10,11 +10,10 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
-import os
 import json
+import os
 
 import boto3
-
 from django.utils.log import DEFAULT_LOGGING
 from django.utils.translation import gettext_lazy as _
 
@@ -28,6 +27,8 @@ environment = os.environ.get('ENV', 'UNDEFINED')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DEBUG', False)
+MAINTENANCE_MODE = os.environ.get('MAINTENANCE_MODE', False)
+
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/

--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-23 17:09+0000\n"
+"POT-Creation-Date: 2020-10-23 20:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1223,12 +1223,14 @@ msgid "Skip to main content"
 msgstr "Pasar directamente al contenido principal"
 
 #: templates/base.html:98 templates/forms/base.html:92
-#: templates/forms/errors.html:13 templates/landing.html:18
+#: templates/forms/errors.html:13 templates/forms/report_maintenance.html:13
+#: templates/landing.html:18
 msgid "U.S. Department of Justice"
 msgstr "Departamento de Justicia de los EE. UU."
 
 #: templates/base.html:101 templates/forms/base.html:91
-#: templates/forms/errors.html:14 templates/landing.html:21
+#: templates/forms/errors.html:14 templates/forms/report_maintenance.html:14
+#: templates/landing.html:21
 msgid "Civil Rights Division"
 msgstr "División de Derechos Civiles"
 
@@ -1519,29 +1521,32 @@ msgstr "Esperamos tenerlo arreglado en breve"
 msgid "Error: "
 msgstr "Error: "
 
-#: templates/forms/errors.html:34
+#: templates/forms/errors.html:34 templates/forms/report_maintenance.html:33
 msgid "If you need to contact us immediately, you can reach us by:"
 msgstr ""
 "Si usted necesita comunicarse con nosotros urgentemente, lo puede hacer "
 "mediante los siguientes modos:"
 
-#: templates/forms/errors.html:38
+#: templates/forms/errors.html:38 templates/forms/report_maintenance.html:38
 msgid "Email"
 msgstr ""
 
-#: templates/forms/errors.html:45 templates/partials/footer.html:32
+#: templates/forms/errors.html:45 templates/forms/report_maintenance.html:47
+#: templates/partials/footer.html:32
 msgid "(toll-free)"
 msgstr "(línea gratuita)"
 
-#: templates/forms/errors.html:46 templates/partials/footer.html:33
+#: templates/forms/errors.html:46 templates/forms/report_maintenance.html:48
+#: templates/partials/footer.html:33
 msgid "Telephone Device for the Deaf"
 msgstr "Dispositivo telefónico para sordos"
 
-#: templates/forms/errors.html:47 templates/partials/footer.html:34
+#: templates/forms/errors.html:47 templates/forms/report_maintenance.html:49
+#: templates/partials/footer.html:34
 msgid "(TTY)"
 msgstr "Teletipo (TTY por sus siglas en inglés)"
 
-#: templates/forms/errors.html:59
+#: templates/forms/errors.html:59 templates/forms/report_maintenance.html:64
 msgid "Other information"
 msgstr "Información adicional"
 
@@ -1549,11 +1554,13 @@ msgstr "Información adicional"
 msgid "File a complaint"
 msgstr "Presentar una querella"
 
-#: templates/forms/errors.html:61 templates/landing.html:125
+#: templates/forms/errors.html:61 templates/forms/report_maintenance.html:66
+#: templates/landing.html:125
 msgid "About the Civil Rights Division"
 msgstr "Acerca de la División de Derechos Civiles"
 
-#: templates/forms/errors.html:62 templates/landing.html:108
+#: templates/forms/errors.html:62 templates/forms/report_maintenance.html:69
+#: templates/landing.html:108
 msgid ""
 "If you or someone else is in immediate danger, <a href=\"tel:911\">please "
 "call 911 or local police.</a>"
@@ -1671,6 +1678,18 @@ msgstr ""
 msgid "Get help from the National Human Trafficking Hotline"
 msgstr "Reciba ayuda de la Línea Nacional contra la Trata de Personas"
 
+#: templates/forms/report_maintenance.html:30
+msgid "This page is currently down for maintenance."
+msgstr "Esta página está actualmente desactivada por razones de mantenimiento."
+
+#: templates/forms/report_maintenance.html:31
+msgid ""
+"We expect to be back shortly. We recommend checking back to report a civil "
+"rights violation."
+msgstr ""
+"Esperamos volver a activarla en breve. Le recomendamos que vuelva más tarde "
+"para informarnos de una vulneración de derechos civiles."
+
 #: templates/forms/report_review.html:10
 msgid "Before you submit your report, please check your responses"
 msgstr "Antes de entregar su informe, favor de comprobar sus respuestas"
@@ -1736,7 +1755,7 @@ msgid "Already submitted?"
 msgstr "¿Ya nos informó de una vulneración?"
 
 #: templates/landing.html:59 templates/partials/footer.html:9 views.py:799
-#: views.py:855 views.py:874
+#: views.py:860 views.py:879
 msgid "Contact"
 msgstr "Contacto"
 
@@ -2626,54 +2645,54 @@ msgstr ""
 "acceder a esta página en otra pestaña o ventana en su navegador. Eso le "
 "creará otra cookie de seguridad y debería resolver el problema."
 
-#: views.py:674 views.py:902
+#: views.py:674 views.py:907
 msgid "word remaining"
 msgstr "palabra restante"
 
-#: views.py:675 views.py:903
+#: views.py:675 views.py:908
 msgid " words remaining"
 msgstr "palabras restantes"
 
-#: views.py:676 views.py:904
+#: views.py:676 views.py:909
 msgid " word limit reached"
 msgstr "límite de palabras alcanzado"
 
-#: views.py:800 views.py:856 views.py:857 views.py:875 views.py:876
-#: views.py:911
+#: views.py:800 views.py:861 views.py:862 views.py:880 views.py:881
+#: views.py:916
 msgid "Primary concern"
 msgstr "Motivo principal de preocupación"
 
-#: views.py:801 views.py:858 views.py:859 views.py:860 views.py:861
-#: views.py:862 views.py:863
+#: views.py:801 views.py:863 views.py:864 views.py:865 views.py:866
+#: views.py:867 views.py:868
 msgid "Location"
 msgstr "Lugar"
 
-#: views.py:802 views.py:864 views.py:883
+#: views.py:802 views.py:869 views.py:888
 msgid "Personal characteristics"
 msgstr "Características personales"
 
-#: views.py:803 views.py:865 views.py:884
+#: views.py:803 views.py:870 views.py:889
 msgid "Date"
 msgstr "Fecha"
 
-#: views.py:804 views.py:866 views.py:885
+#: views.py:804 views.py:871 views.py:890
 msgid "Personal description"
 msgstr "Descripción personal"
 
-#: views.py:805 views.py:867 views.py:916
+#: views.py:805 views.py:872 views.py:921
 msgid "Review"
 msgstr "Repasar"
 
-#: views.py:877 views.py:878 views.py:879 views.py:880 views.py:881
-#: views.py:882
+#: views.py:882 views.py:883 views.py:884 views.py:885 views.py:886
+#: views.py:887
 msgid "Location details"
 msgstr "Datos de lugar"
 
-#: views.py:886
+#: views.py:891
 msgid "Review your report"
 msgstr "Revise su informe"
 
-#: views.py:914
+#: views.py:919
 msgid "Please select if any that apply to your situation (optional)"
 msgstr "Favor de elegir esta opción si"
 

--- a/crt_portal/cts_forms/templates/forms/report_maintenance.html
+++ b/crt_portal/cts_forms/templates/forms/report_maintenance.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block page_header %}
+<header class="confirmation-header crt-landing--blue padding-bottom-10">
+  <div class="grid-container">
+    <div class="grid-row grid-gap flex-child">
+      <div class="tablet:grid-col-9 tablet:grid-offset-1">
+        <div class="doj-brand display-flex flex-align-center font-serif-lg">
+          <img src="{% static "img/doj-logo-footer.svg" %}" alt="US DOJ logo" height="55" class="margin-right-105" />
+          <div>
+            <span>{% trans 'U.S. Department of Justice' %}</span>
+            <div>{% trans 'Civil Rights Division' %}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+{% endblock %}
+
+{% block content %}
+<section class="grid-container">
+  <div class="grid-row">
+    <div class="tablet:grid-col-8 tablet:grid-offset-2">
+      <div class="crt-error-card">
+        <div class="crt-error-card__content">
+          <div class="display-flex flex-column padding-bottom-3">
+            <h1 class=".h1__display">This page is currently down for maintenance.</h1>
+            <span>We expect to be back shortly. We recommend checking back to report a civil rights violation.</span>
+          </div>
+          <h2 class="error-subheading">{% trans 'If you need to contact us immediately, you can reach us by:' %}</h2>
+          <div class="crt-error-box">
+            <img src="{% static "img/at-sign.svg" %}" />
+            <span>
+              <li>{% trans 'Email' %} : <a href="mailto:Ask.CRT@crt.usdoj.gov">ask.CRT@crt.usdoj.gov</a></li>
+            </span>
+          </div>
+          <div class="crt-error-box">
+            <img src="{% static "img/phone_70.svg" %}" />
+            <span class="display-flex flex-column">
+              <li><a href="tel:202-514-3847">(202) 514-3847</a></li>
+              <li><a href="tel:1-855-856-1247">1-855-856-1247</a> {% trans '(toll-free)' %}</li>
+              <li>{% trans 'Telephone Device for the Deaf' %}</li>
+              <li>{% trans '(TTY)' %} <a href="tel:202-514-0716">(202) 514-0716</a></li>
+            </span>
+          </div>
+          <div class="crt-error-box">
+            <img src="{% static "img/mail_70.svg" %}" />
+            <span class="display-flex flex-column">
+              <li>U.S. Department of Justice</li>
+              <li>Civil Rights Division</li>
+              <li>950 Pennsylvania Avenue, NW</li>
+              <li>Washington, D.C. 20530-0001</li>
+            </span>
+          </div>
+          <h2 class="error-subheading">{% trans 'Other information' %}</h2>
+          <p><a href="https://civilrights.justice.gov/#about-the-division">{% trans 'About the Civil Rights Division' %}</a><p>
+          <p>{% trans 'If you or someone else is in immediate danger, <a href="tel:911">please call 911 or local police.</a>' %}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}
+

--- a/crt_portal/cts_forms/templates/forms/report_maintenance.html
+++ b/crt_portal/cts_forms/templates/forms/report_maintenance.html
@@ -27,41 +27,50 @@
       <div class="crt-error-card">
         <div class="crt-error-card__content">
           <div class="display-flex flex-column padding-bottom-3">
-            <h1 class=".h1__display">This page is currently down for maintenance.</h1>
-            <span>We expect to be back shortly. We recommend checking back to report a civil rights violation.</span>
+            <h1 class=".h1__display">{% trans 'This page is currently down for maintenance.' %}</h1>
+            <span>{% trans 'We expect to be back shortly. We recommend checking back to report a civil rights violation.' %}</span>
           </div>
           <h2 class="error-subheading">{% trans 'If you need to contact us immediately, you can reach us by:' %}</h2>
           <div class="crt-error-box">
-            <img src="{% static "img/at-sign.svg" %}" />
+            <img src="{% static "img/at-sign.svg" %}" alt="Email" />
             <span>
-              <li>{% trans 'Email' %} : <a href="mailto:Ask.CRT@crt.usdoj.gov">ask.CRT@crt.usdoj.gov</a></li>
+              <ul>
+                <li>{% trans 'Email' %} : <a href="mailto:Ask.CRT@crt.usdoj.gov">ask.CRT@crt.usdoj.gov</a></li>
+              </ul>
             </span>
           </div>
           <div class="crt-error-box">
-            <img src="{% static "img/phone_70.svg" %}" />
+            <img src="{% static "img/phone_70.svg" %}" alt='Phone' />
             <span class="display-flex flex-column">
-              <li><a href="tel:202-514-3847">(202) 514-3847</a></li>
-              <li><a href="tel:1-855-856-1247">1-855-856-1247</a> {% trans '(toll-free)' %}</li>
-              <li>{% trans 'Telephone Device for the Deaf' %}</li>
-              <li>{% trans '(TTY)' %} <a href="tel:202-514-0716">(202) 514-0716</a></li>
+              <ul>
+                <li><a href="tel:202-514-3847">(202) 514-3847</a></li>
+                <li><a href="tel:1-855-856-1247">1-855-856-1247</a> {% trans '(toll-free)' %}</li>
+                <li>{% trans 'Telephone Device for the Deaf' %}</li>
+                <li>{% trans '(TTY)' %} <a href="tel:202-514-0716">(202) 514-0716</a></li>
+              </ul>
             </span>
           </div>
           <div class="crt-error-box">
-            <img src="{% static "img/mail_70.svg" %}" />
+            <img src="{% static "img/mail_70.svg" %}" alt="Mail" />
             <span class="display-flex flex-column">
-              <li>U.S. Department of Justice</li>
-              <li>Civil Rights Division</li>
-              <li>950 Pennsylvania Avenue, NW</li>
-              <li>Washington, D.C. 20530-0001</li>
+              <ul>
+                <li>U.S. Department of Justice</li>
+                <li>Civil Rights Division</li>
+                <li>950 Pennsylvania Avenue, NW</li>
+                <li>Washington, D.C. 20530-0001</li>
+              </ul>
             </span>
           </div>
           <h2 class="error-subheading">{% trans 'Other information' %}</h2>
-          <p><a href="https://civilrights.justice.gov/#about-the-division">{% trans 'About the Civil Rights Division' %}</a><p>
-          <p>{% trans 'If you or someone else is in immediate danger, <a href="tel:911">please call 911 or local police.</a>' %}</p>
+          <p><a
+              href="https://civilrights.justice.gov/#about-the-division">{% trans 'About the Civil Rights Division' %}</a>
+            <p>
+              <p>
+                {% trans 'If you or someone else is in immediate danger, <a href="tel:911">please call 911 or local police.</a>' %}
+              </p>
         </div>
       </div>
     </div>
   </div>
 </section>
 {% endblock %}
-

--- a/crt_portal/cts_forms/tests/test_views.py
+++ b/crt_portal/cts_forms/tests/test_views.py
@@ -1,12 +1,12 @@
 
-from django.test import TestCase
-from django.test.client import Client
 from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.test.client import Client
 from django.urls import reverse
 
-from ..models import Report, Profile
-from ..model_variables import PRIMARY_COMPLAINT_CHOICES
 from ..forms import ContactEditForm, ReportEditForm
+from ..model_variables import PRIMARY_COMPLAINT_CHOICES
+from ..models import Profile, Report
 from .test_data import SAMPLE_REPORT
 
 
@@ -137,3 +137,19 @@ class ReportEditShowViewTests(TestCase):
         response = self.client.post(self.url, form_data, follow=True)
 
         self.assertEqual(response.context['contact_form'].initial['contact_email'], initial)
+
+
+class CRTReportWizardTests(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse('crt_report_form')
+
+    @override_settings(MAINTENANCE_MODE=True)
+    def test_returns_503_when_maintenance_mode_true(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 503)
+
+    def test_returns_200_when_maintenance_mode_false(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from .views import (ActionsView, index_view, ShowView, ProFormView,
                     SaveCommentView, TrendView, ResponseView,
-                    PrintView, ProfileView)
+                    PrintView, ProfileView, CRTReportWizard)
 from .forms import ProForm
 
 app_name = 'crt_forms'
@@ -18,4 +18,5 @@ urlpatterns = [
     path('actions/', ActionsView.as_view(), name='crt-forms-actions'),
     path('comment/report/<int:report_id>/', SaveCommentView.as_view(), name='save-report-comment'),
     path('trends/', TrendView.as_view(), name='trends'),
+    path('report_maintenance/', CRTReportWizard.get, name='report-maintenance'),
 ]

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from .views import (ActionsView, index_view, ShowView, ProFormView,
                     SaveCommentView, TrendView, ResponseView,
-                    PrintView, ProfileView, CRTReportWizard)
+                    PrintView, ProfileView)
 from .forms import ProForm
 
 app_name = 'crt_forms'
@@ -18,5 +18,4 @@ urlpatterns = [
     path('actions/', ActionsView.as_view(), name='crt-forms-actions'),
     path('comment/report/<int:report_id>/', SaveCommentView.as_view(), name='save-report-comment'),
     path('trends/', TrendView.as_view(), name='trends'),
-    path('report_maintenance/', CRTReportWizard.get, name='report-maintenance'),
 ]

--- a/crt_portal/static/sass/custom/error.scss
+++ b/crt_portal/static/sass/custom/error.scss
@@ -6,6 +6,13 @@
   span {
     padding: 0 .5rem;
 
+    ul {
+      margin-top: 0px;
+      margin-bottom: 0px;
+      padding-left: 0px
+    }
+
+
     li {
       list-style: none;
     }

--- a/docs/maintenance_or_infrequent_tasks.md
+++ b/docs/maintenance_or_infrequent_tasks.md
@@ -279,7 +279,7 @@ Either approach will result in an updated `Pipfile.lock` files located in your l
 [Pipenv]: https://docs.pipenv.org/
 
 
-## Periodic tasks
+# Periodic tasks
 
 We use Django management commands to execute periodic maintenance, refresh, or other code as necessary.
 
@@ -296,3 +296,35 @@ cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" -
 Your local output of executing the above command will reflect success or failure of the task's submission.
 
 Output, if any, of the command being executed will be be available in the application logs.
+
+
+
+# Maintenance Mode
+
+We use an environment variable, `MAINTENANCE_MODE`, to run the application with altered functionality.
+
+To **enable** maintenance mode, we need to set the `MAINTENANCE_MODE` environment variable to `True` and restart all running instances.
+
+> **NOTE**: Cloud Foundry [CLI Version 7](https://docs.cloudfoundry.org/cf-cli/v7.html) is required to use `--strategy rolling`
+
+
+```shell
+cf target -s {target environment}
+cf set-env crt-portal-django MAINTENANCE_MODE True
+cf restart crt-portal-django --strategy rolling
+```
+
+To **disable** maintenance mode and return the application to normal operations, remove the `MAINTENANCE_MODE` variable from the desired environment and restart all running instances.
+
+```shell
+cf target -s {target environment}
+cf unset-env crt-portal-django MAINTENANCE_MODE
+cf restart crt-portal-django --strategy rolling
+```
+
+## A list of modified functionality when operating in maintenance mode
+
+URL | Method | Normal | Maintenance mode
+----|--------|--------|--------
+/report/| GET | Render report form | Render 503 maintenance page
+


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/706)

## What does this change?
1. Adds functionality to enable a maintenance mode via environment variable.
2. For GET requests to `/report/`, returns a 503 response and custom error page

~TODO~ Done
- [x] Create template per Acceptance Criteria

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
