### PR TITLE
added location name to view all table header

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -30,6 +30,7 @@
           {% render_sortable_heading 'Submitted' sort_state filter_state %}
           {% render_sortable_heading 'Contact Name' sort_state filter_state %}
           {% render_sortable_heading 'Contact Details' sort_state filter_state %}
+          {% render_sortable_heading 'Location Name' sort_state filter_state %}
           {% render_sortable_heading 'Incident Location' sort_state filter_state %}
           {% render_sortable_heading 'Summary' sort_state filter_state %}
           {% render_sortable_heading 'Incident Date' sort_state filter_state %}
@@ -91,6 +92,7 @@
                   {% endwith %}
                 </a>
               </td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.location_name|default:"-" }}</a></td>
               <td>
                 <a class="td-link display-block" href="{{datum.url}}">
                   {{ datum.report.location_city_town }}, {{ datum.report.location_state }}

--- a/crt_portal/cts_forms/templatetags/sortable_table_heading.py
+++ b/crt_portal/cts_forms/templatetags/sortable_table_heading.py
@@ -9,6 +9,7 @@ sort_lookup = {
     'routed': 'assigned_section',
     'submitted': 'create_date',
     'contact name': 'contact_last_name',
+    'location name': 'location_name',
     'incident location': 'location_city_town',
     'incident date': 'last_incident_month',
 }
@@ -19,6 +20,7 @@ sortable_props = [
     'assigned_section',
     'create_date',
     'contact_last_name',
+    'location_name',
     'location_city_town',
     'last_incident_month',
 ]


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/963)

## What does this change?
This display Incident Location Name on the view all table header and data.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
