### PR TITLE
Disable NR auto-instrumentation

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -153,7 +153,7 @@ error_collector.ignore_errors =
 # For those Python web frameworks that are supported, this
 # setting enables the auto-insertion of the browser monitoring
 # JavaScript fragments.
-browser_monitoring.auto_instrument = true
+browser_monitoring.auto_instrument = false
 
 # A thread profiling session can be scheduled via the UI when
 # this option is enabled. The thread profiler will periodically


### PR DESCRIPTION


[No card](link-goes-here)

## What does this change?
Disables auto-instrumentation by the NR python agent in our settings. We do not want NR to inject content into our
application's responses and our CSP configuration prevents it from being functional.

## Checklist:

### Author

+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
