### PR TITLE
Reduce number of database hits for rendering individual report pages

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -314,7 +314,7 @@ class Report(models.Model):
         return self.status == CLOSED_STATUS
 
     def activity(self):
-        return self.target_actions.exclude(verb__contains='comment:')
+        return self.target_actions.exclude(verb__contains='comment:').prefetch_related('actor')
 
     def closeout_report(self):
         """
@@ -339,9 +339,13 @@ class Report(models.Model):
     def related_reports_display(self):
         """Return set of related reports grouped by STATUS for template rendering"""
         reports = self.related_reports
-        return (('new', reports.filter(status='new')),
-                ('open', reports.filter(status='open')),
-                ('closed', reports.filter(status='closed')),
+        display = {'new': [], 'open': [], 'closed': []}
+        for report in reports:
+            display[report.status].append(report)
+
+        return (('new', display['new']),
+                ('open', display['open']),
+                ('closed', display['closed']),
                 )
 
     @property

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -232,7 +232,7 @@ def setup_filter_parameters(report, querydict):
             return {}
 
         output.update({
-            'filter_count': requested_query.count(),
+            'filter_count': len(requested_ids),
             'filter_previous': previous_id,
             'filter_next': next_id,
             'filter_previous_query': f'?next={next_query}&index={index - 1}',
@@ -354,7 +354,7 @@ def serialize_data(report, request, report_id):
         'attachment_actions': AttachmentActions(),
         'comments': CommentActions(),
         'print_options': PrintActions(),
-        'activity_stream': report.target_actions.all(),
+        'activity_stream': report.target_actions.all().prefetch_related('actor'),
         'attachments': report.attachments.all(),
         'crimes': crimes,
         'data': report,


### PR DESCRIPTION
Incremental progress for [Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/895)

## What does this change?
Detaches the number of database queries required to render an individual report page from the number of Activity log entries and grabs related reports in a single query instead of 3. 

## Screenshots (for front-end PR):
Before on a report with ~10 activity log entries.
![Screen Shot 2021-03-03 at 1 18 35 PM](https://user-images.githubusercontent.com/3485564/109853607-10f39d80-7c24-11eb-9c96-15e7c466205b.png)

After, on the same report.
![Screen Shot 2021-03-03 at 1 19 00 PM](https://user-images.githubusercontent.com/3485564/109853639-1d77f600-7c24-11eb-9c01-cfe58bda3647.png)


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
