### PR TITLE
Autocomplete tweaks

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -932,7 +932,7 @@ class Filters(ModelForm):
     )
     assigned_to = ModelChoiceField(
         required=False,
-        queryset=User.objects.filter(is_active=True),
+        queryset=User.objects.filter(is_active=True).order_by('username'),
         label=_("Assigned to"),
         to_field_name='username',
         widget=Select(attrs={
@@ -1120,7 +1120,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
     report_closed = False
     CONTEXT_KEY = 'actions'
     assigned_to = ModelChoiceField(
-        queryset=User.objects.filter(is_active=True),
+        queryset=User.objects.filter(is_active=True).order_by('username'),
         # crt view only
         label="Assigned to",
         required=False
@@ -1307,7 +1307,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         required=False
     )
     assigned_to = ModelChoiceField(
-        queryset=User.objects.filter(is_active=True),
+        queryset=User.objects.filter(is_active=True).order_by('username'),
         label='Assigned to',
         required=False
     )

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -41,6 +41,9 @@
 <script type="text/javascript" src="{% static 'js/aria-autocomplete-1.2.3.min.js' %}"></script>
 <script nonce="{{request.csp_nonce}}">
  var select = document.getElementById('id_assigned_to');
- AriaAutocomplete(select, {});
+ AriaAutocomplete(select, {
+   minLength: 0,
+   maxResults: 10
+ });
 </script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -43,7 +43,7 @@
  var select = document.getElementById('id_assigned_to');
  AriaAutocomplete(select, {
    minLength: 0,
-   maxResults: 10
+   maxResults: 5
  });
 </script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -97,7 +97,7 @@
  var select = document.getElementById('id_assigned_to');
  AriaAutocomplete(select, {
    minLength: 0,
-   maxResults: 10
+   maxResults: 5
  });
 </script>
 {%endblock%}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -95,6 +95,9 @@
 <script type="text/javascript" src="{% static 'js/aria-autocomplete-1.2.3.min.js' %}"></script>
 <script nonce="{{request.csp_nonce}}">
  var select = document.getElementById('id_assigned_to');
- AriaAutocomplete(select, {});
+ AriaAutocomplete(select, {
+   minLength: 0,
+   maxResults: 10
+ });
 </script>
 {%endblock%}

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -607,7 +607,6 @@ ul.messages {
     position: absolute;
     width: 60%;
     border-radius: 3px;
-    font-weight: bold;
     margin-top: 0;
     box-shadow: 0 15px 10px hsla(0, 0%, 39.2%, 0.2);
 
@@ -626,6 +625,7 @@ ul.messages {
       }
 
       &:hover {
+        font-weight: bold;
         @include u-bg($theme-color-primary-lightest);
         @include u-text($theme-color-primary-darker);
       }


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/799)

## What does this change?

- Force a list of names to come up. 
  - This behavior inadvertently fixes a few issues with clearing out -- the user now has to explicitly click elsewhere for the autocomplete to disappear, which forces a focus switch away from the assigned list and hence clears the autocomplete properly. This is the only way I've found to fix this behavior, alas.
- Autocomplete styling tweaks

To test, please try:
- Clearing out an assignee
- Replacing (clearing out and then re-selecting) an assignee
- Clicking and confirming that a list of (at most 5) names comes up

## Screenshots (for front-end PR):

![2020-12-07_09-08](https://user-images.githubusercontent.com/3013175/101381619-d15b2680-386b-11eb-8251-bef385157434.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
