### PR TITLE
Use relative path for static files

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
@@ -32,7 +32,7 @@
               <button class="usa-button print-report-button" type="submit" name="type" value="print_all" {% if print_reports.count > 100 %}disabled="disabled"{% endif %}>Print all {{ print_reports.count }} reports</button>
               {% if print_reports.count > 100 %}
                 <p>
-                  <img width="20" height="20" src="{% static "/img/alerts/warning.svg" %}" alt="warning" class="icon" />
+                  <img width="20" height="20" src="{% static 'img/alerts/warning.svg' %}" alt="warning" class="icon" />
                   The maximum number of records for this function is 100.
                 </p>
               {% endif %}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/734#issuecomment-723216635)

## What does this change?
Corrects `print_report.html` to use a relative path in the `static` template tag. We missed this in #715 and it's generating a 400 error when attempting to render this template in the dev environment.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
