### PR TITLE
filtering: standardize on case insensitive matches

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -16,22 +16,22 @@ filter_options = {
     'primary_complaint': '__in',
     'status': '__in',
     'location_state': '__in',
-    'contact_first_name': '__contains',
-    'contact_last_name': '__contains',
-    'contact_email': '__search',
+    'contact_first_name': '__icontains',
+    'contact_last_name': '__icontains',
+    'contact_email': '__icontains',
     'other_class': '__search',
     'violation_summary': 'violation_summary',
-    'location_name': '__contains',
-    'location_city_town': '__contains',
-    'location_address_line_1': '__search',
-    'location_address_line_2': '__search',
+    'location_name': '__icontains',
+    'location_city_town': '__icontains',
+    'location_address_line_1': '__icontains',
+    'location_address_line_2': '__icontains',
     'create_date_start': '__gte',
     'create_date_end': '__lte',
     'closed_date_start': '__gte',
     'closed_date_end': '__lte',
     'modified_date_start': '__gte',
     'modified_date_end': '__lte',
-    'public_id': '__contains',
+    'public_id': '__icontains',
     'primary_statute': '__in',
     'assigned_to': 'foreign_key',
     'summary': 'summary',
@@ -79,7 +79,7 @@ def report_filter(querydict):
             elif filter_options[field] == '__search':
                 # takes one phrase
                 kwargs[f'{field}__search'] = querydict.getlist(field)[0]
-            elif filter_options[field] == '__contains':
+            elif filter_options[field] == '__icontains':
                 kwargs[f'{field}__icontains'] = querydict.getlist(field)[0]
             elif 'date' in field:
                 # filters by a start date or an end date expects yyyy-mm-dd


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/839)

## What does this change?

For filters, use `__search` sparingly, as this is for longer free form responses (with this PR we only use it for `other_class`). Otherwise, standardize on `__icontains` (note: case insensitive -- this was already the default but the code wasn't clear about this). 

![2020-12-18_11-15](https://user-images.githubusercontent.com/3013175/102652068-5c68d600-4122-11eb-874a-8a37c9974e69.png)

**Note: the above is fictional data**

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
