### PR TITLE
Filter reports by contact email

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1025,6 +1025,7 @@ class Filters(ModelForm):
             'hate_crime',
             'servicemember',
             'intake_format',
+            'contact_email',
         ]
 
         labels = {
@@ -1041,6 +1042,7 @@ class Filters(ModelForm):
             'violation_summary': 'Personal description',
             'create_date_start': 'Created Date Start',
             'create_date_end': 'Created Date End',
+            'contact_email': 'Contact email',
         }
 
         widgets = {
@@ -1080,6 +1082,12 @@ class Filters(ModelForm):
                 'name': 'violation_summary',
                 'placeholder': 'Personal Description',
                 'aria-label': 'Personal Description'
+            }),
+            'contact_email': EmailInput(attrs={
+                'class': 'usa-input',
+                'name': 'contact_email',
+                'placeholder': 'Contact Email',
+                'aria-label': 'Contact Email', 
             }),
         }
         error_messages = {

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1087,7 +1087,7 @@ class Filters(ModelForm):
                 'class': 'usa-input',
                 'name': 'contact_email',
                 'placeholder': 'Contact Email',
-                'aria-label': 'Contact Email', 
+                'aria-label': 'Contact Email',
             }),
         }
         error_messages = {

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1086,7 +1086,7 @@ class Filters(ModelForm):
             'contact_email': EmailInput(attrs={
                 'class': 'usa-input',
                 'name': 'contact_email',
-                'placeholder': 'Email',
+                'placeholder': 'Contact Email',
                 'aria-label': 'Email',
             }),
         }

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1086,8 +1086,8 @@ class Filters(ModelForm):
             'contact_email': EmailInput(attrs={
                 'class': 'usa-input',
                 'name': 'contact_email',
-                'placeholder': 'Contact Email',
-                'aria-label': 'Contact Email',
+                'placeholder': 'Email',
+                'aria-label': 'Email',
             }),
         }
         error_messages = {

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -37,6 +37,7 @@
         {% include 'forms/complaint_view/index/filters/hate_crime.html' %}
         {% include 'forms/complaint_view/index/filters/servicemember.html' %}
         {% include 'forms/complaint_view/index/filters/intake_type.html' %}
+        {% include 'forms/complaint_view/index/filters/contact_email.html' %}
       </div>
     </div>
   </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/contact_email.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/contact_email.html
@@ -1,0 +1,9 @@
+{% extends "forms/complaint_view/index/filter-no-dropdown.html" %}
+
+{% block content %}
+  <div id="contact-email-filter" >
+    <label for="id_contact_email">
+      {{ form.contact_email }}
+    </label>
+  </div>
+{% endblock %}

--- a/crt_portal/cts_forms/templatetags/get_field_label.py
+++ b/crt_portal/cts_forms/templatetags/get_field_label.py
@@ -22,6 +22,7 @@ variable_rename = {
     'commercial_or_public_place': 'Relevant details',
     'reported_reason': 'Reported reason',
     'summary': 'Summary',
+    'contact_email': 'Contact email',
 }
 
 

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -361,6 +361,12 @@ class FormNavigationTests(TestCase):
         for index, report in enumerate(reports):
             report.assigned_section = sections[index % len(sections)]
             report.save()
+        # generate random reports associated with a different email address
+        reports = [Report.objects.create(**SAMPLE_REPORT) for _ in range(5)]
+        for report in reports:
+            report.assigned_section = 'VOT'
+            report.contact_email = 'SomeoneElse@usa.gov'
+            report.save()
 
     def test_basic_navigation(self):
         first = self.reports[-1]
@@ -421,6 +427,19 @@ class FormNavigationTests(TestCase):
         self.assertEquals(content.count('complaint-nav'), 2)
         self.assertEquals(content.count('disabled-nav'), 1)
 
+    def test_email_filtering(self):
+        first = self.reports[-1]
+        response = self.client.post(
+            reverse('crt_forms:crt-forms-show', kwargs={'id': first.id}),
+            {
+                'next': f'?per_page=15&contact_email=SomeoneElse@usa.gov',
+                'index': '1',
+                'type': ComplaintActions.CONTEXT_KEY,
+            },
+            follow=True
+        )
+        self.assertEquals(response.status_code, 200)
+        self.assertTrue('N/A of 5 records' in str(response.content))
 
 class PrintActionTests(TestCase):
     def setUp(self):

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -361,12 +361,6 @@ class FormNavigationTests(TestCase):
         for index, report in enumerate(reports):
             report.assigned_section = sections[index % len(sections)]
             report.save()
-        # generate random reports associated with a different email address
-        reports = [Report.objects.create(**SAMPLE_REPORT) for _ in range(5)]
-        for report in reports:
-            report.assigned_section = 'VOT'
-            report.contact_email = 'SomeoneElse@usa.gov'
-            report.save()
 
     def test_basic_navigation(self):
         first = self.reports[-1]
@@ -428,6 +422,13 @@ class FormNavigationTests(TestCase):
         self.assertEquals(content.count('disabled-nav'), 1)
 
     def test_email_filtering(self):
+        # generate random reports associated with a different email address
+        reports = [Report.objects.create(**SAMPLE_REPORT) for _ in range(5)]
+        for report in reports:
+            report.assigned_section = 'VOT'
+            report.contact_email = 'SomeoneElse@usa.gov'
+            report.save()
+
         first = self.reports[-1]
         response = self.client.post(
             reverse('crt_forms:crt-forms-show', kwargs={'id': first.id}),

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -432,7 +432,7 @@ class FormNavigationTests(TestCase):
         response = self.client.post(
             reverse('crt_forms:crt-forms-show', kwargs={'id': first.id}),
             {
-                'next': f'?per_page=15&contact_email=SomeoneElse@usa.gov',
+                'next': '?per_page=15&contact_email=SomeoneElse@usa.gov',
                 'index': '1',
                 'type': ComplaintActions.CONTEXT_KEY,
             },
@@ -440,6 +440,7 @@ class FormNavigationTests(TestCase):
         )
         self.assertEquals(response.status_code, 200)
         self.assertTrue('N/A of 5 records' in str(response.content))
+
 
 class PrintActionTests(TestCase):
     def setUp(self):

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -431,7 +431,7 @@
     textInputView({
       el: contactEmailEl,
       name: 'contact_email'
-    })
+    });
   }
 
   // Bootstrap the filter code's data persistence and

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -290,6 +290,8 @@
     var intakeFormatEl = dom.getElementsByName('intake_format');
     var hateCrimeEl = dom.getElementsByName('hate_crime');
     var servicememberEl = dom.getElementsByName('servicemember');
+    var contactEmailEl = dom.querySelector('input[name="contact_email"]');
+
     /**
      * Update the filter data model when the user clears (clicks on) a filter tag,
      * and perform a new search with the updated filters applied.
@@ -426,6 +428,10 @@
       el: servicememberEl,
       name: 'servicemember'
     });
+    textInputView({
+      el: contactEmailEl,
+      name: 'contact_email'
+    })
   }
 
   // Bootstrap the filter code's data persistence and


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/820)

## What does this change?
Adds contact email as a report filtering option. All other filters remain active when an email filter is specified.

## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/1425377/102249407-f3862180-3ec7-11eb-9c7e-65e92b86ec17.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
