### PR TITLE
voting module change in primary concern page

### DIFF
--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -13,11 +13,12 @@ SERVICEMEMBER_CHOICES = (
 SERVICEMEMBER_ERROR = _('Please select a status as an active duty service member.')
 
 PRIMARY_COMPLAINT_CHOICES = (
-    ('voting', _('Voting rights or ability to vote affected')),
+
     ('workplace', _('Workplace discrimination or other employment-related problem')),
     ('housing', _('Housing discrimination or harassment')),
     ('education', _('Discrimination at a school, educational program or service, or related to receiving education')),
     ('police', _('Mistreated by police, correctional staff, or inmates')),
+    ('voting', _('Voting rights or ability to vote affected')),
     ('commercial_or_public', _('Discriminated against in a commercial location or public place')),
     ('something_else', _('Something else happened')),
 )

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -71,7 +71,7 @@ def test_report_complete_and_valid_submission(page):
     assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"
 
     # Check voting
-    page.check("#id_1-primary_complaint_0")
+    page.check("#id_1-primary_complaint_4")
 
     # Go to step 2-2
     next_step()


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/880)

## What does this change?
move voting module from top to 5th place on primary concern page.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
