### PR TITLE
Feature/bh update form to est 943

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -475,48 +475,48 @@ class ResponseTemplate(models.Model):
         section_choices_zh_hans = dict(SECTION_CHOICES_ZH_HANS)
         section_choices_zh_hant = dict(SECTION_CHOICES_ZH_HANT)
 
-        local_datetime = self.utc_timezone_to_est(report.create_date)
+        eastern_standard_datetime = self.utc_timezone_to_est(report.create_date)
 
         return Context({
             'record_locator': report.public_id,
             'addressee': report.addressee,
-            'date_of_intake': format_date(local_datetime, format='long', locale='en_US'),
+            'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='en_US'),
             'outgoing_date': format_date(today, locale='en_US'),  # required for paper mail
             'section_name': section_choices.get(report.assigned_section, "no section"),
             # spanish translations
             'es': {
                 'addressee': report.addressee_es,
-                'date_of_intake': format_date(report.create_date, format='long', locale='es_ES'),
+                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='es_ES'),
                 'outgoing_date': format_date(today, locale='es_ES'),
                 'section_name': section_choices_es.get(report.assigned_section, "no section"),
             },
             'ko': {
                 'addressee': report.addressee_ko,
-                'date_of_intake': format_date(report.create_date, format='long', locale='ko'),
+                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='ko'),
                 'outgoing_date': format_date(today, locale='ko'),
                 'section_name': section_choices_ko.get(report.assigned_section, "no section"),
             },
             'tl': {
                 'addressee': report.addressee_tl,
-                'date_of_intake': format_date(report.create_date, format='long', locale='tl'),
+                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='tl'),
                 'outgoing_date': format_date(today, locale='tl'),
                 'section_name': section_choices_tl.get(report.assigned_section, "no section"),
             },
             'vi': {
                 'addressee': report.addressee_vi,
-                'date_of_intake': format_date(report.create_date, format='long', locale='vi'),
+                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='vi'),
                 'outgoing_date': format_date(today, locale='vi'),
                 'section_name': section_choices_vi.get(report.assigned_section, "no section"),
             },
             'zh_hans': {
                 'addressee': report.addressee_zh_hans,
-                'date_of_intake': format_date(report.create_date, format='long', locale='zh_hans'),
+                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='zh_hans'),
                 'outgoing_date': format_date(today, locale='zh_hans'),
                 'section_name': section_choices_zh_hans.get(report.assigned_section, "no section"),
             },
             'zh_hant': {
                 'addressee': report.addressee_zh_hant,
-                'date_of_intake': format_date(report.create_date, format='long', locale='zh_hant'),
+                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='zh_hant'),
                 'outgoing_date': format_date(today, locale='zh_hant'),
                 'section_name': section_choices_zh_hant.get(report.assigned_section, "no section"),
             },

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -475,7 +475,7 @@ class ResponseTemplate(models.Model):
         section_choices_zh_hans = dict(SECTION_CHOICES_ZH_HANS)
         section_choices_zh_hant = dict(SECTION_CHOICES_ZH_HANT)
 
-        # as of July 1, create_dates are being converted to eastern standard time from utc, 
+        # as of July 1, create_dates are being converted to eastern standard time from utc,
         # to show the correct date for reports created in the evening.
         report_create_date_est = self.utc_timezone_to_est(report.create_date)
 

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -475,48 +475,50 @@ class ResponseTemplate(models.Model):
         section_choices_zh_hans = dict(SECTION_CHOICES_ZH_HANS)
         section_choices_zh_hant = dict(SECTION_CHOICES_ZH_HANT)
 
-        eastern_standard_datetime = self.utc_timezone_to_est(report.create_date)
+        # as of July 1, create_dates are being converted to eastern standard time from utc, 
+        # to show the correct date for reports created in the evening.
+        report_create_date_est = self.utc_timezone_to_est(report.create_date)
 
         return Context({
             'record_locator': report.public_id,
             'addressee': report.addressee,
-            'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='en_US'),
+            'date_of_intake': format_date(report_create_date_est, format='long', locale='en_US'),
             'outgoing_date': format_date(today, locale='en_US'),  # required for paper mail
             'section_name': section_choices.get(report.assigned_section, "no section"),
             # spanish translations
             'es': {
                 'addressee': report.addressee_es,
-                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='es_ES'),
+                'date_of_intake': format_date(report_create_date_est, format='long', locale='es_ES'),
                 'outgoing_date': format_date(today, locale='es_ES'),
                 'section_name': section_choices_es.get(report.assigned_section, "no section"),
             },
             'ko': {
                 'addressee': report.addressee_ko,
-                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='ko'),
+                'date_of_intake': format_date(report_create_date_est, format='long', locale='ko'),
                 'outgoing_date': format_date(today, locale='ko'),
                 'section_name': section_choices_ko.get(report.assigned_section, "no section"),
             },
             'tl': {
                 'addressee': report.addressee_tl,
-                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='tl'),
+                'date_of_intake': format_date(report_create_date_est, format='long', locale='tl'),
                 'outgoing_date': format_date(today, locale='tl'),
                 'section_name': section_choices_tl.get(report.assigned_section, "no section"),
             },
             'vi': {
                 'addressee': report.addressee_vi,
-                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='vi'),
+                'date_of_intake': format_date(report_create_date_est, format='long', locale='vi'),
                 'outgoing_date': format_date(today, locale='vi'),
                 'section_name': section_choices_vi.get(report.assigned_section, "no section"),
             },
             'zh_hans': {
                 'addressee': report.addressee_zh_hans,
-                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='zh_hans'),
+                'date_of_intake': format_date(report_create_date_est, format='long', locale='zh_hans'),
                 'outgoing_date': format_date(today, locale='zh_hans'),
                 'section_name': section_choices_zh_hans.get(report.assigned_section, "no section"),
             },
             'zh_hant': {
                 'addressee': report.addressee_zh_hant,
-                'date_of_intake': format_date(eastern_standard_datetime, format='long', locale='zh_hant'),
+                'date_of_intake': format_date(report_create_date_est, format='long', locale='zh_hant'),
                 'outgoing_date': format_date(today, locale='zh_hant'),
                 'section_name': section_choices_zh_hant.get(report.assigned_section, "no section"),
             },

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -475,7 +475,7 @@ class ResponseTemplate(models.Model):
         section_choices_zh_hans = dict(SECTION_CHOICES_ZH_HANS)
         section_choices_zh_hant = dict(SECTION_CHOICES_ZH_HANT)
 
-        # as of July 1, create_dates are being converted to eastern standard time from utc,
+        # as of July 1, create_dates are being converted to eastern standard time from utc
         # to show the correct date for reports created in the evening.
         report_create_date_est = self.utc_timezone_to_est(report.create_date)
 

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -13,6 +13,7 @@ from django.urls import reverse
 from django.utils.html import escape
 from django.utils.http import urlencode
 
+from datetime import datetime
 
 from ..forms import BulkActionsForm, ComplaintActions, Filters, ReportEditForm
 from ..model_variables import PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES
@@ -372,6 +373,25 @@ class ResponseActionTests(TestCase):
         content = str(response.content)
         self.assertTrue('?per_page=15' in content)
         self.assertFalse('Contacted complainant:' in content)
+
+    def test_create_date_is_EST(self):
+        # Add datetime without timezone to make sure its converted to EST
+        self.report.create_date = datetime(2020, 12, 31, 23, 0, 0)
+        self.report.save()
+        response = self.client.post(
+            reverse(
+                'crt_forms:crt-forms-response',
+                kwargs={'id': self.report.id},
+            ),
+            {
+                'next': '?per_page=15',
+            },
+            follow=True
+        )
+        self.assertEquals(response.status_code, 200)
+        content = str(response.content)
+        self.assertTrue('You contacted the Department of Justice on December 31, 2020' in content)
+        self.assertFalse('You contacted the Department of Justice on January 1, 2021' in content)
 
 
 class FormNavigationTests(TestCase):


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)
https://github.com/usdoj-crt/crt-portal-management/issues/943

## What does this change?
Updates the datetime field model.create_date from UTC to Eastern Standard time.  This lets the user see the correct date if they fill out a complaint in the evening. 

## Screenshots (for front-end PR):

<img width="657" alt="image" src="https://user-images.githubusercontent.com/6232068/124186216-faead200-da89-11eb-90d5-0e034cd79a7f.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
