### PR TITLE
Submission confirmation page title change

### DIFF
--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -1,6 +1,17 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
+{% get_current_language as LANGUAGE_CODE %}
+
+
+{% block page_title %}
+ <!-- needs translation update   -->
+  {% if  LANGUAGE_CODE == 'en' %}
+    <title>{% trans "Submission complete" %}</title>
+  {% else %}
+    <title> {% trans "Contact the Civil Rights Division | Department of Justice" %} </title>
+  {% endif %}
+{% endblock %}
 
 {% block body_class %}class="confirmation-page"{% endblock %}
 

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -123,4 +123,4 @@ def test_report_complete_and_valid_submission(page):
 
     # Complete submission
     next_step()
-    assert page.title() == "Contact the Civil Rights Division | Department of Justice"
+    assert page.title() == "Submission complete"


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/881)

## What does this change?
Confirmation page title change to 'Submission complete'.
For other language we are keeping the original title for tracking purpose.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
