### PR TITLE
Revised Action ModelAdmin and export 

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -79,6 +79,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.postgres',
+    'actstream',
     'cts_forms',
     'compressor',
     'compressor_toolkit',
@@ -86,7 +87,6 @@ INSTALLED_APPS = [
     'formtools',
     # 'django_auth_adfs' in production only
     'crequest',
-    'actstream',
 ]
 SITE_ID = 1
 

--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -1,7 +1,7 @@
 import csv
 import logging
 
-from actstream.models import Action
+from actstream.models import Action, Follow
 from django.contrib import admin
 from django.core.paginator import Paginator
 from django.db.models import Prefetch
@@ -145,6 +145,7 @@ class ReportAdmin(ReadOnlyModelAdmin):
 
 class ActionAdmin(ReadOnlyModelAdmin):
     """Read-only admin for browsing and exporting raw activity log entries"""
+    search_fields = ['description']
     date_hierarchy = 'timestamp'
     list_display = ('timestamp', 'actor', 'verb', 'description', 'target')
     list_editable = ('verb',)
@@ -163,4 +164,5 @@ admin.site.register(Profile)
 
 # Activity stream already registers an Admin for Action, we want to replace it
 admin.site.unregister(Action)
+admin.site.unregister(Follow)
 admin.site.register(Action, ActionAdmin)

--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -1,10 +1,11 @@
 import csv
 import logging
 
+from actstream.models import Action
 from django.contrib import admin
 from django.core.paginator import Paginator
-from django.http import StreamingHttpResponse
 from django.db.models import Prefetch
+from django.http import StreamingHttpResponse
 
 from .models import (CommentAndSummary, HateCrimesandTrafficking, Profile,
                      ProtectedClass, Report, ResponseTemplate)
@@ -13,6 +14,22 @@ from .signals import get_client_ip
 logger = logging.getLogger(__name__)
 
 REPORT_FIELDS = [field.name for field in Report._meta.fields]
+ACTION_FIELDS = ['timestamp', 'actor', 'verb', 'description', 'target']
+
+
+class ReadOnlyModelAdmin(admin.ModelAdmin):
+    """Disable add, modify, and delete functionality"""
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        return request.user.is_superuser
 
 
 class Echo:
@@ -24,12 +41,12 @@ class Echo:
         return value
 
 
-def format_export_message(request, records):
+def format_export_message(request, records, what_was_exported):
     """Log user and # of records exported"""
     ip = get_client_ip(request) if request else 'CLI'
     username = request.user.username if request else 'CLI'
     userid = request.user.id if request else 'CLI'
-    return f'ADMIN ACTION by: {username} {userid} @ {ip}. Exported {records} reports as csv.'
+    return f'ADMIN ACTION by: {username} {userid} @ {ip}. Exported {records} {what_was_exported} as csv.'
 
 
 def iter_queryset(queryset, headers):
@@ -66,7 +83,14 @@ def _serialize_report_export(data):
     return data
 
 
-def export_as_csv(modeladmin, request, queryset):
+def _serialize_action(data):
+    """Preserve headers while rendering ACTION_FIELDS for inbound actions"""
+    if isinstance(data, Action):
+        return [getattr(data, field) for field in ACTION_FIELDS]
+    return data
+
+
+def export_reports_as_csv(modeladmin, request, queryset):
     """
     Stream all non-related fields,
     protected_class M2M,
@@ -86,12 +110,29 @@ def export_as_csv(modeladmin, request, queryset):
                                      content_type="text/csv")
     response['Content-Disposition'] = 'attachment; filename="report_export.csv"'
 
-    logger.info(format_export_message(request, queryset.count()))
+    logger.info(format_export_message(request, queryset.count(), 'reports'))
     return response
-export_as_csv.allowed_permissions = ('view',)  # noqa
+export_reports_as_csv.allowed_permissions = ('view',)  # noqa
 
 
-class ReportAdmin(admin.ModelAdmin):
+def export_actions_as_csv(modeladmin, request, queryset):
+    """
+    Stream actions as csv
+    Log all use
+    """
+    writer = csv.writer(Echo(), quoting=csv.QUOTE_ALL)
+    iterator = iter_queryset(queryset, ACTION_FIELDS)
+
+    response = StreamingHttpResponse((writer.writerow(_serialize_action(action)) for action in iterator),
+                                     content_type="text/csv")
+    response['Content-Disposition'] = 'attachment; filename="activity_export.csv"'
+
+    logger.info(format_export_message(request, queryset.count(), 'activity log entries'))
+    return response
+export_actions_as_csv.allowed_permissions = ('view',)  # noqa
+
+
+class ReportAdmin(ReadOnlyModelAdmin):
     """
     View-only report admin providing filtering and export functionality
     """
@@ -99,19 +140,18 @@ class ReportAdmin(admin.ModelAdmin):
     list_filter = ['status', 'create_date', 'modified_date', 'assigned_section', 'servicemember',
                    'hate_crime', 'primary_complaint', 'assigned_to']
     ordering = ['public_id']
-    actions = [export_as_csv]
+    actions = [export_reports_as_csv]
 
-    def has_add_permission(self, request):
-        return False
 
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
-
-    def has_view_permission(self, request, obj=None):
-        return request.user.is_superuser
+class ActionAdmin(ReadOnlyModelAdmin):
+    """Read-only admin for browsing and exporting raw activity log entries"""
+    date_hierarchy = 'timestamp'
+    list_display = ('timestamp', 'actor', 'verb', 'description', 'target')
+    list_editable = ('verb',)
+    list_filter = ('timestamp', 'verb')
+    raw_id_fields = ('actor_content_type', 'target_content_type',
+                     'action_object_content_type')
+    actions = [export_actions_as_csv]
 
 
 admin.site.register(CommentAndSummary)
@@ -120,3 +160,7 @@ admin.site.register(ProtectedClass)
 admin.site.register(HateCrimesandTrafficking)
 admin.site.register(ResponseTemplate)
 admin.site.register(Profile)
+
+# Activity stream already registers an Admin for Action, we want to replace it
+admin.site.unregister(Action)
+admin.site.register(Action, ActionAdmin)

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -209,7 +209,7 @@ class Report(models.Model):
         return date
 
     def __str__(self):
-        return f'{self.create_date} {self.violation_summary}'
+        return self.public_id
 
     def __has_immigration_protected_classes(self, pcs):
         immigration_classes = [

--- a/crt_portal/cts_forms/tests/test_admin.py
+++ b/crt_portal/cts_forms/tests/test_admin.py
@@ -1,0 +1,49 @@
+import csv
+
+from actstream.models import Action
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.test.client import Client
+from django.urls import reverse
+
+from ..admin import ACTION_FIELDS
+from ..forms import add_activity
+from ..models import Report
+from .test_data import SAMPLE_REPORT
+
+User = get_user_model()
+
+
+class ActionAdminTests(TestCase):
+
+    def setUp(self):
+        # We'll need a report and a handful of actions
+        self.client = Client()
+        self.superuser = User.objects.create_superuser('ACTION_EXPORT_TEST_USER', 'a@a.com', '')
+        self.report = Report.objects.create(**SAMPLE_REPORT)
+        self.url = reverse('admin:actstream_action_changelist')
+
+        [add_activity(self.superuser, 'verb', 'description', self.report) for _ in range(5)]
+
+    def test_action_csv_export(self):
+        """
+        Selecting Actions and triggering the `export_actions_as_csv`
+        action returns a StreamingHttpResponse containing a csv file
+        with headers and all selected actions
+        """
+        self.client.force_login(self.superuser)
+        form_data = {'action': 'export_actions_as_csv',
+                     '_selected_action': [action.id for action in Action.objects.all()]}
+        response = self.client.post(self.url, form_data)
+        # Read through the entire streamed response
+        rows = [r.decode('utf-8') for r in response.streaming_content]
+
+        # Parse the response as a csv
+        reader = csv.reader(rows)
+        exported_action_csv = [row for row in reader]
+
+        # Headers + 5 actions expected
+        self.assertEquals(len(exported_action_csv), 6)
+
+        # Headers match ACTION_FIELDS
+        self.assertEquals(exported_action_csv[0], ACTION_FIELDS)


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/821)

## What does this change?
Introducing a customized admin interface for `Actions` allowing authorized staff, `superusers`, to explore and export sets of `Actions` from the ActivityLog for analysis and investigation.

This uses the same [StreamingHttpResponse](https://docs.djangoproject.com/en/2.2/ref/request-response/) approach as exporting `Reports`.

## Screenshots (for front-end PR):
Example from local development environment and fake data
<img width="1303" alt="Screen Shot 2020-12-17 at 1 53 01 PM" src="https://user-images.githubusercontent.com/3485564/102530598-37fff180-406f-11eb-9a6b-80f7dcaf4142.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
