### PR TITLE
Move voting to top of primary complaint choices

### DIFF
--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -13,10 +13,10 @@ SERVICEMEMBER_CHOICES = (
 SERVICEMEMBER_ERROR = _('Please select a status as an active duty service member.')
 
 PRIMARY_COMPLAINT_CHOICES = (
+    ('voting', _('Voting rights or ability to vote affected')),
     ('workplace', _('Workplace discrimination or other employment-related problem')),
     ('housing', _('Housing discrimination or harassment')),
     ('education', _('Discrimination at a school, educational program or service, or related to receiving education')),
-    ('voting', _('Voting rights or ability to vote affected')),
     ('police', _('Mistreated by police, correctional staff, or inmates')),
     ('commercial_or_public', _('Discriminated against in a commercial location or public place')),
     ('something_else', _('Something else happened')),


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/746undefined)

## What does this change?
Moves voting to top of primary complaint choices.

## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/66343959/97217131-33206f00-179d-11eb-869a-64d17d047d54.png)

## Checklist:

### Author
hakhalid11

+ [X] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [X] Check for [accessibility](/docs/a11y_plan.md).
+ [X] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
