### PR TITLE
contact complainant: send button

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template.html
@@ -21,6 +21,7 @@
           <div class="modal-footer">
             <button disabled id="intake_copy" class="usa-button" type="submit" name="type" value="copy">Copy</button>
             <button disabled id="intake_print" class="usa-button" type="submit" name="type" value="print">Print</button>
+            <button disabled id="intake_send" class="usa-button" type="submit" name="type" value="send">Send</button>
             <a id="intake_template_cancel" href="#">Cancel</a>
           </div>
         </div>

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -380,7 +380,12 @@ class ResponseView(LoginRequiredMixin, View):
         if form.is_valid() and form.has_changed():
             template_name = form.cleaned_data['templates'].title
             button_type = request.POST['type']
-            action = "Copied" if button_type == "copy" else "Printed"
+            actions = {
+                'send': 'Emailed',
+                'copy': 'Copied',
+                'print': 'Printed'
+            }
+            action = actions[button_type]
             description = f"{action} '{template_name}' template"
             add_activity(request.user, "Contacted complainant:", description, report)
             messages.add_message(request, messages.SUCCESS, description)


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/476)

## What does this change?

- Stub out "Send" button for contacting a complainant. Will be disabled until we actually integrate email functionality.

In the event the user bypasses this form restriction, allow the operation to continue (as a no-op, does nothing).

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
