### PR TITLE
Make clamav-rest routes unique across spaces

### DIFF
--- a/manifest_dev.yaml
+++ b/manifest_dev.yaml
@@ -11,7 +11,7 @@ applications:
     NEW_RELIC_ENVIRONMENT: dev
     NEW_RELIC_APP_NAME: CRT PORTAL (dev)
     NEW_RELIC_LOG: stdout
-    AV_SCAN_URL: http://clamav-rest.apps.internal:9000/scan
+    AV_SCAN_URL: http://clamav-rest-dev.apps.internal:9000/scan
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack
@@ -28,4 +28,4 @@ applications:
   docker:
     image: ajilaag/clamav-rest:20201028
   routes:
-  - route: clamav-rest.apps.internal
+  - route: clamav-rest-dev.apps.internal

--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -15,7 +15,7 @@ applications:
     NEW_RELIC_ENVIRONMENT: production
     NEW_RELIC_APP_NAME: CRT PORTAL (prod)
     NEW_RELIC_LOG: stdout
-    AV_SCAN_URL: http://clamav-rest.apps.internal:9000/scan
+    AV_SCAN_URL: http://clamav-rest-prod.apps.internal:9000/scan
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack
@@ -32,4 +32,4 @@ applications:
   docker:
     image: ajilaag/clamav-rest:20201028
   routes:
-  - route: clamav-rest.apps.internal
+  - route: clamav-rest-prod.apps.internal

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -14,7 +14,7 @@ applications:
     NEW_RELIC_ENVIRONMENT: staging
     NEW_RELIC_APP_NAME: CRT PORTAL (stage)
     NEW_RELIC_LOG: stdout
-    AV_SCAN_URL: http://clamav-rest.apps.internal:9000/scan
+    AV_SCAN_URL: http://clamav-rest-staging.apps.internal:9000/scan
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack
@@ -31,4 +31,4 @@ applications:
   docker:
     image: ajilaag/clamav-rest:20201028
   routes:
-  - route: clamav-rest.apps.internal
+  - route: clamav-rest-staging.apps.internal


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?
While deploying the `clamav-rest` application to staging on 3-4-2021, we encountered the following error:

`For application 'clamav-rest': Routes cannot be mapped to destinations in different spaces
FAILED`

This suggests that the internal routes we configure for `clamav-rest` need to be unique across spaces (e.g., `clamav-rest-dev.apps.internal`, `clamav-rest-staging.apps.internal`, etc).

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
