### PR TITLE
adjusted clamav file check for dev, stage and prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     image: ajilaag/clamav-rest:20201028
     environment:
       - MAX_FILE_SIZE=100M
+      - SIGNATURE_CHECKS=1
     ports:
       - "9000:9000"
 volumes:

--- a/manifest_dev.yaml
+++ b/manifest_dev.yaml
@@ -25,6 +25,7 @@ applications:
   memory: 2G
   env:
     MAX_FILE_SIZE: 100M
+    SIGNATURE_CHECKS: 1
   docker:
     image: ajilaag/clamav-rest:20201028
   routes:

--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -29,6 +29,7 @@ applications:
   memory: 2G
   env:
     MAX_FILE_SIZE: 100M
+    SIGNATURE_CHECKS: 8
   docker:
     image: ajilaag/clamav-rest:20201028
   routes:

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -28,6 +28,7 @@ applications:
   memory: 2G
   env:
     MAX_FILE_SIZE: 100M
+    SIGNATURE_CHECKS: 2
   docker:
     image: ajilaag/clamav-rest:20201028
   routes:


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/985)

## What does this change?
This changes the ClamAV SIGNATURE_CHECKS threshold to an acceptable range for dev, stage and prod.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
