### PR TITLE
Return error if session data has been cleared

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run:
           name: Run bandit (Python security) tests
           command: |
-            pipenv run bandit -r crt_portal/
+            pipenv run bandit -r crt_portal/ --exclude cts_forms/tests
       - run:
           name: Run flake8 test for Python code style
           command: |

--- a/crt_portal/crt_portal/urls.py
+++ b/crt_portal/crt_portal/urls.py
@@ -91,6 +91,5 @@ if settings.DEBUG:
     urlpatterns += [
         path('errors/404', error_404),
         path('errors/422', error_422),
-
         path('errors/500', error_500),
     ]

--- a/crt_portal/crt_portal/urls.py
+++ b/crt_portal/crt_portal/urls.py
@@ -21,7 +21,8 @@ from cts_forms.forms import (CommercialPublicLocation, Contact, Details,
                              ProtectedClassForm, Review, When,
                              WorkplaceLocation)
 from cts_forms.views import (CRTReportWizard, LandingPageView, error_404,
-                             error_500, show_commercial_public_form_condition,
+                             error_422, error_500,
+                             show_commercial_public_form_condition,
                              show_education_form_condition,
                              show_election_form_condition,
                              show_location_form_condition,
@@ -89,5 +90,7 @@ handler503 = 'cts_forms.views.error_503'
 if settings.DEBUG:
     urlpatterns += [
         path('errors/404', error_404),
+        path('errors/422', error_422),
+
         path('errors/500', error_500),
     ]

--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-23 20:33+0000\n"
+"POT-Creation-Date: 2020-12-11 18:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:160 forms.py:1464
+#: forms.py:160 forms.py:1482
 msgid " - Select - "
 msgstr " - Elija - "
 
@@ -155,7 +155,7 @@ msgstr "Asignado a"
 msgid "Create date cannot be in the future."
 msgstr "La fecha no puede ser en el futuro."
 
-#: forms.py:1228
+#: forms.py:1236
 msgid "Comment cannot be empty"
 msgstr ""
 
@@ -178,24 +178,24 @@ msgstr ""
 "Elija un estatus como miembro de las fuerzas armadas en servicio activo."
 
 #: model_variables.py:16
+msgid "Voting rights or ability to vote affected"
+msgstr "Derecho al voto o la posibilidad de votar afectada"
+
+#: model_variables.py:17
 msgid "Workplace discrimination or other employment-related problem"
 msgstr "Discriminación en el empleo u otro problema relacionado con el empleo"
 
-#: model_variables.py:17
+#: model_variables.py:18
 msgid "Housing discrimination or harassment"
 msgstr "Discriminación u hostigamiento en la vivienda"
 
-#: model_variables.py:18
+#: model_variables.py:19
 msgid ""
 "Discrimination at a school, educational program or service, or related to "
 "receiving education"
 msgstr ""
 "Discriminación en una escuela, un programa o un servicio educativo o algo "
 "relacionado con la recepción de educación"
-
-#: model_variables.py:19
-msgid "Voting rights or ability to vote affected"
-msgstr "Derecho al voto o la posibilidad de votar afectada"
 
 #: model_variables.py:20
 msgid "Mistreated by police, correctional staff, or inmates"
@@ -477,7 +477,7 @@ msgstr ""
 "físico, la retención de sueldos prometidos o la retención bajo un contrato "
 "laboral falso"
 
-#: model_variables.py:124 templates/landing.html:252
+#: model_variables.py:124 templates/landing.html:253
 msgid "Age"
 msgstr "Edad"
 
@@ -520,11 +520,11 @@ msgstr "Origen nacional (incluyendo ascendencia y etnia)"
 msgid "Pregnancy"
 msgstr "Embarazo"
 
-#: model_variables.py:133 templates/landing.html:245
+#: model_variables.py:133 templates/landing.html:246
 msgid "Race/color"
 msgstr "Raza/color de piel"
 
-#: model_variables.py:134 templates/landing.html:247
+#: model_variables.py:134 templates/landing.html:248
 msgid "Religion"
 msgstr "Religión"
 
@@ -1197,14 +1197,14 @@ msgstr ""
 msgid "Any supporting materials (please list and describe them)"
 msgstr "Cualquier material de apoyo (haga una lista y describa cada artículo)"
 
-#: templates/base.html:22 templates/base.html:47 templates/forms/base.html:19
+#: templates/base.html:34 templates/base.html:59 templates/forms/base.html:20
 #: templates/forms/report_base.html:13
 msgid "Contact the Civil Rights Division | Department of Justice"
 msgstr ""
 "Comuníquese con la División de Derechos Civiles | Departamento de Justicia"
 
 #  Meta tag description of site
-#: templates/base.html:35
+#: templates/base.html:47
 msgid ""
 "Have you or someone you know experienced unlawful discrimination? The Civil "
 "Rights Division may be able to help. Civil rights laws can protect you from "
@@ -1218,23 +1218,23 @@ msgstr ""
 "variedad de entornos como la vivienda, el lugar de trabajo, la escuela, la "
 "votación, los negocios, la atención médica, los espacios públicos y más."
 
-#: templates/base.html:55 templates/forms/base.html:28
+#: templates/base.html:71 templates/forms/base.html:33
 msgid "Skip to main content"
 msgstr "Pasar directamente al contenido principal"
 
-#: templates/base.html:98 templates/forms/base.html:92
+#: templates/base.html:125 templates/forms/base.html:97
 #: templates/forms/errors.html:13 templates/forms/report_maintenance.html:13
-#: templates/landing.html:18
+#: templates/landing.html:19
 msgid "U.S. Department of Justice"
 msgstr "Departamento de Justicia de los EE. UU."
 
-#: templates/base.html:101 templates/forms/base.html:91
+#: templates/base.html:128 templates/forms/base.html:96
 #: templates/forms/errors.html:14 templates/forms/report_maintenance.html:14
-#: templates/landing.html:21
+#: templates/landing.html:22
 msgid "Civil Rights Division"
 msgstr "División de Derechos Civiles"
 
-#: templates/forms/base.html:15
+#: templates/forms/base.html:16
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -1252,23 +1252,23 @@ msgstr ""
 "División de Derechos Civiles - Departamento de Justicia\n"
 "      "
 
-#: templates/forms/base.html:38
+#: templates/forms/base.html:43
 #: templates/partials/banner/usa_banner_header.html:9
 msgid "An official website of the United States government"
 msgstr "Una página web oficial del Gobierno de los Estados Unidos"
 
-#: templates/forms/base.html:39 templates/forms/base.html:42
+#: templates/forms/base.html:44 templates/forms/base.html:47
 #: templates/partials/banner/usa_banner_header.html:10
 #: templates/partials/banner/usa_banner_header.html:13
 msgid "Here’s how you know"
 msgstr "Así es como lo sabe"
 
-#: templates/forms/base.html:52
+#: templates/forms/base.html:57
 #: templates/partials/banner/usa_banner_content.html:7
 msgid "The .gov means it’s official."
 msgstr "El .gov significa que es oficial."
 
-#: templates/forms/base.html:53
+#: templates/forms/base.html:58
 #: templates/partials/banner/usa_banner_content.html:8
 msgid ""
 "Federal government websites often end in .gov or .mil. Before sharing "
@@ -1278,12 +1278,12 @@ msgstr ""
 "información confidencial, compruebe que se encuentra en un sitio del "
 "gobierno federal."
 
-#: templates/forms/base.html:61
+#: templates/forms/base.html:66
 #: templates/partials/banner/usa_banner_content.html:16
 msgid "The site is secure."
 msgstr "Este sitio es seguro."
 
-#: templates/forms/base.html:62
+#: templates/forms/base.html:67
 #: templates/partials/banner/usa_banner_content.html:17
 msgid ""
 "The <strong>https://</strong> ensures that you are connecting to the "
@@ -1420,7 +1420,7 @@ msgid "We’re receiving and actively reviewing many requests at the same time."
 msgstr ""
 "Estamos recibiendo y revisando activamente muchas solicitudes a la vez."
 
-#: templates/forms/confirmation.html:119 templates/landing.html:348
+#: templates/forms/confirmation.html:119 templates/landing.html:349
 msgid ""
 "If we are able to respond, we will contact you using the contact information "
 "you provided in this report. Depending on the type of report, response times "
@@ -1509,58 +1509,76 @@ msgstr ""
 msgid "Your submission"
 msgstr "Su entrega"
 
-#: templates/forms/errors.html:30
+#: templates/forms/error_422.html:5 templates/forms/errors.html:31
 msgid "We're sorry, something went wrong"
 msgstr "Lo siento, se ha producido un error"
 
-#: templates/forms/errors.html:31
+#: templates/forms/error_422.html:8
+msgid ""
+"\n"
+"        <p>This error might be associated with an incompatible Internet "
+"browser. Please download the latest version of Google Chrome, Mozilla "
+"Firefox, Safari or Microsoft Edge.</p>\n"
+"        <p>Additionally, please do not use multiple browsers and/or browser "
+"tabs when entering your report.</p>\n"
+"    "
+msgstr ""
+"\n"
+"        <p>Este error puede estar asociado con un navegador de Internet "
+"incompatible. Descargue la última versión de Google Chrome, Mozilla Firefox, "
+"Safari o Microsoft Edge.</p>\n"
+"        <p>Además, no utilice varios navegadores ni pestañas del navegador "
+"al ingresar su informe.</p>\n"
+"    "
+
+#: templates/forms/errors.html:33
 msgid "We hope to fix this issue shortly"
 msgstr "Esperamos tenerlo arreglado en breve"
 
-#: templates/forms/errors.html:32
+#: templates/forms/errors.html:35
 msgid "Error: "
 msgstr "Error: "
 
-#: templates/forms/errors.html:34 templates/forms/report_maintenance.html:33
+#: templates/forms/errors.html:37 templates/forms/report_maintenance.html:33
 msgid "If you need to contact us immediately, you can reach us by:"
 msgstr ""
 "Si usted necesita comunicarse con nosotros urgentemente, lo puede hacer "
 "mediante los siguientes modos:"
 
-#: templates/forms/errors.html:38 templates/forms/report_maintenance.html:38
+#: templates/forms/errors.html:42 templates/forms/report_maintenance.html:38
 msgid "Email"
 msgstr ""
 
-#: templates/forms/errors.html:45 templates/forms/report_maintenance.html:47
+#: templates/forms/errors.html:51 templates/forms/report_maintenance.html:47
 #: templates/partials/footer.html:32
 msgid "(toll-free)"
 msgstr "(línea gratuita)"
 
-#: templates/forms/errors.html:46 templates/forms/report_maintenance.html:48
+#: templates/forms/errors.html:52 templates/forms/report_maintenance.html:48
 #: templates/partials/footer.html:33
 msgid "Telephone Device for the Deaf"
 msgstr "Dispositivo telefónico para sordos"
 
-#: templates/forms/errors.html:47 templates/forms/report_maintenance.html:49
+#: templates/forms/errors.html:53 templates/forms/report_maintenance.html:49
 #: templates/partials/footer.html:34
 msgid "(TTY)"
 msgstr "Teletipo (TTY por sus siglas en inglés)"
 
-#: templates/forms/errors.html:59 templates/forms/report_maintenance.html:64
+#: templates/forms/errors.html:68 templates/forms/report_maintenance.html:64
 msgid "Other information"
 msgstr "Información adicional"
 
-#: templates/forms/errors.html:60
+#: templates/forms/errors.html:69
 msgid "File a complaint"
 msgstr "Presentar una querella"
 
-#: templates/forms/errors.html:61 templates/forms/report_maintenance.html:66
-#: templates/landing.html:125
+#: templates/forms/errors.html:71 templates/forms/report_maintenance.html:66
+#: templates/landing.html:126
 msgid "About the Civil Rights Division"
 msgstr "Acerca de la División de Derechos Civiles"
 
-#: templates/forms/errors.html:62 templates/forms/report_maintenance.html:69
-#: templates/landing.html:108
+#: templates/forms/errors.html:74 templates/forms/report_maintenance.html:69
+#: templates/landing.html:109
 msgid ""
 "If you or someone else is in immediate danger, <a href=\"tel:911\">please "
 "call 911 or local police.</a>"
@@ -1662,7 +1680,7 @@ msgid "None selected"
 msgstr "Ninguna selección hecha"
 
 #: templates/forms/report_hate_crime.html:13
-#: templates/forms/report_hate_crime.html:18 templates/landing.html:222
+#: templates/forms/report_hate_crime.html:18 templates/landing.html:223
 msgid "Were you forced to work against your will?"
 msgstr "¿Le obligaron a trabajar en contra de su voluntad?"
 
@@ -1674,7 +1692,7 @@ msgstr ""
 "La trata de personas incluye ser forzado o coaccionado a hacer trabajo, o "
 "forzado o coaccionado a participar en actos sexuales por algo de valor."
 
-#: templates/forms/report_hate_crime.html:18 templates/landing.html:222
+#: templates/forms/report_hate_crime.html:18 templates/landing.html:223
 msgid "Get help from the National Human Trafficking Hotline"
 msgstr "Reciba ayuda de la Línea Nacional contra la Trata de Personas"
 
@@ -1738,34 +1756,34 @@ msgstr ""
 "          %(word_limit)s límite de palabras alcanzado\n"
 "        "
 
-#: templates/landing.html:39
+#: templates/landing.html:40
 msgid "About the Division"
 msgstr "Acerca de la División"
 
-#: templates/landing.html:44
+#: templates/landing.html:45
 msgid "Your rights"
 msgstr "Sus derechos"
 
-#: templates/landing.html:49 templates/partials/footer.html:69
+#: templates/landing.html:50 templates/partials/footer.html:69
 msgid "Report a violation"
 msgstr "Informe sobre una vulneración"
 
-#: templates/landing.html:54
+#: templates/landing.html:55
 msgid "Already submitted?"
 msgstr "¿Ya nos informó de una vulneración?"
 
-#: templates/landing.html:59 templates/partials/footer.html:9 views.py:799
-#: views.py:860 views.py:879
+#: templates/landing.html:60 templates/partials/footer.html:9 views.py:825
+#: views.py:904 views.py:923
 msgid "Contact"
 msgstr "Contacto"
 
-#: templates/landing.html:78
+#: templates/landing.html:79
 msgid "We uphold the civil rights of <em>all</em> people in the United States."
 msgstr ""
 "Nosotros defendemos los derechos civiles de <em>todas</em> las personas en "
 "los Estados Unidos."
 
-#: templates/landing.html:83
+#: templates/landing.html:84
 msgid ""
 "The Civil Rights Division enforces federal laws that protect you from "
 "discrimination based on your race, color, national origin, disability "
@@ -1777,7 +1795,7 @@ msgstr ""
 "de piel, origen nacional, discapacidad, género, religión, estatus familiar o "
 "pérdida de otros derechos constitucionales."
 
-#: templates/landing.html:86
+#: templates/landing.html:87
 #, fuzzy
 #| msgid ""
 #| "If you believe your civil rights, or someone’s, have been violated, "
@@ -1789,19 +1807,19 @@ msgstr ""
 "Si usted cree que sus derechos civiles o los de otra persona han sido "
 "vulnerados, puede entregar un informe mediante nuestro formulario virtual."
 
-#: templates/landing.html:88
+#: templates/landing.html:89
 msgid "Start a report"
 msgstr "Inicie el proceso de querella"
 
-#: templates/landing.html:89
+#: templates/landing.html:90
 msgid "or learn more about <a href=\"#your-rights\">your rights</a>"
 msgstr "o aprenda más sobre <a href=\"#your-rights\">sus derechos</a>"
 
-#: templates/landing.html:102
+#: templates/landing.html:103
 msgid "If you are in danger, contact <a href=\"tel:911\">911</a>"
 msgstr "Si usted se encuentra en peligro, llame al <a href=\"tel:911\">911</a>"
 
-#: templates/landing.html:113
+#: templates/landing.html:114
 msgid ""
 "If you are reporting misconduct by law enforcement or believe you have "
 "experienced a hate crime, please <a aria-label=\"contact the FBI\" class="
@@ -1813,15 +1831,15 @@ msgstr ""
 "<a aria-label=\"debe comunicarse con el FBI\"class=\"crt-external--link\" "
 "href=\"https://www.fbi.gov/tips\">debe comunicarse con el FBI</a>."
 
-#: templates/landing.html:127
+#: templates/landing.html:128
 msgid "We protect your rights through:"
 msgstr "Protegemos sus derechos mediante:"
 
-#: templates/landing.html:130
+#: templates/landing.html:131
 msgid "Enforcement"
 msgstr "Aplicación de la ley"
 
-#: templates/landing.html:132
+#: templates/landing.html:133
 msgid ""
 "We sue or prosecute individuals and organizations who violate civil rights "
 "laws."
@@ -1829,7 +1847,7 @@ msgstr ""
 "Nosotros entablamos pleitos o enjuiciamos a personas y organizaciones que "
 "vulneran las leyes de derechos civiles."
 
-#: templates/landing.html:133
+#: templates/landing.html:134
 msgid ""
 "You can help us do this work by reporting a possible civil rights violation "
 "through our"
@@ -1837,34 +1855,34 @@ msgstr ""
 "Usted nos puede ayudar a realizar este trabajo al denunciar posibles "
 "vulneraciones de derechos civiles a través de nuestro"
 
-#: templates/landing.html:133
+#: templates/landing.html:134
 msgid "online form"
 msgstr "formulario virtual"
 
-#: templates/landing.html:136
+#: templates/landing.html:137
 msgid "Education"
 msgstr "Educación"
 
-#: templates/landing.html:138
+#: templates/landing.html:139
 msgid "We help the public understand how to comply with these laws."
 msgstr "Ayudamos al público a entender cómo cumplir con estas leyes."
 
-#: templates/landing.html:139
+#: templates/landing.html:140
 msgid "We do this through public speaking, technical assistance, and more."
 msgstr "Lo hacemos mediante discursos públicos, asistencia técnica y más."
 
-#: templates/landing.html:142
+#: templates/landing.html:143
 msgid "Coordination"
 msgstr "Coordinación"
 
-#: templates/landing.html:144
+#: templates/landing.html:145
 msgid ""
 "We help the entire federal government work together to enforce these laws."
 msgstr ""
 "Ayudamos al Gobierno federal en su conjunto a colaborar en el esfuerzo por "
 "hacer cumplir estas leyes."
 
-#: templates/landing.html:145
+#: templates/landing.html:146
 msgid ""
 "Our teams work with other agencies to promote a consistent approach to civil "
 "rights laws."
@@ -1872,11 +1890,11 @@ msgstr ""
 "Nuestros equipos trabajan con otros organismos gubernamentales para promover "
 "un alcance coherente a las leyes de derechos civiles."
 
-#: templates/landing.html:157
+#: templates/landing.html:158
 msgid "Understanding your rights"
 msgstr "Comprenda sus derechos"
 
-#: templates/landing.html:160
+#: templates/landing.html:161
 msgid ""
 "Civil rights laws can protect you from unlawful discrimination, harassment, "
 "or abuse in a variety of settings like <span class=\"crt-landing--"
@@ -1889,7 +1907,7 @@ msgstr ""
 "vivienda, el empleo, la escuela, la votación, las empresas, la asistencia "
 "sanitaria, los espacios públicos</span> y más."
 
-#: templates/landing.html:163
+#: templates/landing.html:164
 msgid ""
 "If you have been <span class=\"crt-landing--rights_categories\">mistreated "
 "by law enforcement</span> (including while incarcerated), believe you have "
@@ -1904,16 +1922,16 @@ msgstr ""
 "\"crt-landing--rights_categories\">trata de personas</span>, podemos "
 "dirigirle al lugar indicado."
 
-#: templates/landing.html:179
+#: templates/landing.html:180
 msgid "Choose from this list to see example civil rights violations:"
 msgstr ""
 "Para ver ejemplos de vulneraciones de derechos civiles, elija de esta lista:"
 
-#: templates/landing.html:214
+#: templates/landing.html:215
 msgid "Examples"
 msgstr "Ejemplos"
 
-#: templates/landing.html:231
+#: templates/landing.html:232
 msgid ""
 "If you think you’ve experienced a similar situation, learn <a href=\"#crt-"
 "landing--reporting\">how to report a civil rights violation</a>."
@@ -1922,17 +1940,17 @@ msgstr ""
 "\"#crt-landing--reporting\">cómo informar una querella por una vulneración "
 "de sus derechos civiles</a>."
 
-#: templates/landing.html:241
+#: templates/landing.html:242
 msgid "Protected by civil rights laws"
 msgstr "Protecciones en virtud de las leyes de derechos civiles"
 
-#: templates/landing.html:243
+#: templates/landing.html:244
 msgid "These are the most common characteristics that are legally protected."
 msgstr ""
 "Estas son las características más comunes que son protegidas al amparo de la "
 "ley."
 
-#: templates/landing.html:246
+#: templates/landing.html:247
 msgid ""
 "Disability <span class=\"crt-landing--protected\">including temporary or in "
 "recovery</span>"
@@ -1941,15 +1959,15 @@ msgstr ""
 "personas con discapacidades temporales o que se están recuperando de una "
 "discapacidad</span>"
 
-#: templates/landing.html:248
+#: templates/landing.html:249
 msgid "Sex, gender identity, and sexual orientation"
 msgstr "Género, identidad de género y orientación sexual"
 
-#: templates/landing.html:249
+#: templates/landing.html:250
 msgid "Immigration/citizenship status"
 msgstr "Estatus migratorio/de ciudadanía"
 
-#: templates/landing.html:250
+#: templates/landing.html:251
 msgid ""
 "Language and national origin <span class=\"crt-landing--protected"
 "\">including ancestry and ethnicity</span>"
@@ -1957,7 +1975,7 @@ msgstr ""
 "Idioma y origen nacional <span class=\"crt-landing--protected\">Incluye "
 "ascendencia y etnia</span>"
 
-#: templates/landing.html:251
+#: templates/landing.html:252
 msgid ""
 "Family, marital, or parental status <span class=\"crt-landing--protected"
 "\">including pregnancy</span>"
@@ -1965,19 +1983,19 @@ msgstr ""
 "Estatus familiar, civil o parental <span class=\"crt-landing--protected"
 "\">Incluye el embarazo</span>"
 
-#: templates/landing.html:253
+#: templates/landing.html:254
 msgid "Genetic identification"
 msgstr "Información genética"
 
-#: templates/landing.html:254
+#: templates/landing.html:255
 msgid "Servicemember status"
 msgstr "Estatus como miembro de las fuerzas armadas"
 
-#: templates/landing.html:268
+#: templates/landing.html:269
 msgid "How to report a civil rights violation"
 msgstr "Como informar de una vulneración de los derechos civiles"
 
-#: templates/landing.html:273
+#: templates/landing.html:274
 msgid ""
 "If you believe that you or someone else experienced unlawful discrimination, "
 "you can report a civil rights violation."
@@ -1985,11 +2003,11 @@ msgstr ""
 "Si cree que usted u otra persona ha sido discriminado/a ilegalmente, puede "
 "informar de una vulneración de los derechos civiles."
 
-#: templates/landing.html:282
+#: templates/landing.html:283
 msgid "Report using our online form."
 msgstr "Informarnos mediante nuestro formulario virtual."
 
-#: templates/landing.html:283
+#: templates/landing.html:284
 msgid ""
 "By completing the online form, you can provide the details we need to "
 "understand what happened. You will receive a confirmation number and your "
@@ -2000,11 +2018,11 @@ msgstr ""
 "confirmación y su informe se enviará directamente a nuestro personal para "
 "ser revisado."
 
-#: templates/landing.html:291
+#: templates/landing.html:292
 msgid "We review your report."
 msgstr "Revisamos su informe"
 
-#: templates/landing.html:292
+#: templates/landing.html:293
 msgid ""
 "Teams that specialize in handling your type of issue will review it. If it "
 "needs to be forwarded to another team or agency, we will try to connect your "
@@ -2014,11 +2032,11 @@ msgstr ""
 "Si hay que remitirlo a otro equipo u agencia, intentaremos enviaremos su "
 "querella al grupo correcto."
 
-#: templates/landing.html:300
+#: templates/landing.html:301
 msgid "We determine next steps and get back to you."
 msgstr "Determinamos los próximos pasos y le respondemos a usted."
 
-#: templates/landing.html:301
+#: templates/landing.html:302
 msgid ""
 "Possible outcomes include: following up for more information, starting a "
 "mediation or investigation, directing you to another organization for "
@@ -2029,17 +2047,17 @@ msgstr ""
 "a otra organización para buscar ayuda adicional o informarle que no podremos "
 "ayudar."
 
-#: templates/landing.html:320
+#: templates/landing.html:321
 msgid "Have you or someone you know experienced a civil rights violation?"
 msgstr ""
 "¿Usted u otra persona ha sido víctima de una vulneración de sus derechos "
 "civiles?"
 
-#: templates/landing.html:321
+#: templates/landing.html:322
 msgid "Submit a report"
 msgstr "Presentar un informe"
 
-#: templates/landing.html:326
+#: templates/landing.html:327
 msgid ""
 "If you cannot access the online form, you can <a href=\"#phone-footer"
 "\">call</a> to report a violation or report a violation by <a href="
@@ -2049,15 +2067,15 @@ msgstr ""
 "footer\">llamar</a> para reportar una vulneración o bien puede reportar una "
 "vulneración por <a href=\"#address-footer\">correo ordinario</a>."
 
-#: templates/landing.html:336
+#: templates/landing.html:337
 msgid "Already submitted a report?"
 msgstr "¿Ya presentó un informe?"
 
-#: templates/landing.html:339
+#: templates/landing.html:340
 msgid "Here's what to expect."
 msgstr "Puede esperar lo siguiente."
 
-#: templates/landing.html:343
+#: templates/landing.html:344
 msgid ""
 "<strong>Thank you for your report.</strong> We carefully read each one to "
 "determine if we have the authority to help. We do our best to let you know "
@@ -2068,22 +2086,22 @@ msgstr ""
 "determinar si podemos ayudar. Nos esforzamos por notificarle del resultado "
 "de nuestro repaso. No obstante, no siempre podremos actualizarle porque:"
 
-#: templates/landing.html:345
+#: templates/landing.html:346
 msgid ""
 "We're actively working on an investigation or case related to your report."
 msgstr ""
 "Estamos trabajando activamente en una investigación o un caso relacionado "
 "con su informe."
 
-#: templates/landing.html:346
+#: templates/landing.html:347
 msgid "We're receiving and actively reviewing many reports at the same time."
 msgstr "Estamos recibiendo y repasando muchos informes a la vez."
 
-#: templates/landing.html:353
+#: templates/landing.html:354
 msgid "Need urgent legal help?"
 msgstr "¿Necesita ayuda legal urgente?"
 
-#: templates/landing.html:355
+#: templates/landing.html:356
 msgid ""
 "Due to the amount of reports we receive, it can take several weeks for us to "
 "respond to your issue. Local legal aid offices or lawyers in your area may "
@@ -2093,7 +2111,7 @@ msgstr ""
 "semanas en responderle. Oficinas locales de asistencia legal en su zona "
 "podrán responder rápido o ayudarle con su motivo de preocupación."
 
-#: templates/landing.html:356
+#: templates/landing.html:357
 msgid ""
 "Contact Legal Services Corporation at <a aria-label=\"www.lsc.gov/find-legal-"
 "aid\" class=\"external-link--blue external-link--popup\" href=\"https://www."
@@ -2105,7 +2123,7 @@ msgstr ""
 "\"https://lsc.gov/find-legal-aid\">lsc.gov/find-legal-aid</a> o llame al <a "
 "href=\"tel:202-295-1500\">(202) 295-1500</a>."
 
-#: templates/landing.html:357
+#: templates/landing.html:358
 msgid ""
 "Or visit <a class=\"external-link--blue external-link--popup\" aria-label="
 "\"www.findlegalhelp.org\" href=\"http://www.findlegalhelp.org/\">www."
@@ -2117,7 +2135,7 @@ msgstr ""
 "llamar al <a href=\"tel:800-285-2221\">(800) 285-2221</a> para localizar a "
 "un abogado a través del Colegio de Abogados Estadounidense. "
 
-#: templates/landing.html:371
+#: templates/landing.html:372
 msgid "Image attributions"
 msgstr ""
 
@@ -2619,19 +2637,19 @@ msgstr ""
 "(25-5-2017).\n"
 "                "
 
-#: views.py:70
+#: views.py:69
 msgid "404 | Page not found"
 msgstr "404 | Página no encontrada"
 
-#: views.py:71
+#: views.py:70
 msgid "We can't find the page you are looking for"
 msgstr "No encontramos la página que usted está buscando"
 
-#: views.py:122
+#: views.py:129
 msgid "Your browser couldn't create a secure cookie"
 msgstr "Su navegador no pudo crear una cookie segura"
 
-#: views.py:123
+#: views.py:130
 msgid ""
 "We use security cookies to protect your information from attackers. Make "
 "sure you allow cookies for this site. Having the page open for long periods "
@@ -2645,54 +2663,54 @@ msgstr ""
 "acceder a esta página en otra pestaña o ventana en su navegador. Eso le "
 "creará otra cookie de seguridad y debería resolver el problema."
 
-#: views.py:674 views.py:907
+#: views.py:700 views.py:951
 msgid "word remaining"
 msgstr "palabra restante"
 
-#: views.py:675 views.py:908
+#: views.py:701 views.py:952
 msgid " words remaining"
 msgstr "palabras restantes"
 
-#: views.py:676 views.py:909
+#: views.py:702 views.py:953
 msgid " word limit reached"
 msgstr "límite de palabras alcanzado"
 
-#: views.py:800 views.py:861 views.py:862 views.py:880 views.py:881
-#: views.py:916
+#: views.py:826 views.py:905 views.py:906 views.py:924 views.py:925
+#: views.py:960
 msgid "Primary concern"
 msgstr "Motivo principal de preocupación"
 
-#: views.py:801 views.py:863 views.py:864 views.py:865 views.py:866
-#: views.py:867 views.py:868
+#: views.py:827 views.py:907 views.py:908 views.py:909 views.py:910
+#: views.py:911 views.py:912
 msgid "Location"
 msgstr "Lugar"
 
-#: views.py:802 views.py:869 views.py:888
+#: views.py:828 views.py:913 views.py:932
 msgid "Personal characteristics"
 msgstr "Características personales"
 
-#: views.py:803 views.py:870 views.py:889
+#: views.py:829 views.py:914 views.py:933
 msgid "Date"
 msgstr "Fecha"
 
-#: views.py:804 views.py:871 views.py:890
+#: views.py:830 views.py:915 views.py:934
 msgid "Personal description"
 msgstr "Descripción personal"
 
-#: views.py:805 views.py:872 views.py:921
+#: views.py:831 views.py:916 views.py:965
 msgid "Review"
 msgstr "Repasar"
 
-#: views.py:882 views.py:883 views.py:884 views.py:885 views.py:886
-#: views.py:887
+#: views.py:926 views.py:927 views.py:928 views.py:929 views.py:930
+#: views.py:931
 msgid "Location details"
 msgstr "Datos de lugar"
 
-#: views.py:891
+#: views.py:935
 msgid "Review your report"
 msgstr "Revise su informe"
 
-#: views.py:919
+#: views.py:963
 msgid "Please select if any that apply to your situation (optional)"
 msgstr "Favor de elegir esta opción si"
 

--- a/crt_portal/cts_forms/templates/forms/error_422.html
+++ b/crt_portal/cts_forms/templates/forms/error_422.html
@@ -1,0 +1,14 @@
+{% extends "forms/errors.html" %}
+{% load i18n %}
+
+
+{% block error_heading %}We're sorry, something went wrong.{% endblock %}
+
+{% block error_message %}
+    {% blocktrans %}
+        <p>This error might be associated with an incompatible Internet browser. Please download the latest version of Google Chrome, Mozilla Firefox, Safari or Microsoft Edge.</p>
+        <p>Additionally, please do not use multiple browsers and/or browser tabs when entering your report.</p>
+    {% endblocktrans %}
+{% endblock error_message%}
+
+{% block error_helptext %}{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/error_422.html
+++ b/crt_portal/cts_forms/templates/forms/error_422.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 
-{% block error_heading %}We're sorry, something went wrong.{% endblock %}
+{% block error_heading %}{% trans "We're sorry, something went wrong." %}{% endblock %}
 
 {% block error_message %}
     {% blocktrans %}

--- a/crt_portal/cts_forms/templates/forms/error_422.html
+++ b/crt_portal/cts_forms/templates/forms/error_422.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 
-{% block error_heading %}{% trans "We're sorry, something went wrong." %}{% endblock %}
+{% block error_heading %}{% trans "We're sorry, something went wrong" %}{% endblock %}
 
 {% block error_message %}
     {% blocktrans %}

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -3,6 +3,33 @@ import pytest
 
 
 @pytest.mark.only_browser("chromium")
+def test_error_if_form_refreshed(page, base_url):
+
+    def next_step():
+        with page.expect_navigation() as response:
+            page.click('input[type="submit"]')
+        return response.value
+
+    page.goto("/report")
+    # We'll complete the first step
+    page.check("input[name='0-servicemember']")
+    next_step()
+
+    # Refresh the page in another tab
+    new_tab = page.context.newPage()
+    new_tab.goto(f"{base_url}/report")
+
+    # Now try and progress on original tab where we're still on step #2
+    assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"  # nosec
+    page.check("#id_1-primary_complaint_0")
+    response = next_step()
+
+    # Now we've got an error page on the original tab
+    assert response.status == 422
+    assert "We're sorry, something went wrong." in response.text()
+
+
+@pytest.mark.only_browser("chromium")
 def test_report_complete_and_valid_submission(page):
 
     def next_step():

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -20,7 +20,7 @@ def test_error_if_form_refreshed(page, base_url):
     new_tab.goto(f"{base_url}/report")
 
     # Now try and progress on original tab where we're still on step #2
-    assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"  # nosec
+    assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"
     page.check("#id_1-primary_complaint_0")
     response = next_step()
 
@@ -37,7 +37,7 @@ def test_report_complete_and_valid_submission(page):
             page.click('input[type="submit"]')
 
     page.goto("/report")
-    assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"  # nosec
+    assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"
 
     # Fill input[name="0-contact_first_name"]
     page.fill("input[name='0-contact_first_name']", "Testing")
@@ -68,21 +68,21 @@ def test_report_complete_and_valid_submission(page):
 
     # Go to step 2
     next_step()
-    assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"  # nosec
+    assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"
 
     # Check voting
     page.check("#id_1-primary_complaint_0")
 
     # Go to step 2-2
     next_step()
-    assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"  # nosec
+    assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"
 
     # Check NOT hatecrime
     page.check("#id_2-hate_crime_1")
 
     # Go to step 3
     next_step()
-    assert page.title() == "Step 3: Location - Contact the Civil Rights Division | Department of Justice"  # nosec
+    assert page.title() == "Step 3: Location - Contact the Civil Rights Division | Department of Justice"
 
     # Fill input[name="3-location_name"]
     page.fill("input[name='3-location_name']", "Test store")
@@ -95,14 +95,14 @@ def test_report_complete_and_valid_submission(page):
 
     # Go to step 4
     next_step()
-    assert page.title() == "Step 4: Personal characteristics - Contact the Civil Rights Division | Department of Justice"  # nosec
+    assert page.title() == "Step 4: Personal characteristics - Contact the Civil Rights Division | Department of Justice"
 
     # Check AGE
     page.check("#id_9-protected_class_0")
 
     # Go to step 5
     next_step()
-    assert page.title() == "Step 5: Date - Contact the Civil Rights Division | Department of Justice"  # nosec
+    assert page.title() == "Step 5: Date - Contact the Civil Rights Division | Department of Justice"
 
     # Fill input[name="10-last_incident_month"]
     page.fill("input[name='10-last_incident_month']", "1")
@@ -112,15 +112,15 @@ def test_report_complete_and_valid_submission(page):
 
     # Go to step 6
     next_step()
-    assert page.title() == "Step 6: Personal description - Contact the Civil Rights Division | Department of Justice"  # nosec
+    assert page.title() == "Step 6: Personal description - Contact the Civil Rights Division | Department of Justice"
 
     # Fill textarea[name="11-violation_summary"]
     page.fill("textarea[name='11-violation_summary']", "Test report submission")
 
     # Go to step 7
     next_step()
-    assert page.title() == "Step 7: Review - Contact the Civil Rights Division | Department of Justice"  # nosec
+    assert page.title() == "Step 7: Review - Contact the Civil Rights Division | Department of Justice"
 
     # Complete submission
     next_step()
-    assert page.title() == "Contact the Civil Rights Division | Department of Justice"  # nosec
+    assert page.title() == "Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -26,7 +26,10 @@ def test_error_if_form_refreshed(page, base_url):
 
     # Now we've got an error page on the original tab
     assert response.status == 422
-    assert "We're sorry, something went wrong." in response.text()
+    assert "We're sorry, something went wrong" in response.text()
+
+    # # First h1 on page is our test banner
+    # assert page.querySelectorAll('h1')[1].innerText() == "We're sorry, something went wrong"
 
 
 @pytest.mark.only_browser("chromium")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -28,9 +28,6 @@ def test_error_if_form_refreshed(page, base_url):
     assert response.status == 422
     assert "We're sorry, something went wrong" in response.text()
 
-    # # First h1 on page is our test banner
-    # assert page.querySelectorAll('h1')[1].innerText() == "We're sorry, something went wrong"
-
 
 @pytest.mark.only_browser("chromium")
 def test_report_complete_and_valid_submission(page):

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -73,6 +73,14 @@ def error_404(request, exception=None):
     )
 
 
+def error_422(request):
+    return render(
+        request,
+        'forms/error_422.html',
+        status=422
+    )
+
+
 def error_500(request, exception=None):
     return render(
         request,
@@ -822,6 +830,24 @@ class CRTReportWizard(SessionWizardView):
         _('Personal description'),
         _('Review'),
     ]
+
+    def form_refreshed(self):
+        """
+        True if the form and associated session data have been refreshed and cleared
+        which invalidates the submission and requires a user to restart the form.
+        """
+        form_current_step = self.request.POST.get('crt_report_wizard-current_step', None)
+        return (form_current_step != self.steps.current and self.storage.current_step is not None)
+
+    def post(self, *args, **kwargs):
+        """
+        Prior to handling the inbound request, check for and handle
+        session data which has been cleared while someone is progressing through
+        the form
+        """
+        if self.form_refreshed():
+            return error_422(self.request)
+        return super().post(*args, **kwargs)
 
     def get(self, request):
         if settings.MAINTENANCE_MODE:


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/824)

## What does this change?
If while progressing through the form, a user's session data has been cleared - commonly caused by refreshing the page or any other GET request to `/report/`- they'll need to restart the from.

The original issue here calls for catching the specific `KeyError` which led to our recognition of this issue. This approach differs in that we prevent the error from occurring by detecting "refreshes" as soon as possible in a user's submission of a report. 

We borrow the [approach](https://github.com/jazzband/django-formtools/blob/af200c06c224c2dcb16857203bcdf2c264d4a5b0/formtools/wizard/views.py#L285) of `django-form-tools` and examine the inbound management form contents, comparing to current state of the data to detect occurrences as soon as the first POST following a refresh.

When we've detected a refresh, we'll return a [422 error](https://http.cat/422) and messaging.

For testing, the error page is accessible directly in development environments at `/errors/422`. Manual testing can follow the user flow laid out the in playwright test implemented in this PR.

**Note**
This PR also updates our bandit execution to exclude our test suite from examination. Avoiding non-valuable results for `[B101:assert_used] Use of assert detected` when using pytest.
 
## Screenshots (for front-end PR):
Error page in EN:
<img width="817" alt="Screen Shot 2020-12-11 at 1 19 57 PM" src="https://user-images.githubusercontent.com/3485564/101939869-9af71180-3bb3-11eb-8b18-c23f93c13f95.png">

Error page in ES:
<img width="802" alt="Screen Shot 2020-12-11 at 1 20 33 PM" src="https://user-images.githubusercontent.com/3485564/101943136-97b25480-3bb8-11eb-9637-fb4fd6fec3a6.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
