### PR TITLE
`Submission complete` Spanish translation

### DIFF
--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-17 16:54+0000\n"
+"POT-Creation-Date: 2021-03-18 18:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -296,8 +296,8 @@ msgid ""
 "Denied an accommodation for a disability, including not being allowed to "
 "have a service animal <strong>in the workplace</strong>"
 msgstr ""
-"Denegado/a un acomodo para una discapacidad, incluyendo el no poder tener "
-"un animal de servicio <strong>en un lugar de trabajo</strong>"
+"Denegado/a un acomodo para una discapacidad, incluyendo el no poder tener un "
+"animal de servicio <strong>en un lugar de trabajo</strong>"
 
 #: model_variables.py:62
 msgid ""
@@ -326,7 +326,8 @@ msgid ""
 "have a service or assistance animal <strong>in public housing</strong>"
 msgstr ""
 "Denegado/a un acomodo para una discapacidad, incluyendo el no tener permiso "
-"para tener un animal de servicio o de asistencia <strong>en una vivienda pública</strong>"
+"para tener un animal de servicio o de asistencia <strong>en una vivienda "
+"pública</strong>"
 
 #: model_variables.py:68
 msgid "Harassment based on race, sex, national origin, disability, or religion"
@@ -417,7 +418,8 @@ msgid ""
 "have a service animal <strong>in a commercial or public location</strong>"
 msgstr ""
 "Denegado/a un acomodo para una discapacidad, incluyendo el no tener permiso "
-"para tener un animal de servicio <strong>en un lugar comercial o público</strong>"
+"para tener un animal de servicio <strong>en un lugar comercial o público</"
+"strong>"
 
 #: model_variables.py:92
 msgid ""
@@ -1326,7 +1328,7 @@ msgstr "obligatorio"
 
 #: templates/forms/confirmation.html:10
 msgid "Submission complete"
-msgstr ""
+msgstr "Envío completo"
 
 #: templates/forms/confirmation.html:25 templates/forms/confirmation.html:31
 #: templates/forms/portal/header.html:3

--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -5,12 +5,7 @@
 
 
 {% block page_title %}
- <!-- needs translation update   -->
-  {% if  LANGUAGE_CODE == 'en' %}
-    <title>{% trans "Submission complete" %}</title>
-  {% else %}
-    <title> {% trans "Contact the Civil Rights Division | Department of Justice" %} </title>
-  {% endif %}
+  <title>{% trans "Submission complete" %}</title>
 {% endblock %}
 
 {% block body_class %}class="confirmation-page"{% endblock %}


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/909)

## What does this change?
Adds the Spanish translation for "Submission complete", which is the page title for the report submission confirmation page.

## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/1425377/111678345-2e149880-87ee-11eb-8859-489cf7a995be.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
