### PR TITLE
bulk printing message: fix wording and proper count

### DIFF
--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -370,7 +370,7 @@ class PrintActionTests(TestCase):
         # verify that next QP is preserved and activity log shows up
         self.assertTrue('?per_page=15' in content)
         self.assertTrue('Printed report' in content)
-        self.assertTrue(escape('Selected correspondent, activity') in content)
+        self.assertTrue(escape('Printed correspondent, activity') in content)
 
     def test_response_action_print_with_ids(self):
         options = ['issue', 'summary']
@@ -387,7 +387,7 @@ class PrintActionTests(TestCase):
         )
         self.assertEquals(response.status_code, 200)
         content = str(response.content)
-        self.assertTrue(escape('Selected issue, summary for 1 reports') in content)
+        self.assertTrue(escape('Printed issue, summary for 1 reports') in content)
 
     def test_response_action_print_all(self):
         options = ['activity', 'issue']
@@ -396,7 +396,7 @@ class PrintActionTests(TestCase):
                 'crt_forms:crt-forms-print',
             ),
             {
-                'print_all': True,
+                'type': 'print_all',
                 'options': options,
                 'modal_next': '?per_page=15',
             },
@@ -404,7 +404,7 @@ class PrintActionTests(TestCase):
         )
         self.assertEquals(response.status_code, 200)
         content = str(response.content)
-        self.assertTrue(escape('Selected activity, issue for 2 reports') in content)
+        self.assertTrue(escape('Printed activity, issue for 2 reports') in content)
 
 
 class BulkActionsTests(TestCase):

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -395,7 +395,7 @@ class PrintView(LoginRequiredMixin, View):
         form = PrintActions(request.POST)
 
         return_url_args = request.POST.get('modal_next', '')
-        print_all = request.POST.get('print_all', None)
+        print_all = request.POST.get('type', None) == 'print_all'
         if print_all:
             reports = reconstruct_query(return_url_args)
         else:
@@ -405,10 +405,11 @@ class PrintView(LoginRequiredMixin, View):
         if form.is_valid():
             options = form.cleaned_data['options']
             all_options = ', '.join(options)
-            description = f"Selected {all_options}"
+            description = f"Printed {all_options}"
             for report in reports:
                 add_activity(request.user, "Printed report", description, report)
-            description += f" for {reports.count()} reports"
+            count = min(reports.count(), 100)
+            description += f" for {count} reports"
             messages.add_message(request, messages.SUCCESS, description)
 
         if id:


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/783)

## What does this change?

Fixes messages when printing, particularly when selecting all (capped at 100). 

Note that the previous message was "Selected {options}" in the activity log, so there might be a discrepancy when looking at older activity logs (the newer activities will say "Printed ..." instead).

## Screenshots (for front-end PR):

![2020-11-17_09-49](https://user-images.githubusercontent.com/3013175/99427502-5a5cee80-28ba-11eb-8b38-e88f2cf529ae.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
