### PR TITLE
add complaint id in view all table

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -25,6 +25,7 @@
           <th></th>
           {% render_sortable_heading 'Status' sort_state filter_state %}
           {% render_sortable_heading 'Total #' sort_state filter_state nowrap=True %}
+          {% render_sortable_heading 'ID' sort_state filter_state %}
           {% render_sortable_heading 'Routed' sort_state filter_state %}
           {% render_sortable_heading 'Submitted' sort_state filter_state %}
           {% render_sortable_heading 'Contact Name' sort_state filter_state %}
@@ -68,6 +69,7 @@
                   {% endwith %}
                 </a>
               </td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.public_id }}</a></td>
               <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.assigned_section }}</a></td>
               <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.create_date|date:"SHORT_DATE_FORMAT" }}</a></td>
               <td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -144,14 +144,6 @@
                   {{ datum.report.location_name|default:"-" }}
                 </div>
               </td>
-              <td>
-                <div class="td-quickview">
-                  Complaint ID
-                </div>
-                <div class="td-summary">
-                  {{ datum.report.public_id|default:"-" }}
-                </div>
-              </td>
             </tr>
           {% endfor %}
         </tbody>

--- a/crt_portal/cts_forms/templatetags/sortable_table_heading.py
+++ b/crt_portal/cts_forms/templatetags/sortable_table_heading.py
@@ -5,6 +5,7 @@ register = template.Library()
 sort_lookup = {
     'status': 'status',
     'total #': 'email_count',
+    'id': 'public_id',
     'routed': 'assigned_section',
     'submitted': 'create_date',
     'contact name': 'contact_last_name',
@@ -14,6 +15,7 @@ sort_lookup = {
 sortable_props = [
     'status',
     'email_count',
+    'public_id',
     'assigned_section',
     'create_date',
     'contact_last_name',

--- a/crt_portal/cts_forms/tests/test_views.py
+++ b/crt_portal/cts_forms/tests/test_views.py
@@ -411,6 +411,7 @@ class CRT_FILTER_Tests(TestCase):
         test_report.assigned_section = test_report.assign_section()
         test_report.servicemember = 'yes'
         test_report.hate_crime = 'yes'
+        test_report.public_id = '999-XYZ'
         test_report.save()
 
         self.client = Client()
@@ -431,6 +432,12 @@ class CRT_FILTER_Tests(TestCase):
         actual_reports = one_filter_response.context['data_dict']
 
         self.assertTrue(len(actual_reports) == len(list(expected_reports)))
+
+    def test_id_filter(self):
+        url = f'{self.url_base}?public_id=999-XYZ'
+        one_filter_response = self.client.get(url)
+        actual_reports = str(one_filter_response.content)
+        self.assertTrue('999-XYZ' in actual_reports)
 
     def test_combined_filter(self):
         url_1 = f'{self.url_base}?assigned_section=ADM&status=new'


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/962)

## What does this change?
display Complaint ID column in the view all table

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
