### PR TITLE
Reduce top margin for agency header on report page

### DIFF
--- a/crt_portal/static/sass/custom/header.scss
+++ b/crt_portal/static/sass/custom/header.scss
@@ -16,10 +16,13 @@
 
   .doj-brand {
     font-size: $theme-text-font-size-lg;
-    margin-top: 1rem;
+    margin-top: 4rem;
     img {
       height: 38px;
       width: 38px;
+    }
+    @include at-media-max(mobile-lg) {
+      margin-top: 1rem;
     }
   }
 }

--- a/crt_portal/static/sass/custom/header.scss
+++ b/crt_portal/static/sass/custom/header.scss
@@ -16,7 +16,7 @@
 
   .doj-brand {
     font-size: $theme-text-font-size-lg;
-    margin-top: 4rem;
+    margin-top: 1rem;
     img {
       height: 38px;
       width: 38px;


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/731)

## What does this change?
We're reducing the top spacing between the agency header and the top of the page.

## Screenshots (for front-end PR):
![Screen Shot 2020-11-03 at 3 09 45 PM](https://user-images.githubusercontent.com/3485564/98036860-b74fa380-1de8-11eb-828f-b04b5bdb952e.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
