### PR TITLE
bulk actions tweaks: wording and disable multiple section option

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_actions.html
@@ -37,7 +37,7 @@
           <li>Assigned To</li>
         </ul>
         <p>
-          If you need to edit these fields, please press the 'Back to All' button to the left. If you have additional questions, please contact <a href="mailto:randy.abramson@usdoj.gov">randy.abramson@usdoj.gov</a> or <a href="mailto:bill.laughman@usdoj.gov">bill.laughman@usdoj.gov</a>
+          If you need to edit these fields, please return to the <a href="{% url 'crt_forms:crt-forms-index' %}{{ return_url_args }}">Back to All Table</a>. If you have additional questions, please contact <a href="mailto:randy.abramson@usdoj.gov">randy.abramson@usdoj.gov</a> or <a href="mailto:bill.laughman@usdoj.gov">bill.laughman@usdoj.gov</a>
         </p>
         <div class="margin-bottom-2 crt-dropdown crt-dropdown__shrink-to-contents">
           <label for="id_status" class="intake-label">

--- a/crt_portal/static/js/bulk_actions.js
+++ b/crt_portal/static/js/bulk_actions.js
@@ -89,4 +89,7 @@
     var actualSelectElement = document.getElementById('id_assigned_to-select');
     actualSelectElement.value = '';
   };
+
+  // disable "Multiple" selection for section
+  assigned_section.options[0].setAttribute('disabled', 'disabled');
 })(window, document);


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/758)

## What does this change?

- Wording change for section help text
- Disable first option for assigned section (so the user cannot select "Multiple")

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
