### PR TITLE
de-duplicate "your name" section

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_data.html
+++ b/crt_portal/cts_forms/templates/forms/report_data.html
@@ -8,13 +8,9 @@
         <h2 class="h1 margin-top-0 margin-bottom-0">{{ordered_step_names.0}}</h2>
 
         <div class="question">
-          <h3 class="crt-portal-card__subheader">{{ question.contact.contact_name_title }}</h3>
-            <h4>{% trans "Your name" %}</h4>
-            <p>{{ report.contact_first_name|default:"-" }} {{ report.contact_last_name|default:"-" }}</p>
-        </div>
-
-        <div class="question">
           <h3 class="crt-portal-card__subheader">{{ question.contact.contact_title }}</h3>
+          <h4>{% trans "Your name" %}</h4>
+          <p>{{ report.contact_first_name|default:"-" }} {{ report.contact_last_name|default:"-" }}</p>
 
           <h4>{{ question.contact.contact_email }}</h4>
           <p>{{ report.contact_email|default:"-" }}</p>


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/873)

## What does this change?

"Your name" was repeated twice. Moved to under the "Contact" section. We still have a slight duplication of "Contact" vs "Contact Information", but Aviva and I agree that this is OK for now.

## Screenshots (for front-end PR):

Before hitting submission:

![2021-01-28_12-40](https://user-images.githubusercontent.com/3013175/106196430-44936180-6166-11eb-8b12-891b7e1e205b.png)

Confirmation page:

![2021-01-28_12-41](https://user-images.githubusercontent.com/3013175/106196428-42c99e00-6166-11eb-857e-800fbe7d7ed1.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
