### PR TITLE
Record section and other changes in activity log

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1191,7 +1191,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
                     yield f"{name}:", f'"{changed}"'
                 else:
                     original = User.objects.get(id=original)
-                    yield f"{name}:", f'Updated from "{original}" to "{changed}"'
+            yield f"{name}:", f'Updated from "{original}" to "{changed}"'
         if self.report_closed:
             yield "Report closed and Assignee removed", f"Date closed updated to {self.instance.closed_date.strftime('%m/%d/%y %H:%M:%M %p')}"
 

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -77,8 +77,8 @@ class ActionTests(TestCase):
         self.assertTrue(form.is_valid())
         actions = list(form.get_actions())
         self.assertTrue(actions)
-        self.assertEqual(actions[0], (f'Assigned to: "{self.user2.username}"')
-        self.assertEqual(actions[1], (f'Updated from "None" to "{self.user2.username}"'))
+        self.assertEqual(actions[0], ('Assigned to:', f'"{self.user2.username}"'))
+        self.assertEqual(actions[1], ('Assigned to:', f'Updated from "None" to "{self.user2.username}"'))
 
     def test_section_change(self):
         """Changes to section are recorded in activity log"""

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -74,10 +74,35 @@ class ActionTests(TestCase):
 
         self.assertTrue(form.is_valid())
 
-        # Running the code to check error.
-        for action in form.get_actions():
-            self.assertEqual(action[0], 'Assigned to:')
-            self.assertEqual(action[1], f'"{self.user2.username}"')
+        self.assertTrue(form.is_valid())
+        actions = list(form.get_actions())
+        self.assertTrue(actions)
+        self.assertEqual(actions[0], (f'Assigned to: "{self.user2.username}"')
+        self.assertEqual(actions[1], (f'Updated from "None" to "{self.user2.username}"'))
+
+    def test_section_change(self):
+        """Changes to section are recorded in activity log"""
+        form = ComplaintActions(
+            initial={
+                'assigned_section': 'ADM',
+                'status': 'new',
+                'primary_statute': '144',
+                'district': '1',
+                'assigned_to': self.user1.pk
+            },
+            data={
+                'assigned_section': 'VOT',
+                'status': 'new',
+                'primary_statute': '144',
+                'district': '1',
+                'assigned_to': self.user1.pk
+            }
+        )
+
+        self.assertTrue(form.is_valid())
+        actions = list(form.get_actions())
+        self.assertTrue(actions)
+        self.assertEqual(actions[0], ('Assigned section:', 'Updated from "ADM" to "VOT"'))
 
 
 class CommentActionTests(TestCase):


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/816)

## What does this change?
In #678 a change was introduced which limited activity log updates when modifying `assigned_to`, `status`, `district`, `section`, and `primary_classification` to only those stemming from the `assigned_to` field. 

Here we add a test to ensure `section` changes are being written to the activity log and we correct the indentation error which led to this bug 

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

* Test manually by updating all report action fields and ensuring they are recorded to activity log

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
