### PR TITLE
Whitelist .msg file attachments

### DIFF
--- a/crt_portal/cts_forms/attachments.py
+++ b/crt_portal/cts_forms/attachments.py
@@ -1,8 +1,10 @@
 MAX_FILE_SIZE_MB = 100
 ALLOWED_CONTENT_TYPES = [
     'application/msword',
+    'application/octet-stream',
     'application/pdf',
     'application/vnd.ms-excel',
+    'application/vnd.ms-outlook',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     'audio/mpeg',
@@ -28,6 +30,7 @@ ALLOWED_FILE_EXTENSIONS = [
     '.jpeg',
     '.jpg',
     '.mp3',
+    '.msg',
     '.png',
     '.tif',
     '.txt',

--- a/crt_portal/cts_forms/tests/test_validators.py
+++ b/crt_portal/cts_forms/tests/test_validators.py
@@ -5,7 +5,15 @@ from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.test import TestCase
 from unittest.mock import patch
 
-from ..validators import validate_file_infection, validate_file_size, validate_content_type, validate_file_extension
+from ..attachments import (
+    ALLOWED_CONTENT_TYPES,
+)
+from ..validators import (
+    validate_file_infection,
+    validate_file_size,
+    validate_content_type,
+    validate_file_extension
+)
 
 
 class MockHttpResponse:
@@ -76,14 +84,26 @@ class FileWrapper:
 
 class TestFileContentTypeValidator(TestCase):
     def test_file_size_contenttype_ok(self):
-        file = FileWrapper(TemporaryUploadedFile('file.txt', 'text/plain', 10000, 'utf-8'))
-        validate_content_type(file)
+        for content_type in ALLOWED_CONTENT_TYPES:
+            file = FileWrapper(TemporaryUploadedFile('file', content_type, 10000, 'utf-8'))
+            validate_content_type(file)
 
     def test_file_size_contenttype_bad(self):
-        file = FileWrapper(TemporaryUploadedFile('file.zip', 'application/zip', 10000, 'utf-8'))
+        some_bad_content_types = [
+            'application/gzip',
+            'application/vnd.rar',
+            'application/x-7z-compressed',
+            'application/x-httpd-php',
+            'application/x-sh',
+            'application/x-tar',
+            'application/zip',
+            'text/javascript',
+        ]
+        for content_type in some_bad_content_types:
+            file = FileWrapper(TemporaryUploadedFile('file', content_type, 10000, 'utf-8'))
 
-        with self.assertRaises(ValidationError):
-            validate_content_type(file)
+            with self.assertRaises(ValidationError):
+                validate_content_type(file)
 
 
 class TestFileExtensionValidator(TestCase):


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/896)

## What does this change?

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
