### PR TITLE
ga tagmanager to head and body tag of base template

### DIFF
--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -9,18 +9,12 @@
       {% environment as env %}
       {% if env == "PRODUCTION" %}
        <!-- Google Tag Manager -->
-       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+       <script nonce="{{ request.csp_nonce }}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
        })(window,document,'script','dataLayer','GTM-N6M8JRD');</script>
        <!-- End Google Tag Manager -->
-       <script nonce="{{ request.csp_nonce }}">
-       window.dataLayer = window.dataLayer || [];
-       function gtag(){dataLayer.push(arguments);}
-       gtag('js', new Date());
-       gtag('config', 'GTM-N6M8JRD');
-      </script>
       {% endif %}
     {% endblock %}
 
@@ -66,6 +60,7 @@
 
     <link rel="icon" href="{% static "img/favicon.png" %}">
     <link rel="stylesheet" href="{% static "css/compiled/styles.css" %}">
+
     {% block head %}{% endblock %}
   </head>
   <body {% block body_class %}{% endblock %}>

--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -5,7 +5,18 @@
 <!DOCTYPE html>
 <html lang="{{LANGUAGE_CODE}}">
  <head>
-
+    {% block ga_tagmanager_head %}
+      {% environment as env %}
+      {% if env == "PRODUCTION" %}
+       <!-- Google Tag Manager -->
+       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+       })(window,document,'script','dataLayer','GTM-N6M8JRD');</script>
+       <!-- End Google Tag Manager -->
+      {% endif %}
+    {% endblock %}
 
 
     {% block meta %}
@@ -53,6 +64,17 @@
   </head>
   <body {% block body_class %}{% endblock %}>
     <a class="usa-skipnav" href="#main-content">{% trans "Skip to main content" %}</a>
+
+    {% block ga_tagmanager_body %}
+      {% environment as env %}
+      {% if env == "PRODUCTION" %}
+        <!-- Google Tag Manager (noscript) -->
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N6M8JRD"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        <!-- End Google Tag Manager (noscript) -->
+      {% endif %}
+    {% endblock %}
+
     {% block usa_banner %}
       {% include "partials/banner/usa_banner.html" %}
     {% endblock %}

--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -15,6 +15,12 @@
        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
        })(window,document,'script','dataLayer','GTM-N6M8JRD');</script>
        <!-- End Google Tag Manager -->
+       <script nonce="{{ request.csp_nonce }}">
+       window.dataLayer = window.dataLayer || [];
+       function gtag(){dataLayer.push(arguments);}
+       gtag('js', new Date());
+       gtag('config', 'GTM-N6M8JRD');
+      </script>
       {% endif %}
     {% endblock %}
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
+{% block ga_tagmanager_head %}{% endblock %}
+{% block ga_tagmanager_body %}{% endblock %}
 {% block meta_analytics %}{% endblock %}
 {% block usa_banner %}{% endblock %}
 {% block page_header %}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/757)

## What does this change?
this provide google tag manager analytics for production environment only.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
