### PR TITLE
Feature/bh print margins

### DIFF
--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -349,5 +349,8 @@
     section.what-to-expect ul.confirmation-list li {
       padding-left: 0;
     }
+    .confirmation-page .confirmation-content {
+      margin-left: .5rem !important;
+    }
   }
 }

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -2,6 +2,15 @@
   .intake-bg {
     background-color: color('white');
   }
+  body,
+  html {
+    padding: 0;
+    margin: 0;
+  }
+
+  @page {
+    margin: .5cm;
+  }
 
   // selectively hide page elements that we don't want to be visible
   // when printing.

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -2,15 +2,6 @@
   .intake-bg {
     background-color: color('white');
   }
-  body,
-  html {
-    padding: 0;
-    margin: 0;
-  }
-
-  @page {
-    margin: .5cm;
-  }
 
   // selectively hide page elements that we don't want to be visible
   // when printing.
@@ -271,7 +262,7 @@
       margin: 1rem 0;
     }
     .confirmation-content {
-      margin: 0 2rem !important;
+      margin: 0 1rem !important;
       padding-bottom: 1.5rem !important;
     }
     .title-icon-blue {
@@ -354,6 +345,9 @@
       border-radius: 2px;
       background: color('black');
       width: 30px !important;
+    }
+    section.what-to-expect ul.confirmation-list li {
+      padding-left: 0;
     }
   }
 }


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/976)

## What does this change?

Added css to keep long strings from running off the page.

**Note:** Originally, I thought I would do language specific solutions.  But after digging into the css a little more, I realized the same problem could happen on english language forms if the text was changed.  

## Screenshots (for front-end PR):

**Before**: 
![image](https://user-images.githubusercontent.com/6232068/125134506-73c6db00-e0d5-11eb-8641-bcc15d3d3c3f.png)
Notice cut off word "mình."

**After**: 
![image](https://user-images.githubusercontent.com/6232068/125134244-1599f800-e0d5-11eb-9057-114c68cd487e.png)

**Sample page of english language printout, post fix**
![image](https://user-images.githubusercontent.com/6232068/125134933-2dbe4700-e0d6-11eb-943c-d3d2dfe4f055.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
