### PR TITLE
Hotfix/11-18-20, revert use of CRTLoginRequiredMiddleware

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -175,7 +175,7 @@ if environment == 'PRODUCTION':
     AUTHENTICATION_BACKENDS = (
         'django_auth_adfs.backend.AdfsAuthCodeBackend',
     )
-    MIDDLEWARE.append('crt_portal.middleware.CRTLoginRequiredMiddleware')
+    MIDDLEWARE.append('django_auth_adfs.middleware.LoginRequiredMiddleware')
 
     for service in vcap['s3']:
         if service['instance_name'] == 'sso-creds':


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?
In https://github.com/usdoj-crt/crt-portal/pull/732 we implemented `CRTLoginRequiredMiddleware` to expose 404 responses without requiring authentication. The current implementation is malformed and calling views 2x in some situations. 

Here we [revert this change](https://github.com/usdoj-crt/crt-portal/pull/732/files#diff-5f2812a9232bee05211675dd13e8911daacff84cbfcf0f8167356d249464148aR178) in order use the previous middleware, `django_auth_adfs.LoginRequiredMiddleware`, by updating the settings.

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
