### PR TITLE
Conditionally load Tinos fonts when rendering pages in Vietnamese

### DIFF
--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -28,6 +28,15 @@
 
       <meta property="og:url" content="https://civilrights.justice.gov{{ request.path }}" />
       <meta property="og:type" content="website" />
+      {% comment "Why we're conditionally loading a font " %}
+       This is intended as a temporary fix to resolve inconsistent diacritic rendering
+       for vietnamese glyphs when using the serif font family.
+      {% endcomment %}
+
+      {% if LANGUAGE_CODE == 'vi' %}
+        <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Tinos:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+      {% endif %}
 
       {% block meta_title %}
         {% trans 'Contact the Civil Rights Division | Department of Justice' as meta_title %}

--- a/crt_portal/static/sass/_uswds-theme-typography.scss
+++ b/crt_portal/static/sass/_uswds-theme-typography.scss
@@ -199,7 +199,7 @@ $theme-font-icon-custom-stack:  false;
 $theme-font-lang-custom-stack:  false;
 $theme-font-mono-custom-stack:  false;
 $theme-font-sans-custom-stack:  false;
-$theme-font-serif-custom-stack: false;
+$theme-font-serif-custom-stack: "Merriweather Web, Tinos, Georgia, Cambria, Times New Roman, Times, serif";
 
 /*
 ----------------------------------------
@@ -399,7 +399,7 @@ $theme-body-line-height:           5;
 $theme-style-body-element:         false;
 
 // Headings -- not used
-// NOTE: We don't use these because the design system's font token normalization 
+// NOTE: We don't use these because the design system's font token normalization
 // changes the size of the font on the fly:
 // https://designsystem.digital.gov/design-tokens/typesetting/overview/
 // Instead, we use REM defined in the next section.


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/936)

## What does this change?
Intended as a temporary fix to inconsistent rendering of diacritics for Vietnamese glyphs.

When rendering the page in `VI` we're loading Tinos from google.

We're including Tinos in our serif font-stack such that it precedes the problematic fonts after "Merriweather Web". When `Tinos` is not present, the browser continues down the stack and renders the page as it would have before this change.

## Screenshots (for front-end PR):
**Note that all rendered fonts are network provided (by us) and not system fonts**
<img width="1320" alt="Screen Shot 2021-04-29 at 9 13 34 PM" src="https://user-images.githubusercontent.com/3485564/116636687-deb6a180-a92f-11eb-8cde-633c44699e70.png">

**Noting the difference between serif and sans rendering for the diacritics in `quyền` from the original issue**
<img width="1323" alt="Screen Shot 2021-04-29 at 9 14 03 PM" src="https://user-images.githubusercontent.com/3485564/116636757-102f6d00-a930-11eb-8fdf-a41ae57c9360.png">

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
