### PR TITLE
Filter by report language #927

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -41,6 +41,7 @@ filter_options = {
     'commercial_or_public_place': '__in',
     'reported_reason': 'reported_reason',
     'referred': 'eq',
+    'language': '__in',
 }
 
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timezone
-
 from actstream import action
+
 from django.contrib.auth import get_user_model
 from django.core.validators import ValidationError
 from django.forms import (BooleanField, CharField, CheckboxInput, ChoiceField,
@@ -13,6 +13,7 @@ from django.forms import (BooleanField, CharField, CheckboxInput, ChoiceField,
                           TypedChoiceField)
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+from django.conf import settings
 
 from .model_variables import (COMMERCIAL_OR_PUBLIC_ERROR,
                               COMMERCIAL_OR_PUBLIC_PLACE_CHOICES,
@@ -1007,6 +1008,13 @@ class Filters(ModelForm):
             'name': 'intake_format',
         }),
     )
+    language = MultipleChoiceField(
+        required=False,
+        choices=settings.LANGUAGES,
+        widget=UsaCheckboxSelectMultiple(attrs={
+            'name': 'language',
+        }),
+    )
     referred = MultipleChoiceField(
         required=False,
         choices=((True, 'Yes'),),
@@ -1036,6 +1044,7 @@ class Filters(ModelForm):
             'intake_format',
             'contact_email',
             'referred',
+            'language'
         ]
 
         labels = {

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -39,6 +39,7 @@
         {% include 'forms/complaint_view/index/filters/intake_type.html' %}
         {% include 'forms/complaint_view/index/filters/contact_email.html' %}
         {% include 'forms/complaint_view/index/filters/secondary_review.html' %}
+        {% include 'forms/complaint_view/index/filters/report_language.html' %}
       </div>
     </div>
   </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/report_language.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/report_language.html
@@ -1,0 +1,16 @@
+{% extends "forms/complaint_view/index/filter.html" %}
+
+{% load i18n %}
+{% get_available_languages as LANGUAGES %}
+{% get_language_info_list for LANGUAGES as languages %}
+
+{% block controls %}report_languge{% endblock %}
+{% block label %}Report Language{% endblock %}
+{% block id %}report-language{% endblock %}
+
+{% block content %}
+  <div id="report_language-filter" class="multicheckboxes-container">
+    {{ form.language }}
+  </div>
+
+{% endblock %}

--- a/crt_portal/cts_forms/templatetags/get_field_label.py
+++ b/crt_portal/cts_forms/templatetags/get_field_label.py
@@ -24,6 +24,7 @@ variable_rename = {
     'summary': 'Summary',
     'contact_email': 'Contact email',
     'referred': 'Secondary review',
+    'language': 'Report Language',
 }
 
 

--- a/crt_portal/cts_forms/tests/test_data.py
+++ b/crt_portal/cts_forms/tests/test_data.py
@@ -10,6 +10,7 @@ SAMPLE_REPORT = {
     'location_name': 'Yosemite',
     'location_city_town': 'Yosemite Valley',
     'location_state': 'CA',
+    'language': 'en',
 }
 
 SAMPLE_RESPONSE_TEMPLATE = {

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -20,57 +20,15 @@ class ReportFilterTests(TestCase):
         age = ProtectedClass.objects.get(value='age')
         gender = ProtectedClass.objects.get(value='gender')
         test_data = SAMPLE_REPORT.copy()
+
         test_data['violation_summary'] = 'plane'
         r1 = Report.objects.create(**test_data)
         r1.protected_class.add(age)
+
         test_data['violation_summary'] = 'truck'
         r2 = Report.objects.create(**test_data)
         r2.protected_class.add(age)
         r2.protected_class.add(gender)
-
-        # http://0.0.0.0:8000/form/view/?status=new&status=open&no_status=false&language=es&language=en&language=zh-hant&language=zh-hans&language=vi&language=ko&language=tl
-
-        # test setup for language English
-        r3 = Report.objects.create(**test_data)
-        r3.protected_class.add(age)
-        r3.protected_class.add(gender)
-        test_data['language'] = 'en'
-
-        # test setup for language Spanish
-        r4 = Report.objects.create(**test_data)
-        r4.protected_class.add(age)
-        r4.protected_class.add(gender)
-        test_data['language'] = 'es'
-
-        # test setup for language Chinese traditional
-        r5 = Report.objects.create(**test_data)
-        r5.protected_class.add(age)
-        r5.protected_class.add(gender)
-        test_data['language'] = 'zh-hant'
-
-        # test setup for language Chinese simplified
-        r6 = Report.objects.create(**test_data)
-        r6.protected_class.add(age)
-        r6.protected_class.add(gender)
-        test_data['language'] = 'zh-hans'
-
-        # test setup for language Vietnamese
-        r7 = Report.objects.create(**test_data)
-        r7.protected_class.add(age)
-        r7.protected_class.add(gender)
-        test_data['language'] = 'vi'
-
-        # test setup for language Korean
-        r8 = Report.objects.create(**test_data)
-        r8.protected_class.add(age)
-        r8.protected_class.add(gender)
-        test_data['language'] = 'ko'
-
-        # test setup for language tagalog
-        r9 = Report.objects.create(**test_data)
-        r9.protected_class.add(age)
-        r9.protected_class.add(gender)
-        test_data['language'] = 'tl'
 
     def test_no_filters(self):
         """Returns all reports when no filters provided"""
@@ -79,47 +37,86 @@ class ReportFilterTests(TestCase):
 
     def test_or_search_for_violation_summary(self):
         """
-        Returns queryset responsive to N terms provided as OR search
+        Returns query set responsive to N terms provided as OR search
         """
         reports, _ = report_filter(QueryDict('violation_summary=plane'))
         self.assertEquals(reports.count(), 1)
 
         reports, _ = report_filter(QueryDict('violation_summary=plane&violation_summary=truck'))
-        self.assertEquals(reports.count(), 9)
+        self.assertEquals(reports.count(), 2)
 
     def test_reported_reason(self):
         reports, _ = report_filter(QueryDict('reported_reason=age'))
-        self.assertEquals(reports.count(), 9)
+        self.assertEquals(reports.count(), 2)
 
         reports, _ = report_filter(QueryDict('reported_reason=gender&reported_reason=language'))
-        self.assertEquals(reports.count(), 8)
+        self.assertEquals(reports.count(), 1)
 
-    # language=es&language=en&language=zh-hant&language=zh-hans&language=vi&language=ko&language=tl
+
+class ReportLanguageFilterTests(TestCase):
+    def setUp(self):
+        test_data = SAMPLE_REPORT.copy()
+
+        # test setup for language English
+        test_data['language'] = 'en'
+        Report.objects.create(**test_data)
+
+        # test setup for language Spanish
+        test_data['language'] = 'es'
+        Report.objects.create(**test_data)
+
+        # test setup for language Chinese traditional
+        test_data['language'] = 'zh-hant'
+        Report.objects.create(**test_data)
+
+        # test setup for language Chinese simplified
+        test_data['language'] = 'zh-hans'
+        Report.objects.create(**test_data)
+
+        # test setup for language Vietnamese
+        test_data['language'] = 'vi'
+        Report.objects.create(**test_data)
+
+        # test setup for language Korean
+        test_data['language'] = 'ko'
+        Report.objects.create(**test_data)
+
+        # test setup for language tagalog
+        test_data['language'] = 'tl'
+        Report.objects.create(**test_data)
+
     # report language filter test
+    # report submitted in English
     def test_reported_language_en(self):
         reports, _ = report_filter(QueryDict('language=en'))
-        self.assertEquals(reports.count(), 4)
+        self.assertEquals(reports.count(), 1)
 
+    # report submitted in Spanish
     def test_reported_language_es(self):
         reports, _ = report_filter(QueryDict('language=es'))
         self.assertEquals(reports.count(), 1)
 
+    # report submitted in Chinese Traditional
     def test_reported_language_hant(self):
         reports, _ = report_filter(QueryDict('language=zh-hant'))
         self.assertEquals(reports.count(), 1)
 
+    # report submitted in Chinese Simplified
     def test_reported_language_hans(self):
         reports, _ = report_filter(QueryDict('language=zh-hans'))
         self.assertEquals(reports.count(), 1)
 
+    # report submitted in Vietnamese
     def test_reported_language_vi(self):
         reports, _ = report_filter(QueryDict('language=vi'))
         self.assertEquals(reports.count(), 1)
 
+    # report submitted in Korean
     def test_reported_language_ko(self):
         reports, _ = report_filter(QueryDict('language=ko'))
         self.assertEquals(reports.count(), 1)
 
+    # report submitted in Tagalog
     def test_reported_language_tl(self):
         reports, _ = report_filter(QueryDict('language=tl'))
         self.assertEquals(reports.count(), 1)

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -28,6 +28,50 @@ class ReportFilterTests(TestCase):
         r2.protected_class.add(age)
         r2.protected_class.add(gender)
 
+        # http://0.0.0.0:8000/form/view/?status=new&status=open&no_status=false&language=es&language=en&language=zh-hant&language=zh-hans&language=vi&language=ko&language=tl
+
+        # test setup for language English
+        r3 = Report.objects.create(**test_data)
+        r3.protected_class.add(age)
+        r3.protected_class.add(gender)
+        test_data['language'] = 'en'
+
+        # test setup for language Spanish
+        r4 = Report.objects.create(**test_data)
+        r4.protected_class.add(age)
+        r4.protected_class.add(gender)
+        test_data['language'] = 'es'
+
+        # test setup for language Chinese traditional
+        r5 = Report.objects.create(**test_data)
+        r5.protected_class.add(age)
+        r5.protected_class.add(gender)
+        test_data['language'] = 'zh-hant'
+
+        # test setup for language Chinese simplified
+        r6 = Report.objects.create(**test_data)
+        r6.protected_class.add(age)
+        r6.protected_class.add(gender)
+        test_data['language'] = 'zh-hans'
+
+        # test setup for language Vietnamese
+        r7 = Report.objects.create(**test_data)
+        r7.protected_class.add(age)
+        r7.protected_class.add(gender)
+        test_data['language'] = 'vi'
+
+        # test setup for language Korean
+        r8 = Report.objects.create(**test_data)
+        r8.protected_class.add(age)
+        r8.protected_class.add(gender)
+        test_data['language'] = 'ko'
+
+        # test setup for language tagalog
+        r9 = Report.objects.create(**test_data)
+        r9.protected_class.add(age)
+        r9.protected_class.add(gender)
+        test_data['language'] = 'tl'
+
     def test_no_filters(self):
         """Returns all reports when no filters provided"""
         reports, _ = report_filter(QueryDict(''))
@@ -41,11 +85,41 @@ class ReportFilterTests(TestCase):
         self.assertEquals(reports.count(), 1)
 
         reports, _ = report_filter(QueryDict('violation_summary=plane&violation_summary=truck'))
-        self.assertEquals(reports.count(), 2)
+        self.assertEquals(reports.count(), 9)
 
     def test_reported_reason(self):
         reports, _ = report_filter(QueryDict('reported_reason=age'))
-        self.assertEquals(reports.count(), 2)
+        self.assertEquals(reports.count(), 9)
 
         reports, _ = report_filter(QueryDict('reported_reason=gender&reported_reason=language'))
+        self.assertEquals(reports.count(), 8)
+
+    # language=es&language=en&language=zh-hant&language=zh-hans&language=vi&language=ko&language=tl
+    # report language filter test
+    def test_reported_language_en(self):
+        reports, _ = report_filter(QueryDict('language=en'))
+        self.assertEquals(reports.count(), 4)
+
+    def test_reported_language_es(self):
+        reports, _ = report_filter(QueryDict('language=es'))
+        self.assertEquals(reports.count(), 1)
+
+    def test_reported_language_hant(self):
+        reports, _ = report_filter(QueryDict('language=zh-hant'))
+        self.assertEquals(reports.count(), 1)
+
+    def test_reported_language_hans(self):
+        reports, _ = report_filter(QueryDict('language=zh-hans'))
+        self.assertEquals(reports.count(), 1)
+
+    def test_reported_language_vi(self):
+        reports, _ = report_filter(QueryDict('language=vi'))
+        self.assertEquals(reports.count(), 1)
+
+    def test_reported_language_ko(self):
+        reports, _ = report_filter(QueryDict('language=ko'))
+        self.assertEquals(reports.count(), 1)
+
+    def test_reported_language_tl(self):
+        reports, _ = report_filter(QueryDict('language=tl'))
         self.assertEquals(reports.count(), 1)

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -126,7 +126,8 @@
     sort: '',
     page: '',
     per_page: '',
-    no_status: ''
+    no_status: '',
+    language: []
   };
   var filterDataModel = {};
 
@@ -293,7 +294,7 @@
     var servicememberEl = dom.getElementsByName('servicemember');
     var contactEmailEl = dom.querySelector('input[name="contact_email"]');
     var referredEl = dom.getElementsByName('referred');
-
+    var languageEl = dom.getElementsByName('language');
     /**
      * Update the filter data model when the user clears (clicks on) a filter tag,
      * and perform a new search with the updated filters applied.
@@ -310,7 +311,8 @@
         'primary_complaint',
         'intake_format',
         'commercial_or_public_place',
-        'reported_reason'
+        'reported_reason',
+        'language'
       ];
       var filterIndex = multiSelectElements.indexOf(filterName);
       if (filterIndex !== -1) {
@@ -437,6 +439,10 @@
     checkBoxView({
       el: referredEl,
       name: 'referred'
+    });
+    checkBoxView({
+      el: languageEl,
+      name: 'language'
     });
   }
 


### PR DESCRIPTION
[Link to the crt-portal-management issue.](https://github.com/usdoj-crt/crt-portal-management/issues/927)

## What does this change?
Allow portal intake user to filter in view all table by report language.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
