### PR TITLE
Remove Touchpoints form from Primary Concern page

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
+++ b/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
@@ -31,5 +31,4 @@
 {% block page_js %}
   {{ block.super }}
   <script src="{% static 'js/primary_complaint.js' %}"></script>
-  <script src="https://touchpoints.app.cloud.gov/touchpoints/e0517981/js" async></script>
 {% endblock %}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/866)

## What does this change?
Removes the Touchpoint form from the Primary Concern page.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
