### PR TITLE
compress assets: re-enable, configure

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -335,8 +335,7 @@ COMPRESS_PRECOMPILERS = (
     ('css', 'compressor_toolkit.precompilers.SCSSCompiler'),
 )
 
-# would like to add this before public release
-COMPRESS_ENABLED = False
+COMPRESS_ENABLED = True
 
 # adding better messaging
 CSRF_FAILURE_VIEW = 'cts_forms.views.csrf_failure'

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -250,6 +250,7 @@ if environment not in ['LOCAL', 'UNDEFINED']:
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     AWS_DEFAULT_ACL = 'public-read'
+    AWS_IS_GZIPPED = True
 
 if environment in ['PRODUCTION', 'STAGE', 'DEVELOP']:
     MIDDLEWARE.append('csp.middleware.CSPMiddleware')

--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -1,6 +1,7 @@
 {% load static %}
 {% load i18n %}
 {% load get_env %}
+{% load compress %}
 {% get_current_language as LANGUAGE_CODE %}
 <!DOCTYPE html>
 <html lang="{{LANGUAGE_CODE}}">
@@ -133,11 +134,13 @@
       {% endblock footer_extra %}
     </footer>
     {% endblock %}
+    {% compress js %}
     <script src="{% static 'js/url_params_polyfill.js' %}"></script>
     <script src="{% static 'js/uswds.min.js' %}"></script>
     <script src="{% static 'js/focus_alert.js' %}"></script>
     <script src="{% static 'js/clear_error_class.js' %}"></script>
     {% block page_js %}{% endblock %}
+    {% endcompress %}
 
     {% block analytics %}
     {% environment as env %}

--- a/crt_portal/cts_forms/templates/forms/base.html
+++ b/crt_portal/cts_forms/templates/forms/base.html
@@ -1,6 +1,7 @@
 {% load static %}
 {% load i18n %}
 {% load with_input_error %}
+{% load compress %}
 {% get_current_language as LANGUAGE_CODE %}
 
 <!DOCTYPE html>
@@ -99,8 +100,10 @@
     </div>
     {% endblock %}
   </body>
+  {% compress js %}
   <script src="{% static 'js/url_params_polyfill.js' %}"></script>
   <script src="{% static 'js/uswds.min.js' %}"></script>
   <script src="{% static 'js/focus_alert.js' %}"></script>
   {% block page_js %}{% endblock %}
+  {% endcompress %}
 </html>

--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -2,6 +2,7 @@
 
 {% load static %}
 {% load i18n %}
+{% load compress %}
 
 {% block page_header %}
   <header class="crt-landing--header crt-landing--blue">
@@ -429,6 +430,8 @@
      }
    };
   </script>
+  {% compress js %}
   <script src="{% static 'js/modal.js' %}"></script>
   <script src="{% static 'js/redirect-modal.js' %}"></script>
+  {% endcompress %}
 {% endblock %}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/562)

## What does this change?

Compresses JS assets. CSS is already compressed, via gulp and `nanocss`. 

From some rough benchmarks, when viewing a report (`/form/view`), the compressing of javascript itself is negligible (before: 705kb transferred; after: 692kb transferred), but the number of requests goes down from 33 to 22 and so does rendering speed, from ~4.5s to ~2s (when `DOMContentLoaded` triggers).

So overall compressing does offer some benefits. One thing to consider is that bundling (not necessarily minifying) our javascript files would help just as much.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
