### PR TITLE
Add nonce to unsupported browser modal script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,23 @@ install-cf7: &install-cf7
       rm cf7.deb
       cf7 api https://api.fr.cloud.gov
 
+install-python-dependencies: &install-python-dependencies
+  run:
+    name: Install python dependencies
+    command: |
+      pip install -U pip
+      pip install pipenv
+      pipenv install
+
+install-python-dev-dependencies: &install-python-dev-dependencies
+  run:
+    name: Install python dev dependencies
+    command: |
+      pip install -U pip
+      pip install pipenv
+      pipenv install --dev
+      pipenv run python -m playwright install
+
 version: 2
 jobs:
   build_and_test: # runs not using Workflows must have a `build` job as entry point
@@ -51,14 +68,10 @@ jobs:
             - pip-packages-v1-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
             - pip-packages-v1-{{ .Branch }}-
             - pip-packages-v1-
+      - *install-python-dev-dependencies
       - run:
-          name: Python install with pipenv then migrate the database
-          command: |
-            pip install -U pip
-            pip install pipenv
-            pipenv install --dev
-            pipenv run crt_portal/manage.py migrate
-            pipenv run python -m playwright install
+          name: Migrate the database
+          command: pipenv run crt_portal/manage.py migrate
       - save_cache:
           paths:
             - /home/circleci/code/.venv # this path depends on where pipenv creates a virtualenv
@@ -167,13 +180,8 @@ jobs:
             rm -rf /var/lib/apt/lists/*
             npm ci --production
             node node_modules/gulp/bin/gulp build-sass
-      - run:
-          # database will be migrated in cloud.gov
-          name: Python install with pipenv
-          command: |
-            pip install -U pip
-            pip install pipenv
-            pipenv install
+      # database will be migrated in cloud.gov
+      - *install-python-dependencies
       - run:
           name: Install cloud foundry deploy tools
           command: |
@@ -191,6 +199,8 @@ jobs:
           name: Deploy to dev
           command: |
               ./blue-green-deploy.sh $CRT_USERNAME_DEV $CRT_PASSWORD_DEV dev
+      # install dev dependencies to enable E2E test run
+      - *install-python-dev-dependencies
       - run:
           name: Post-deploy E2E tests
           command: pipenv run pytest crt_portal/cts_forms/tests/integration/*.py --base-url=https://crt-portal-django-dev.app.cloud.gov
@@ -225,13 +235,8 @@ jobs:
             rm -rf /var/lib/apt/lists/*
             npm ci --production
             node node_modules/gulp/bin/gulp build-sass
-      - run:
-          # database will be migrated in cloud.gov
-          name: Python install with pipenv
-          command: |
-            pip install -U pip
-            pip install pipenv
-            pipenv install
+      # database will be migrated in cloud.gov
+      - *install-python-dependencies
       - run:
           name: Install cloud foundry deploy tools
           command: |
@@ -249,6 +254,8 @@ jobs:
           name: Deploy to stage
           command: |
             ./blue-green-deploy.sh $CRT_USERNAME_STAGE $CRT_PASSWORD_STAGE staging
+      # install dev dependencies to enable E2E test run
+      - *install-python-dev-dependencies
       - run:
           name: Post-deploy E2E tests
           command: pipenv run pytest crt_portal/cts_forms/tests/integration/*.py --base-url=https://crt-portal-django-stage.app.cloud.gov
@@ -284,13 +291,8 @@ jobs:
             rm -rf /var/lib/apt/lists/*
             npm ci --production
             node node_modules/gulp/bin/gulp build-sass
-      - run:
-          # database will be migrated in cloud.gov
-          name: Python install with pipenv
-          command: |
-            pip install -U pip
-            pip install pipenv
-            pipenv install
+      # database will be migrated in cloud.gov
+      - *install-python-dependencies
       - run:
           name: Install cloud foundry deploy tools
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,9 @@ jobs:
           name: Deploy to dev
           command: |
               ./blue-green-deploy.sh $CRT_USERNAME_DEV $CRT_PASSWORD_DEV dev
+      - run:
+          name: Post-deploy E2E tests
+          command: pipenv run pytest crt_portal/cts_forms/tests/integration/*.py --base-url=https://crt-portal-django-dev.app.cloud.gov
 
   deploy-stage:
     working_directory: ~/code
@@ -246,6 +249,9 @@ jobs:
           name: Deploy to stage
           command: |
             ./blue-green-deploy.sh $CRT_USERNAME_STAGE $CRT_PASSWORD_STAGE staging
+      - run:
+          name: Post-deploy E2E tests
+          command: pipenv run pytest crt_portal/cts_forms/tests/integration/*.py --base-url=https://crt-portal-django-stage.app.cloud.gov
 
   deploy-prod:
     working_directory: ~/code

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -126,7 +126,7 @@
 <script src="{% static 'js/word_count.js' %}"></script>
 <script src="{% static 'js/modal.js' %}"></script>
 <script src="{% static 'js/unsupported_browsers.js' %}"></script>
-<script>
+<script nonce="{{request.csp_nonce}}">
   (function(root) {
     if (root.CRT.isUnsupportedBrowser()) {
       var modal = document.getElementById('unsupported_browser_modal');


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/823)

## What does this change?
Adds a nonce to the inline script that displays the unsupported browser modal at `/reports`

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
