### PR TITLE
Add internal summary to Report export

### DIFF
--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -4,6 +4,7 @@ import logging
 from django.contrib import admin
 from django.core.paginator import Paginator
 from django.http import StreamingHttpResponse
+from django.db.models import Prefetch
 
 from .models import (CommentAndSummary, HateCrimesandTrafficking, Profile,
                      ProtectedClass, Report, ResponseTemplate)
@@ -50,33 +51,40 @@ def iter_queryset(queryset, headers):
 
 def _serialize_report_export(data):
     """
-    Customize the rendering of protected_class instances
+    Customize the rendering of protected_class and summary instances
     while rendering headers as-is
     """
     if isinstance(data, Report):
         row = [getattr(data, field) for field in REPORT_FIELDS]
         row.append('; '.join([str(pc) for pc in data.protected_class.all()]))
+        if data.internal_summary:
+            # incoming summaries are sorted by descending modified_date the first is the most recent
+            row.append(data.internal_summary[0].note)
         return row
     return data
 
 
 def export_as_csv(modeladmin, request, queryset):
     """
-    Stream all non-related fields
-    and the protected_class M2M of selected reports as a CSV
+    Stream all non-related fields,
+    protected_class M2M,
+    and latest summary from CommentAndSummary M2M of selected reports as a CSV
     Log all use
     """
     writer = csv.writer(Echo(), quoting=csv.QUOTE_ALL)
-    headers = REPORT_FIELDS + ['protected_class']
+    headers = REPORT_FIELDS + ['protected_class', 'internal_summary']
 
-    queryset = queryset.prefetch_related('protected_class').order_by('id')
+    summaries = CommentAndSummary.objects.filter(is_summary=True).order_by('-modified_date')
+    queryset = queryset.prefetch_related('protected_class',
+                                         Prefetch('internal_comments', queryset=summaries, to_attr='internal_summary')
+                                         ).order_by('id')
     iterator = iter_queryset(queryset, headers)
 
     response = StreamingHttpResponse((writer.writerow(_serialize_report_export(report)) for report in iterator),
                                      content_type="text/csv")
     response['Content-Disposition'] = 'attachment; filename="report_export.csv"'
 
-    logger.info(format_export_message(request, queryset.count() - 1))
+    logger.info(format_export_message(request, queryset.count()))
     return response
 export_as_csv.allowed_permissions = ('view',)  # noqa
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/754)

## What does this change?
We now include the latest internal summary in each export Report row.

Since summaries are currently tracked as `CommentAndSummary` instances as a M2M relationship, we're tackling this with a similar approach to `protected_classes` and leveraging [prefetch_related](https://docs.djangoproject.com/en/2.2/ref/models/querysets/#prefetch-related) to limit the number of database queries needed.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
