### PR TITLE
Widen go button to accommodate Vietnamese

### DIFF
--- a/crt_portal/static/sass/custom/footer.scss
+++ b/crt_portal/static/sass/custom/footer.scss
@@ -129,7 +129,7 @@ footer {
     background-color: color($theme-color-base-ink);
     border: 1px solid color('white');
     width: 50%;
-    max-width: 4em;
+    max-width: 6em;
 
     &:hover {
       background-color: color('white') !important;


### PR DESCRIPTION
[Link to ZenHub issue.](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/945)

## What does this change?
Increases the `max-width` of the language selection go button to accommodate the Vietnamese translation.

## Screenshots (for front-end PR):
BEFORE:
![image](https://user-images.githubusercontent.com/1425377/116914819-de105a80-ac10-11eb-99df-7f3cd02a517a.png)

AFTER:
![image](https://user-images.githubusercontent.com/1425377/116914839-e6689580-ac10-11eb-8df1-51ebf2fba381.png)


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
