### PR TITLE
Don't print Total Reports card

### DIFF
--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -417,5 +417,4 @@ PRINT_CHOICES = (
     ('description', 'Personal Description'),
     ('activity', 'Activity'),
     ('summary', 'Summary'),
-    ('related_reports', "Related Reports"),
 )

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/related_reports.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/related_reports.html
@@ -3,11 +3,11 @@
 {% load all_sections %}
 
 {% block title %}{{title}}{% endblock %}
-{% block extra_classes %}crt-related-reports-card{% endblock %}
+{% block extra_classes %}crt-action-card related-reports-card{% endblock %}
 {% block extra_title %}
     {% if data.related_reports %}
         <small class="margin-left-auto">
-            <a class="related-reports" href="{% url 'crt_forms:crt-forms-index' %}?contact_email={{data.contact_email}}{% filter_for_all_sections %}">
+            <a href="{% url 'crt_forms:crt-forms-index' %}?contact_email={{data.contact_email}}{% filter_for_all_sections %}">
                 View All ({{data.related_reports|length}})
             </a>
         </small>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/related_reports.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/related_reports.html
@@ -3,11 +3,11 @@
 {% load all_sections %}
 
 {% block title %}{{title}}{% endblock %}
-{% block extra_classes %}crt-action-card related-reports-card{% endblock %}
+{% block extra_classes %}crt-related-reports-card{% endblock %}
 {% block extra_title %}
     {% if data.related_reports %}
         <small class="margin-left-auto">
-            <a href="{% url 'crt_forms:crt-forms-index' %}?contact_email={{data.contact_email}}{% filter_for_all_sections %}">
+            <a class="related-reports" href="{% url 'crt_forms:crt-forms-index' %}?contact_email={{data.contact_email}}{% filter_for_all_sections %}">
                 View All ({{data.related_reports|length}})
             </a>
         </small>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/related_reports.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/related_reports.html
@@ -5,7 +5,7 @@
 {% block title %}{{title}}{% endblock %}
 {% block extra_classes %}crt-related-reports-card{% endblock %}
 {% block extra_title %}
-    {% if data.related_reports %}
+    {% if data.related_reports and data.related_reports|length > 1 %}
         <small class="margin-left-auto">
             <a class="related-reports" href="{% url 'crt_forms:crt-forms-index' %}?contact_email={{data.contact_email}}{% filter_for_all_sections %}">
                 View All ({{data.related_reports|length}})

--- a/crt_portal/static/js/print_report.js
+++ b/crt_portal/static/js/print_report.js
@@ -5,8 +5,7 @@
     id_options_1: '.crt-report-card',
     id_options_2: '.crt-description-card',
     id_options_3: '.crt-activities-card',
-    id_options_4: '.crt-summary-card',
-    id_options_5: '.crt-related-reports-card'
+    id_options_4: '.crt-summary-card'
   };
 
   var modal = document.getElementById('print_report');

--- a/crt_portal/static/sass/custom/card.scss
+++ b/crt_portal/static/sass/custom/card.scss
@@ -121,7 +121,7 @@
 }
 
 
-.related-reports-card {
+.crt-related-reports-card {
   max-height: 450px;
   overflow-y: scroll;
 }

--- a/crt_portal/static/sass/custom/card.scss
+++ b/crt_portal/static/sass/custom/card.scss
@@ -121,7 +121,7 @@
 }
 
 
-.crt-related-reports-card {
+.related-reports-card {
   max-height: 450px;
   overflow-y: scroll;
 }

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -29,6 +29,8 @@
   .activity-stream,
   // - hide related report `view all (#) links
   a.related-reports,
+  // - always hide the related reports card
+  .crt-related-reports-card,
   // - always hide the warning banner.
   .crt-header--warning-pii {
     display: none;


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/834)

## What does this change?
When printing a report, the Total Reports card is hidden.
View all link on `Total Reports` table only shown if there are at least 2 reports.
 
## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
