### PR TITLE
Il/move summary to carrot view

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -30,7 +30,6 @@
           {% render_sortable_heading 'Contact Name' sort_state filter_state %}
           {% render_sortable_heading 'Contact Details' sort_state filter_state %}
           {% render_sortable_heading 'Incident Location' sort_state filter_state %}
-          <!-- {% render_sortable_heading 'Summary' sort_state filter_state %} -->
           {% render_sortable_heading 'Incident Date' sort_state filter_state %}
         </tr>
       </thead>
@@ -94,13 +93,6 @@
                   {{ datum.report.location_city_town }}, {{ datum.report.location_state }}
                 </a>
               </td>
-              <!-- <td>
-                <a class="td-link display-block" href="{{datum.url}}">
-                  {% with summary=datum.report.get_summary %}
-                    {{ summary.note|default:"—"|truncatechars:60 }}
-                  {% endwith %}
-                </a>
-              </td> -->
               <td>
                 <a class="td-link display-block" href="{{datum.url}}">
                   {{ datum.report.last_incident_month|default:"-" }}/{{datum.report.last_incident_day|default:"-"}}/{{ datum.report.last_incident_year|default:"-" }}
@@ -110,22 +102,6 @@
             {# this row is hidden by default #}
             <tr id="tr-additional-{{ datum.report.id }}" hidden>
               <td colspan="2"></td>
-              <!-- <td colspan="2">
-                <div class="td-quickview">
-                  Contact
-                </div>
-                <div class="display-flex flex-column">
-                  <span>
-                    {{ datum.report.contact_last_name|default:"-" }} {{ datum.report.contact_first_name|default:"-" }}
-                  </span>
-                  <span>
-                    {{ datum.report.contact_email|default:"-" }}
-                  </span>
-                  <span>
-                    {{ datum.report.contact_phone|default:"-" }}
-                  </span>
-                </div>
-              </td> -->
               <td colspan="4">
                 <div class="td-quickview">
                   Summary
@@ -144,22 +120,6 @@
                   {{ datum.report.violation_summary|linebreaks|default:"-" }}
                 </div>
               </td>
-              <!-- <td>
-                <div class="td-quickview">
-                  Location Name
-                </div>
-                <div class="td-summary">
-                  {{ datum.report.location_name|default:"-" }}
-                </div>
-              </td>
-              <td>
-                <div class="td-quickview">
-                  Complaint ID
-                </div>
-                <div class="td-summary">
-                  {{ datum.report.public_id|default:"-" }}
-                </div>
-              </td> -->
             </tr>
           {% endfor %}
         </tbody>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -30,7 +30,7 @@
           {% render_sortable_heading 'Contact Name' sort_state filter_state %}
           {% render_sortable_heading 'Contact Details' sort_state filter_state %}
           {% render_sortable_heading 'Incident Location' sort_state filter_state %}
-          {% render_sortable_heading 'Summary' sort_state filter_state %}
+          <!-- {% render_sortable_heading 'Summary' sort_state filter_state %} -->
           {% render_sortable_heading 'Incident Date' sort_state filter_state %}
         </tr>
       </thead>
@@ -94,13 +94,13 @@
                   {{ datum.report.location_city_town }}, {{ datum.report.location_state }}
                 </a>
               </td>
-              <td>
+              <!-- <td>
                 <a class="td-link display-block" href="{{datum.url}}">
                   {% with summary=datum.report.get_summary %}
                     {{ summary.note|default:"—"|truncatechars:60 }}
                   {% endwith %}
                 </a>
-              </td>
+              </td> -->
               <td>
                 <a class="td-link display-block" href="{{datum.url}}">
                   {{ datum.report.last_incident_month|default:"-" }}/{{datum.report.last_incident_day|default:"-"}}/{{ datum.report.last_incident_year|default:"-" }}
@@ -110,7 +110,7 @@
             {# this row is hidden by default #}
             <tr id="tr-additional-{{ datum.report.id }}" hidden>
               <td colspan="2"></td>
-              <td colspan="2">
+              <!-- <td colspan="2">
                 <div class="td-quickview">
                   Contact
                 </div>
@@ -125,6 +125,16 @@
                     {{ datum.report.contact_phone|default:"-" }}
                   </span>
                 </div>
+              </td> -->
+              <td colspan="4">
+                <div class="td-quickview">
+                  Summary
+                </div>
+                <div class="td-summary">
+                  {% with summary=datum.report.get_summary %}
+                    {{ summary.note|linebreaks|default:"-" }}
+                  {% endwith %}
+                </div>
               </td>
               <td colspan="4">
                 <div class="td-quickview">
@@ -134,7 +144,7 @@
                   {{ datum.report.violation_summary|linebreaks|default:"-" }}
                 </div>
               </td>
-              <td>
+              <!-- <td>
                 <div class="td-quickview">
                   Location Name
                 </div>
@@ -149,7 +159,7 @@
                 <div class="td-summary">
                   {{ datum.report.public_id|default:"-" }}
                 </div>
-              </td>
+              </td> -->
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/961)

## What does this change?
move summary column to the carrot view under view all table.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
