### PR TITLE
fix metadata syntax

### DIFF
--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -45,7 +45,7 @@
       {% block meta_description %}
         {% trans 'Have you or someone you know experienced unlawful discrimination? The Civil Rights Division may be able to help. Civil rights laws can protect you from unlawful discrimination, harassment, or abuse in a variety of settings like housing, the workplace, school, voting, businesses, healthcare, public spaces, and more.' as meta_description %}
         <meta property="og:description" content="{{meta_description}}" />
-        <meta property="description" content="{{meta_description}}" />
+        <meta name="description" content="{{meta_description}}" />
       {% endblock meta_description %}
 
       <meta property="og:image" content="{% static 'img/facebook-og.png' %}" />


### PR DESCRIPTION
I was looking at the Lighthouse Audit for the site and I think that we need to set the metadata description with "name" rather than "property." (The og:description should be a property, so that is fine.)

https://web.dev/meta-description/?utm_source=lighthouse&utm_medium=devtools