### PR TITLE
[WIP] bulk print cleanups: separate subset from all reports

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_print.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_print.html
@@ -8,14 +8,28 @@
 </span>
 
 <div class="bulk-print-reports display-none">
-  {% for report in print_reports|slice:":100" %}
-    <div class="bulk-print-report{% if forloop.counter > ids_count %} bulk-print-report-extra{% endif %}">
-      {% include 'forms/complaint_view/show/header.html' with data=report %}
-      {% include 'forms/complaint_view/show/correspondent_info.html' with data=report disable_edit=True %}
-      {% include 'forms/complaint_view/print/complaint_details.html' with data=report questions=questions %}
-      {% include 'forms/complaint_view/show/description.html' with description=report.violation_summary %}
-      {% include 'forms/complaint_view/print/activities.html' with activity=report.activity %}
-      {% include 'forms/complaint_view/print/summary.html' with summary=report.get_summary %}
-    </div>
-  {% endfor %}
+  {% if all_ids_count > 100 %}
+    {# the user will not be able to print all reports, so only output the subset #}
+    {% for report in print_reports_subset %}
+      <div class="bulk-print-report">
+        {% include 'forms/complaint_view/show/header.html' with data=report %}
+        {% include 'forms/complaint_view/show/correspondent_info.html' with data=report disable_edit=True %}
+        {% include 'forms/complaint_view/print/complaint_details.html' with data=report questions=questions %}
+        {% include 'forms/complaint_view/show/description.html' with description=report.violation_summary %}
+        {% include 'forms/complaint_view/print/activities.html' with activity=report.activity %}
+        {% include 'forms/complaint_view/print/summary.html' with summary=report.get_summary %}
+      </div>
+    {% endfor %}
+  {% else %}
+    {% for report in print_reports %}
+      <div class="bulk-print-report{% if forloop.counter > ids_count %} bulk-print-report-extra{% endif %}">
+        {% include 'forms/complaint_view/show/header.html' with data=report %}
+        {% include 'forms/complaint_view/show/correspondent_info.html' with data=report disable_edit=True %}
+        {% include 'forms/complaint_view/print/complaint_details.html' with data=report questions=questions %}
+        {% include 'forms/complaint_view/show/description.html' with description=report.violation_summary %}
+        {% include 'forms/complaint_view/print/activities.html' with activity=report.activity %}
+        {% include 'forms/complaint_view/print/summary.html' with summary=report.get_summary %}
+      </div>
+    {% endfor %}
+  {% endif %}
 </div>

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -508,10 +508,11 @@ class ActionsView(LoginRequiredMixin, FormView):
         # than the ids passed in
         selected_all = request.GET.get('all', '') == 'all'
 
+        subset_query = None
+        requested_query = Report.objects.filter(pk__in=ids)
         if selected_all:
+            subset_query = requested_query
             requested_query = reconstruct_query(return_url_args)
-        else:
-            requested_query = Report.objects.filter(pk__in=ids)
 
         bulk_actions_form = BulkActionsForm(requested_query)
         all_ids_count = requested_query.count()
@@ -528,7 +529,8 @@ class ActionsView(LoginRequiredMixin, FormView):
             'show_warning': ids_count > 15,
             'all_ids_count': all_ids_count,
             'bulk_actions_form': bulk_actions_form,
-            'print_reports': requested_query.order_by('id'),
+            'print_reports_subset': subset_query,
+            'print_reports': requested_query,
             'print_options': PrintActions(),
             'questions': Review.question_text,
         }
@@ -540,10 +542,11 @@ class ActionsView(LoginRequiredMixin, FormView):
         confirm_all = request.POST.get('confirm_all', '') == 'confirm_all'
         ids = request.POST.get('ids', '').split(',')
 
+        subset_query = None
+        requested_query = Report.objects.filter(pk__in=ids)
         if confirm_all:
+            subset_query = requested_query
             requested_query = reconstruct_query(return_url_args)
-        else:
-            requested_query = Report.objects.filter(pk__in=ids)
 
         if requested_query.count() > 500:
             raise PermissionDenied
@@ -583,7 +586,8 @@ class ActionsView(LoginRequiredMixin, FormView):
                 'show_warning': ids_count > 15,
                 'all_ids_count': all_ids_count,
                 'bulk_actions_form': bulk_actions_form,
-                'print_reports': requested_query.order_by('id'),
+                'print_reports_subset': subset_query,
+                'print_reports': requested_query,
                 'print_options': PrintActions(),
                 'questions': Review.question_text,
             }


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

I _believe_ there is a bug with current bulk print functionality:

- Filter by any criteria, but order by create_date ascending
- Go to the second page
- Hit "Select all"
- Print only the 15 records selected
- Observe that the printed out records do not correspond to the original 15

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
