### PR TITLE
Fix hardcoded date in non-actionable form letter

### DIFF
--- a/crt_portal/cts_forms/migrations/0106_chinese_traditional_form_letters.py
+++ b/crt_portal/cts_forms/migrations/0106_chinese_traditional_form_letters.py
@@ -295,7 +295,7 @@ www.fbi.gov/contact-us/field-offices
         body="""
 {{ zh_hant.addressee }}，
 
-您於2021年3月2日與司法部聯繫。在仔細審閱了您所提交的內容之後，我們決定不對您的申訴採取任何進一步的行動。
+您於{{ zh_hant.date_of_intake }}與司法部聯繫。在仔細審閱了您所提交的內容之後，我們決定不對您的申訴採取任何進一步的行動。
 
 我們做了什麼：
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/919)

## What does this change?
Replaces a hardcoded date in the non-actionable form letter with the date of intake from the report.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
