### PR TITLE
empty string added for trailing comma bugfix

### DIFF
--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -60,6 +60,8 @@ def _serialize_report_export(data):
         if data.internal_summary:
             # incoming summaries are sorted by descending modified_date the first is the most recent
             row.append(data.internal_summary[0].note)
+        else:
+            row.append('')
         return row
     return data
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/785)

## What does this change?
added empty string to force trailing comma for internal_summary column when there is no internal_summary value.

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.)

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
