### PR TITLE
Correct HTML on error page base template

### DIFF
--- a/crt_portal/crt_portal/urls.py
+++ b/crt_portal/crt_portal/urls.py
@@ -15,24 +15,23 @@ Including another URLconf
 """
 import os
 
-from django.conf import settings
-from django.conf.urls.static import static
-from django.contrib import admin
-from django.urls import include, path, re_path
-from django.views.generic import RedirectView, TemplateView
-
 from cts_forms.forms import (CommercialPublicLocation, Contact, Details,
                              EducationLocation, ElectionLocation, HateCrimes,
                              LocationForm, PoliceLocation, PrimaryReason,
                              ProtectedClassForm, Review, When,
                              WorkplaceLocation)
-from cts_forms.views import (CRTReportWizard, LandingPageView,
-                             show_commercial_public_form_condition,
+from cts_forms.views import (CRTReportWizard, LandingPageView, error_404,
+                             error_500, show_commercial_public_form_condition,
                              show_education_form_condition,
                              show_election_form_condition,
                              show_location_form_condition,
                              show_police_form_condition,
                              show_workplace_form_condition)
+from django.conf import settings
+from django.conf.urls.static import static
+from django.contrib import admin
+from django.urls import include, path, re_path
+from django.views.generic import RedirectView, TemplateView
 
 environment = os.environ.get('ENV', 'UNDEFINED')
 if environment == 'PRODUCTION':
@@ -86,3 +85,9 @@ handler500 = 'cts_forms.views.error_500'
 handler501 = 'cts_forms.views.error_501'
 handler502 = 'cts_forms.views.error_502'
 handler503 = 'cts_forms.views.error_503'
+
+if settings.DEBUG:
+    urlpatterns += [
+        path('errors/404', error_404),
+        path('errors/500', error_500),
+    ]

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -27,43 +27,55 @@
       <div class="crt-error-card">
         <div class="crt-error-card__content">
           <div class="display-flex flex-column padding-bottom-3">
-            <h1 class=".h1__display">{% block error_heading %}{% trans "We're sorry, something went wrong" %}{% endblock %}</h1>
-            <span class="crt-error_message">{% block error_message %}{% trans "We hope to fix this issue shortly" %}{% endblock %}</span>
-            <span class="help-text__small">{% block error_helptext %}{%trans "Error: " %}{{ status }}{% endblock %}</span>
+            <h1 class=".h1__display">
+              {% block error_heading %}{% trans "We're sorry, something went wrong" %}{% endblock %}</h1>
+            <span
+              class="crt-error_message">{% block error_message %}{% trans "We hope to fix this issue shortly" %}{% endblock %}</span>
+            <span
+              class="help-text__small">{% block error_helptext %}{%trans "Error: " %}{{ status }}{% endblock %}</span>
           </div>
           <h2 class="error-subheading">{% trans 'If you need to contact us immediately, you can reach us by:' %}</h2>
           <div class="crt-error-box">
-            <img src="{% static "img/at-sign.svg" %}" />
+            <img src="{% static "img/at-sign.svg" %}" alt="Email" />
             <span>
-              <li>{% trans 'Email' %} : <a href="mailto:Ask.CRT@crt.usdoj.gov">ask.CRT@crt.usdoj.gov</a></li>
+              <ul>
+                <li>{% trans 'Email' %} : <a href="mailto:Ask.CRT@crt.usdoj.gov">ask.CRT@crt.usdoj.gov</a></li>
+              </ul>
             </span>
           </div>
           <div class="crt-error-box">
-            <img src="{% static "img/phone_70.svg" %}" />
+            <img src="{% static "img/phone_70.svg" %}" alt='Phone' />
             <span class="display-flex flex-column">
-              <li><a href="tel:202-514-3847">(202) 514-3847</a></li>
-              <li><a href="tel:1-855-856-1247">1-855-856-1247</a> {% trans '(toll-free)' %}</li>
-              <li>{% trans 'Telephone Device for the Deaf' %}</li>
-              <li>{% trans '(TTY)' %} <a href="tel:202-514-0716">(202) 514-0716</a></li>
+              <ul>
+                <li><a href="tel:202-514-3847">(202) 514-3847</a></li>
+                <li><a href="tel:1-855-856-1247">1-855-856-1247</a> {% trans '(toll-free)' %}</li>
+                <li>{% trans 'Telephone Device for the Deaf' %}</li>
+                <li>{% trans '(TTY)' %} <a href="tel:202-514-0716">(202) 514-0716</a></li>
+              </ul>
             </span>
           </div>
           <div class="crt-error-box">
-            <img src="{% static "img/mail_70.svg" %}" />
+            <img src="{% static "img/mail_70.svg" %}" alt="Mail" />
             <span class="display-flex flex-column">
-              <li>U.S. Department of Justice</li>
-              <li>Civil Rights Division</li>
-              <li>950 Pennsylvania Avenue, NW</li>
-              <li>Washington, D.C. 20530-0001</li>
+              <ul>
+                <li>U.S. Department of Justice</li>
+                <li>Civil Rights Division</li>
+                <li>950 Pennsylvania Avenue, NW</li>
+                <li>Washington, D.C. 20530-0001</li>
+              </ul>
             </span>
           </div>
           <h2 class="error-subheading">{% trans 'Other information' %}</h2>
           <p><a href="https://civilrights.justice.gov/report">{%trans 'File a complaint' %}</a></p>
-          <p><a href="https://civilrights.justice.gov/#about-the-division">{% trans 'About the Civil Rights Division' %}</a></p>
-          <p>{% trans 'If you or someone else is in immediate danger, <a href="tel:911">please call 911 or local police.</a>' %}</p>
+          <p><a
+              href="https://civilrights.justice.gov/#about-the-division">{% trans 'About the Civil Rights Division' %}</a>
+          </p>
+          <p>
+            {% trans 'If you or someone else is in immediate danger, <a href="tel:911">please call 911 or local police.</a>' %}
+          </p>
         </div>
       </div>
     </div>
   </div>
 </section>
 {% endblock %}
-

--- a/pa11y_scripts/.without-report
+++ b/pa11y_scripts/.without-report
@@ -19,6 +19,10 @@
         {
             "url": "http://127.0.0.1:8000/privacy-policy",
             "screenCapture": "pa11y-screenshots/crt-privacy-policy.png"
+        },
+        {
+            "url": "http://127.0.0.1:8000/errors/404",
+            "screenCapture": "pa11y-screenshots/404.png"
         }
     ]
 }


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/760)

## What does this change?

Tweaks to the mark-up to add alt attributes  and parent `<ol>` elements to resolve accessibility issues raised by Accessibility Insights. Includes an import sort and bit of whitespace clean-up as well. 

Includes a bonus of new routes available when `DEBUG=True` to render the 404 and 500 error pages at: http://127.0.0.1:8000/errors/404 and http://127.0.0.1:8000/errors/500. As a result, we're now including an error page in our pa11y-ci suite.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
