### PR TITLE
Prevent duplicate reports

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -32,6 +32,7 @@
                 class="usa-form"
                 action=""
                 method="post"
+                onsubmit="document.getElementById('submit-next').disabled = true;"
                 {% if form_autocomplete_off %}autocomplete="off"{% endif %}
                 {% if form_novalidate %}novalidate{% endif %}
           >


### PR DESCRIPTION
Add onsubmit event to disable form preventing multiple submissions of the same form.

[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/984)

## What does this change?

After form submission, the Submit button will be disabled until page load.

## Screenshots (for front-end PR):

![image](https://user-images.githubusercontent.com/6232068/125639675-8ac95f97-e54e-4435-948d-03c8283815cb.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
