### PR TITLE
Use generators when exporting 

### DIFF
--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -2,14 +2,16 @@ import csv
 import logging
 
 from django.contrib import admin
+from django.core.paginator import Paginator
 from django.http import StreamingHttpResponse
 
-from .models import (CommentAndSummary, HateCrimesandTrafficking,
-                     ProtectedClass, Report, ResponseTemplate, Profile)
+from .models import (CommentAndSummary, HateCrimesandTrafficking, Profile,
+                     ProtectedClass, Report, ResponseTemplate)
 from .signals import get_client_ip
 
-
 logger = logging.getLogger(__name__)
+
+REPORT_FIELDS = [field.name for field in Report._meta.fields]
 
 
 class Echo:
@@ -29,27 +31,52 @@ def format_export_message(request, records):
     return f'ADMIN ACTION by: {username} {userid} @ {ip}. Exported {records} reports as csv.'
 
 
+def iter_queryset(queryset, headers):
+    """
+    The iterator provided by queryset.iterator isn't adequate here
+
+    We add headers to our output
+
+    We also need to traverse M2M relationships for at least 1 field
+    and want tos use prefetch_related to avoid a query for each instance
+    queryset.iterator ignores `prefetch_related` so instead we paginate
+    through the queryset to reduce the number of total queries required
+    """
+    yield headers
+    paginator = Paginator(queryset, 2000)
+    for i in range(paginator.num_pages):
+        yield from paginator.get_page(i + 1)
+
+
+def _serialize_report_export(data):
+    """
+    Customize the rendering of protected_class instances
+    while rendering headers as-is
+    """
+    if isinstance(data, Report):
+        row = [getattr(data, field) for field in REPORT_FIELDS]
+        row.append('; '.join([str(pc) for pc in data.protected_class.all()]))
+        return row
+    return data
+
+
 def export_as_csv(modeladmin, request, queryset):
     """
     Stream all non-related fields
-    and the protected_class M2M of selected reports as CSV
+    and the protected_class M2M of selected reports as a CSV
     Log all use
     """
-    pseudo_buffer = Echo()
-    writer = csv.writer(pseudo_buffer, quoting=csv.QUOTE_ALL)
-    non_m2m_fields = [field.name for field in Report._meta.fields]
-    headers = non_m2m_fields + ['protected_class']
-    rows = [headers]
-    for report in queryset:
-        row = [getattr(report, field) for field in non_m2m_fields]
-        # Add protected_class M2M field
-        row.append('; '.join([str(pc) for pc in report.protected_class.all()]))
-        rows.append(row)
+    writer = csv.writer(Echo(), quoting=csv.QUOTE_ALL)
+    headers = REPORT_FIELDS + ['protected_class']
 
-    response = StreamingHttpResponse((writer.writerow(row) for row in rows),
+    queryset = queryset.prefetch_related('protected_class').order_by('id')
+    iterator = iter_queryset(queryset, headers)
+
+    response = StreamingHttpResponse((writer.writerow(_serialize_report_export(report)) for report in iterator),
                                      content_type="text/csv")
     response['Content-Disposition'] = 'attachment; filename="report_export.csv"'
-    logger.info(format_export_message(request, len(rows) - 1))
+
+    logger.info(format_export_message(request, queryset.count() - 1))
     return response
 export_as_csv.allowed_permissions = ('view',)  # noqa
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/756)

## What does this change?
When exporting reports via the admin a large number may be selected. We'll serialize and stream these on demand to ensure a quick initial response to the requestor.

While the previous implementation used `StreamingHttpResponse`, we did not start streaming responses until the entire export had been created and held in memory.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
