### PR TITLE
omit activity stream updates for unchanging fields

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1392,6 +1392,13 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         Parse incoming changed data for activity stream entry (tweaked for
         bulk update)
         """
+
+        def field_changed(old, new):
+            # if both are Falsy, nothing actually changed (None ~= "")
+            if not old and not new:
+                return False
+            return old != new
+
         updates = self.get_updates()
         for field in updates:
             name = ' '.join(field.split('_')).capitalize()
@@ -1401,12 +1408,6 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
             if field in ['summary', 'comment']:
                 continue
             initial = getattr(report, field, 'None')
-
-            def field_changed(old, new):
-                # if both are Falsy, nothing actually changed (None ~= "")
-                if not old and not new:
-                    return False
-                return old != new
 
             if field_changed(initial, updates[field]):
                 yield f"{name}:", f'Updated from "{initial}" to "{updates[field]}"'

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1360,6 +1360,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
             updates['primary_statute'] = ''
             updates['assigned_to'] = ''
             updates['status'] = 'new'
+
         updates.pop('district', None)  # district is currently disabled (read-only)
         return updates
 
@@ -1400,7 +1401,15 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
             if field in ['summary', 'comment']:
                 continue
             initial = getattr(report, field, 'None')
-            yield f"{name}:", f'Updated from "{initial}" to "{updates[field]}"'
+
+            def field_changed(old, new):
+                # if both are Falsy, nothing actually changed (None ~= "")
+                if not old and not new:
+                    return False
+                return old != new
+
+            if field_changed(initial, updates[field]):
+                yield f"{name}:", f'Updated from "{initial}" to "{updates[field]}"'
 
     def update_activity_stream(self, user, report):
         """

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -553,7 +553,6 @@ class BulkActionsFormTests(TestCase):
         # the activity stream (get_action) should only report fields that actually change as a result
         Report.objects.create(**SAMPLE_REPORT)
         queryset = Report.objects.all()
-        keys = ['assigned_section', 'status', 'id']
         form = BulkActionsForm(queryset, {
             'assigned_section': 'APP',
             'comment': 'this is a comment'
@@ -582,7 +581,6 @@ class BulkActionsFormTests(TestCase):
         report.save()
 
         queryset = Report.objects.all()
-        keys = ['assigned_section', 'status', 'id']
         form = BulkActionsForm(queryset, {
             'assigned_section': 'APP',
             'comment': 'this is a comment'

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -547,3 +547,58 @@ class BulkActionsFormTests(TestCase):
         keys = ['assigned_section', 'status', 'id']
         result = list(BulkActionsForm.get_initial_values(queryset, keys))
         self.assertEquals(result, [('assigned_section', 'ADM'), ('status', 'new')])
+
+    def test_bulk_actions_change_section(self):
+        # changing the section resets primary_status, assigned_to, and status
+        # the activity stream (get_action) should only report fields that actually change as a result
+        Report.objects.create(**SAMPLE_REPORT)
+        queryset = Report.objects.all()
+        keys = ['assigned_section', 'status', 'id']
+        form = BulkActionsForm(queryset, {
+            'assigned_section': 'APP',
+            'comment': 'this is a comment'
+        })
+        self.assertTrue(form.is_valid())
+
+        updates = form.get_updates()
+        self.assertEqual(updates['assigned_section'], 'APP')
+        self.assertEqual(updates['primary_statute'], '')
+        self.assertEqual(updates['assigned_to'], '')
+        self.assertEqual(updates['status'], 'new')
+
+        # the only action in the activity stream should be the section change
+        expected_actions = [
+            ('Assigned section:', 'Updated from "ADM" to "APP"')
+        ]
+        for action in form.get_actions(queryset.first()):
+            self.assertTrue(action in expected_actions)
+
+    def test_bulk_actions_change_section_resets_user(self):
+        # changing the section resets primary_status, assigned_to, and status
+        # the activity stream (get_action) should only report fields that actually change as a result
+        user = User.objects.create_user('DELETE_USER', 'ringo@thebeatles.com', secrets.token_hex(32))
+        report = Report.objects.create(**SAMPLE_REPORT)
+        report.assigned_to = user
+        report.save()
+
+        queryset = Report.objects.all()
+        keys = ['assigned_section', 'status', 'id']
+        form = BulkActionsForm(queryset, {
+            'assigned_section': 'APP',
+            'comment': 'this is a comment'
+        })
+        self.assertTrue(form.is_valid())
+
+        updates = form.get_updates()
+        self.assertEqual(updates['assigned_section'], 'APP')
+        self.assertEqual(updates['primary_statute'], '')
+        self.assertEqual(updates['assigned_to'], '')
+        self.assertEqual(updates['status'], 'new')
+
+        # actions should include the section and assigned_to
+        expected_actions = [
+            ('Assigned to:', f'Updated from "{user.username}" to ""'),
+            ('Assigned section:', 'Updated from "ADM" to "APP"')
+        ]
+        for action in form.get_actions(queryset.first()):
+            self.assertTrue(action in expected_actions)


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/759)

## What does this change?
Omits entries from the activity stream in cases where the underlying value did not actually change.  When bulk editing the assigned section, which resets `primary_statute`, `assigned_to`, and `status`, we would see activity entries for all of those fields even if the value did not actually need to change. 

## Screenshots (for front-end PR):
Before:
![image](https://user-images.githubusercontent.com/1425377/98740986-808e0600-2371-11eb-87b9-2ab3402504eb.png)

After:
![image](https://user-images.githubusercontent.com/1425377/98741107-af0be100-2371-11eb-9f9b-3fe8e218dbc4.png)


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
