### PR TITLE
Add frequent flyer count to view all table

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -24,6 +24,7 @@
           </th>
           <th></th>
           {% render_sortable_heading 'Status' sort_state filter_state %}
+          {% render_sortable_heading 'Total #' sort_state filter_state nowrap=True %}
           {% render_sortable_heading 'Routed' sort_state filter_state %}
           {% render_sortable_heading 'Submitted' sort_state filter_state %}
           {% render_sortable_heading 'Contact Name' sort_state filter_state %}
@@ -58,6 +59,11 @@
                   <span class="status-tag status-{{ datum.report.status }}">
                     {{ datum.report.status }}
                   </span>
+                </a>
+              </td>
+              <td>
+                <a class="td-link display-block" href="{{datum.url}}">
+                  {{ datum.email_report_count }}
                 </a>
               </td>
               <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.assigned_section }}</a></td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -63,7 +63,9 @@
               </td>
               <td>
                 <a class="td-link display-block" href="{{datum.url}}">
-                  {{ datum.email_report_count }}
+                  {% with count=datum.email_report_count|default:"—" %}
+                    {{ count }}
+                  {% endwith %}
                 </a>
               </td>
               <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.assigned_section }}</a></td>

--- a/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-<th scope="col" class="{% if sort_url %}sort-cell{% endif %}">
+<th scope="col" class="{% if sort_url %}sort-cell{% endif %}" {% if nowrap %}nowrap{% endif %}>
   {% if sort_url %}
     <a
       id="{{id}}"

--- a/crt_portal/cts_forms/templatetags/sortable_table_heading.py
+++ b/crt_portal/cts_forms/templatetags/sortable_table_heading.py
@@ -46,13 +46,14 @@ def sort_url_factory(heading, is_descending, filter_state):
 
 
 @register.inclusion_tag('forms/snippets/sortable_table_heading.html')
-def render_sortable_heading(heading, sort_state, filter_state):
+def render_sortable_heading(heading, sort_state, filter_state, nowrap=False):
     safe_heading = heading.lower()
     sortable_prop = sort_lookup.get(safe_heading, None)
 
     sort_dict = {
         'heading': heading,
-        'id': heading.lower().replace(' ', '-') + '-sort'
+        'id': heading.lower().replace(' ', '-') + '-sort',
+        'nowrap': nowrap
     }
 
     if sortable_prop in sortable_props:

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -760,4 +760,4 @@ class FiltersFormTests(TestCase):
             elif row['report'].contact_email == self.email2:
                 self.assertEqual(row['email_report_count'], 5)
             elif row['report'].contact_email is None:
-                self.assertEqual(row['email_report_count'], 8)
+                self.assertEqual(row['email_report_count'], None)

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -737,7 +737,7 @@ class FiltersFormTests(TestCase):
         for report in reports_email_1:
             report.contact_email = self.email1
             report.save()
-        
+
         # generate reports for a different email address
         reports_email_2 = [Report.objects.create(**SAMPLE_REPORT) for _ in range(5)]
         for report in reports_email_2:
@@ -761,5 +761,3 @@ class FiltersFormTests(TestCase):
                 self.assertEqual(row['email_report_count'], 5)
             elif row['report'].contact_email is None:
                 self.assertEqual(row['email_report_count'], 8)
-
-

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -301,8 +301,11 @@ def index_view(request):
             p_class_list = p_class_list[:3]
             p_class_list[2] = f'{p_class_list[2]}...'
 
+        email_report_count = Report.objects.filter(contact_email=report.contact_email).count()
+
         data.append({
             "report": report,
+            "email_report_count": email_report_count,
             "report_protected_classes": p_class_list,
             "url": f'{report.id}?next={all_args_encoded}&index={paginated_offset + index}',
         })


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/819)

## What does this change?
Adds a column to the view all table that displays the total number of reports associated with each row's contact email. This PR does **NOT** include the functionality to sort by the total report count.

## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/1425377/102379540-8f796100-3f8c-11eb-82b1-4a38ea120f03.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
