### PR TITLE
Update proform followup question mapping

### DIFF
--- a/crt_portal/static/js/pro_form_show_hide.js
+++ b/crt_portal/static/js/pro_form_show_hide.js
@@ -4,12 +4,12 @@
   function toggleFollowUpQuestions(event) {
     var primary_complaint_id = event.target.id;
     var predicate_target_mapping = {
-      'id_0-primary_complaint_1': [
+      'id_0-primary_complaint_0': [
         'div-id_0-public_or_private_employer_0',
         'div-id_0-employer_size_0'
       ],
-      'id_0-primary_complaint_3': ['div-id_0-public_or_private_school_0'],
-      'id_0-primary_complaint_4': [
+      'id_0-primary_complaint_2': ['div-id_0-public_or_private_school_0'],
+      'id_0-primary_complaint_3': [
         'div-id_0-inside_correctional_facility_0',
         'div-id_0-correctional_facility_type_0'
       ],


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/880)

## What does this change?
When we updated the ordering of primary concerns as part of card 880, we did not update the mapping between primary concerns and followup questions on the proform. This resulted in irrelevant (or no) followup questions being displayed after selecting the primary concern. This PR updates the mapping to accommodate the new concern ordering. 

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
