### PR TITLE
bulk actions bugfix: do not allow fields to be unset

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1349,6 +1349,11 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
 
     def get_updates(self):
         updates = {field: self.cleaned_data[field] for field in self.changed_data}
+        # do not allow any fields to be unset. this may happen if the
+        # user selects "Multiple".
+        for key in ['assigned_section', 'status', 'primary_statute']:
+            if key in updates and not updates[key]:
+                updates.pop(key)
         # if section is changed, override assignee and status
         # explicitly, even if they are set by the user.
         if 'assigned_section' in updates:


### PR DESCRIPTION
[Link to Github comment.](https://github.com/18F/crt-portal/issues/723#issuecomment-713041800)

## What does this change?

Bugfix: do not allow user to select "Multiple" for either `assigned section` or `status`.

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
