### PR TITLE
added footer back to hate crime modal form page

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_hate_crime.html
+++ b/crt_portal/cts_forms/templates/forms/report_hate_crime.html
@@ -23,8 +23,11 @@
 </div>
 {% endblock %}
 
-{% block usa_footer %}
+{% block footer_extra %}
   {% include "partials/redirect-modal.html" %}
+  <div class="privacy-footer">
+    {% include "partials/policy.html" %}
+  </div>
 {% endblock %}
 
 {% block page_js %}

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -78,9 +78,6 @@ def test_report_complete_and_valid_submission(page):
     assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"
 
     # Check footer exist
-    # assert page.footer() == "Links"
-
-    # Check footer exist
     content = page.text_content("footer")
 
     assert "Links" in content

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -77,6 +77,16 @@ def test_report_complete_and_valid_submission(page):
     next_step()
     assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"
 
+    # Check footer exist
+    assert page.footer() == "Links"
+
+    # Check footer exist
+    content = page.text_content("footer")
+    assert content == "Links"
+
+    # Check privacy footer
+    assert page.footer("privacy-footer") == "Privacy Policy"
+
     # Check NOT hatecrime
     page.check("#id_2-hate_crime_1")
 

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -82,10 +82,11 @@ def test_report_complete_and_valid_submission(page):
 
     # Check footer exist
     content = page.text_content("footer")
-    assert content == "Links"
+
+    assert "Links" in content
 
     # Check privacy footer
-    # assert page.footer("privacy-footer") == "Privacy Policy"
+    assert "Privacy Policy" in content
 
     # Check NOT hatecrime
     page.check("#id_2-hate_crime_1")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -78,14 +78,14 @@ def test_report_complete_and_valid_submission(page):
     assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"
 
     # Check footer exist
-    assert page.footer() == "Links"
+    # assert page.footer() == "Links"
 
     # Check footer exist
     content = page.text_content("footer")
     assert content == "Links"
 
     # Check privacy footer
-    assert page.footer("privacy-footer") == "Privacy Policy"
+    # assert page.footer("privacy-footer") == "Privacy Policy"
 
     # Check NOT hatecrime
     page.check("#id_2-hate_crime_1")


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/917)

## What does this change?
added footer back to the hate crime form page.
## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/53233196/113789779-d17e0c80-970d-11eb-8f47-8998b2b0e7aa.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
