### PR TITLE
Disable Django Debug Toolbar during test runs

### DIFF
--- a/crt_portal/crt_portal/local_settings.py
+++ b/crt_portal/crt_portal/local_settings.py
@@ -16,3 +16,4 @@ SECRET_KEY = os.getenv('SECRET_KEY')
 # This setting will only be used in local development
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '10.0.2.2', '0.0.0.0']  # nosec
 DEBUG = True
+ENABLE_DEBUG_TOOLBAR = True

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -379,8 +379,7 @@ LOGGING = {
 if environment == 'LOCAL':
     from .local_settings import *  # noqa: F401,F403
 
-IS_RUNNING_TEST_SUITE = (os.path.basename(sys.argv[0]) == 'manage.py'
-                        and len(sys.argv) > 1 and sys.argv[1] == 'test')
+IS_RUNNING_TEST_SUITE = (os.path.basename(sys.argv[0]) == 'manage.py' and len(sys.argv) > 1 and sys.argv[1] == 'test')
 
 # Django debug toolbar setup
 if DEBUG and not IS_RUNNING_TEST_SUITE:

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import json
 import os
-import sys
 
 import boto3
 from django.utils.log import DEFAULT_LOGGING

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -28,6 +28,7 @@ environment = os.environ.get('ENV', 'UNDEFINED')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DEBUG', False)
+ENABLE_DEBUG_TOOLBAR = os.environ.get('ENABLE_DEBUG_TOOLBAR', False)
 MAINTENANCE_MODE = os.environ.get('MAINTENANCE_MODE', False)
 
 
@@ -379,10 +380,8 @@ LOGGING = {
 if environment == 'LOCAL':
     from .local_settings import *  # noqa: F401,F403
 
-IS_RUNNING_TEST_SUITE = (os.path.basename(sys.argv[0]) == 'manage.py' and len(sys.argv) > 1 and sys.argv[1] == 'test')
-
 # Django debug toolbar setup
-if DEBUG and not IS_RUNNING_TEST_SUITE:
+if ENABLE_DEBUG_TOOLBAR:
     INSTALLED_APPS += ['debug_toolbar', ]
     MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware', ] + MIDDLEWARE
     DEBUG_TOOLBAR_CONFIG = {'SHOW_TOOLBAR_CALLBACK': lambda _: True}

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import json
 import os
+import sys
 
 import boto3
 from django.utils.log import DEFAULT_LOGGING
@@ -378,8 +379,11 @@ LOGGING = {
 if environment == 'LOCAL':
     from .local_settings import *  # noqa: F401,F403
 
+IS_RUNNING_TEST_SUITE = (os.path.basename(sys.argv[0]) == 'manage.py'
+                        and len(sys.argv) > 1 and sys.argv[1] == 'test')
+
 # Django debug toolbar setup
-if DEBUG:
+if DEBUG and not IS_RUNNING_TEST_SUITE:
     INSTALLED_APPS += ['debug_toolbar', ]
     MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware', ] + MIDDLEWARE
     DEBUG_TOOLBAR_CONFIG = {'SHOW_TOOLBAR_CALLBACK': lambda _: True}

--- a/crt_portal/crt_portal/urls.py
+++ b/crt_portal/crt_portal/urls.py
@@ -87,10 +87,14 @@ handler501 = 'cts_forms.views.error_501'
 handler502 = 'cts_forms.views.error_502'
 handler503 = 'cts_forms.views.error_503'
 
-if settings.DEBUG:
+if settings.ENABLE_DEBUG_TOOLBAR:
     import debug_toolbar
     urlpatterns += [
         path('__debug__/', include(debug_toolbar.urls)),
+    ]
+
+if settings.DEBUG:
+    urlpatterns += [
         path('errors/404', error_404),
         path('errors/422', error_422),
         path('errors/500', error_500),


### PR DESCRIPTION
## What does this change?
Related to #778 - Django test runs are run with `DEBUG=False`, regardless of what you specify in `settings`. This leads to url reversing issues when running tests locally, due to the fact that we toggle the django-debug-toolbar based on this setting. 

This is one option - disable the toolbar when executing tests. We could alternatively use a new setting (i.e. not `DEBUG`) to toggle the toolbar.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
