### PR TITLE
Text and link updates on landing page

### DIFF
--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -85,7 +85,7 @@
           <p class="crt-landing--largetext">
             <strong>{% trans "If you believe your civil rights, or someone else’s, have been violated, submit a report using our online form." %}</strong>
           </p>
-          <a class="usa-button usa-button--big crt-button--large" href="#report-a-violation">{% trans "Start a report" %}</a>
+          <a class="usa-button usa-button--big crt-button--large" href="{% url 'crt_report_form' %}">{% trans "Start a report" %}</a>
           <p class="text-italic">{% trans 'or learn more about <a href="#your-rights">your rights</a>' %}</p>
 
         </div>
@@ -323,7 +323,7 @@
       <div class="grid-row grid-gap">
         <div class="tablet:grid-col-8">
           <h2 class="h2__display">{% trans "Have you or someone you know experienced a civil rights violation?" %}</h2>
-          <a class="usa-button usa-button--big crt-button--large" href="{% url 'crt_report_form' %}">{% trans "Submit a report" %}</a>
+          <a class="usa-button usa-button--big crt-button--large" href="{% url 'crt_report_form' %}">{% trans "Start a report" %}</a>
         </div>
       </div>
       <div class="grid-row grid-gap">


### PR DESCRIPTION
both buttons should go to /report
both buttons should say "Start a report"

[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/940)

## What does this change?
text and link update

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
