### PR TITLE
Filter reports for one day's time

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -53,6 +53,17 @@ def _get_date_field_from_param(field):
     return field[:field.rfind('_')]
 
 
+def _change_datetime_to_end_of_day(dateObj, field):
+    """
+    Takes a datetime and field param to ensure an end_date
+    field has time moved to end of day (23:59:59)
+    """
+    if 'end' in field:
+        return dateObj.replace(hour=23, minute=59, second=59)
+    else:
+        return dateObj
+
+
 def report_filter(querydict):
     kwargs = {}
     filters = {}
@@ -77,6 +88,7 @@ def report_filter(querydict):
                 decodedDate = urllib.parse.unquote(encodedDate)
                 try:
                     dateObj = datetime.strptime(decodedDate, "%Y-%m-%d")
+                    dateObj = _change_datetime_to_end_of_day(dateObj, field)
                     kwargs[f'{field_name}{filter_options[field]}'] = dateObj
                 except ValueError:
                     # if the date is invalid, we ignore it.


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/753undefined)

## What does this change?
Changes report filtering on end date fields (ex. create date) to now pass in end of day (11:59:59) for time attributes.
## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/66343959/97712510-ea1a3480-1a94-11eb-93e3-f735c2aea484.png)
## Checklist:

### Author
hakhalid1
+ [X] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [X] Check for [accessibility](/docs/a11y_plan.md).
+ [X] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
