### PR TITLE
Add playwright test for unsupported browser modal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
           path: ./pa11y-screenshots
       - run:
           name: E2E tests
-          command: pipenv run pytest crt_portal/cts_forms/tests/integration/report_submission.py --base-url=http://127.0.0.1:8000
+          command: pipenv run pytest crt_portal/cts_forms/tests/integration/*.py --base-url=http://127.0.0.1:8000
 
 # owasp scans on live sties
   owasp-scan-dev:

--- a/crt_portal/cts_forms/tests/integration/unsupported_browser.py
+++ b/crt_portal/cts_forms/tests/integration/unsupported_browser.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.fixture(scope="function")
 def browser_context_args(browser_context_args):
     return {
@@ -13,6 +14,6 @@ def test_unsupported_browser_modal_visible(page):
 
     page.goto("/report")
 
-    page.waitForSelector("text=NOTICE: Your mobile browser is not compatible with this form", 
-        state='visible', 
-        timeout=3000)
+    page.waitForSelector("text=NOTICE: Your mobile browser is not compatible with this form",
+                         state='visible',
+                         timeout=3000)

--- a/crt_portal/cts_forms/tests/integration/unsupported_browser.py
+++ b/crt_portal/cts_forms/tests/integration/unsupported_browser.py
@@ -1,0 +1,18 @@
+import pytest
+
+@pytest.fixture(scope="function")
+def browser_context_args(browser_context_args):
+    return {
+        **browser_context_args,
+        "userAgent": "SamsungBrowser/i"
+    }
+
+
+@pytest.mark.only_browser("chromium")
+def test_unsupported_browser_modal_visible(page):
+
+    page.goto("/report")
+
+    page.waitForSelector("text=NOTICE: Your mobile browser is not compatible with this form", 
+        state='visible', 
+        timeout=3000)

--- a/crt_portal/cts_forms/tests/integration/unsupported_browser.py
+++ b/crt_portal/cts_forms/tests/integration/unsupported_browser.py
@@ -5,7 +5,7 @@ import pytest
 def browser_context_args(browser_context_args):
     return {
         **browser_context_args,
-        "userAgent": "SamsungBrowser/i"
+        "userAgent": "SamsungBrowser"
     }
 
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/823)

## What does this change?
Adds a playwright test to assert the visibility of the unsupported browser modal when the user agent string indicates that the Samsung browser is in use. 

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
