### PR TITLE
Hotfix/bulk edit error

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1484,7 +1484,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         comment_string = updated_data.pop('comment', None)
         summary_string = updated_data.pop('summary', None)
 
-        # rebuild the reports queryset w/o annotations to avoid error on update
+        # rebuild the reports queryset w/o sorts and annotations to avoid error on update
         report_ids = reports.values_list('pk', flat=True)
         reports = Report.objects.filter(pk__in=report_ids)
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1496,7 +1496,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
                 'report': report,
                 'verb': v,
                 'description': d
-            } for (v,d) in self.get_actions(report)])
+            } for (v, d) in self.get_actions(report)])
 
         if comment_string:
             kwargs = {

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -608,7 +608,7 @@ class BulkActionsTests(TestCase):
         self.test_pass = secrets.token_hex(32)
         self.user = User.objects.create_user('DELETE_USER', 'ringo@thebeatles.com', self.test_pass)
         self.client.login(username='DELETE_USER', password=self.test_pass)
-        self.reports = [Report.objects.create(**SAMPLE_REPORT) for _ in range(16)]
+        self.reports = ReportFactory.create_batch(16, assigned_section='ADM', status='new')
 
     def get(self, ids, all_ids=False):
         params = {
@@ -669,9 +669,9 @@ class BulkActionsTests(TestCase):
         first_id = content.index('<div class="bulk-print-report">')
         self.assertTrue(first_all > first_id)
 
-    def post(self, ids, all_ids=False, confirm=False, **extra):
+    def post(self, ids, all_ids=False, confirm=False, return_url_args='', **extra):
         params = {
-            'next': '?per_page=15',
+            'next': f'?per_page=15&{return_url_args}',
             'ids': ','.join([str(id) for id in ids]),
             **extra,
         }
@@ -748,6 +748,16 @@ class BulkActionsTests(TestCase):
             last_activity = list(report.target_actions.all())[-1]
             self.assertEquals(last_activity.verb, "Added comment: ")
             self.assertEquals(last_activity.description, 'a comment')
+            self.assertEquals(last_activity.actor, self.user)
+
+    def test_post_with_email_count_sort(self):
+        ids = [report.id for report in self.reports]
+        response = self.post(ids, all_ids=True, confirm=True, return_url_args='sort=-email_count', comment='email count sort', status='closed')
+        for report_id in ids:
+            report = Report.objects.get(id=report_id)
+            last_activity = list(report.target_actions.all())[-1]
+            self.assertEquals(last_activity.verb, 'Status:')
+            self.assertEquals(last_activity.description, 'Updated from "new" to "closed"')
             self.assertEquals(last_activity.actor, self.user)
 
 

--- a/crt_portal/cts_forms/tests/test_forms.py
+++ b/crt_portal/cts_forms/tests/test_forms.py
@@ -752,7 +752,7 @@ class BulkActionsTests(TestCase):
 
     def test_post_with_email_count_sort(self):
         ids = [report.id for report in self.reports]
-        response = self.post(ids, all_ids=True, confirm=True, return_url_args='sort=-email_count', comment='email count sort', status='closed')
+        self.post(ids, all_ids=True, confirm=True, return_url_args='sort=-email_count', comment='email count sort', status='closed')
         for report_id in ids:
             report = Report.objects.get(id=report_id)
             last_activity = list(report.target_actions.all())[-1]


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/878)

## What does this change?
Avoids a `FieldError` that was preventing users from bulk updating Reports while sorting on `email_count`.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
