### PR TITLE
Accommodate re-ordering of primary complaint

### DIFF
--- a/crt_portal/static/js/pro_form_show_hide.js
+++ b/crt_portal/static/js/pro_form_show_hide.js
@@ -4,11 +4,11 @@
   function toggleFollowUpQuestions(event) {
     var primary_complaint_id = event.target.id;
     var predicate_target_mapping = {
-      'id_0-primary_complaint_0': [
+      'id_0-primary_complaint_1': [
         'div-id_0-public_or_private_employer_0',
         'div-id_0-employer_size_0'
       ],
-      'id_0-primary_complaint_2': ['div-id_0-public_or_private_school_0'],
+      'id_0-primary_complaint_3': ['div-id_0-public_or_private_school_0'],
       'id_0-primary_complaint_4': [
         'div-id_0-inside_correctional_facility_0',
         'div-id_0-correctional_facility_type_0'


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/770)

## What does this change?
We're hard coding the pro-form logic based on rendered position.
This update corrects for the recent changes to primary complaint order.

Test locally by ensuring conditional follow-ups for primary complaint on pro-form are rendering as expected.

Needs to be merged back to `develop` as well

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
