### PR TITLE
Email and Phone nudge #982

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -37,7 +37,6 @@
           >
           {% csrf_token %}
           {{ wizard.management_form }}
-
           {% if form.non_field_errors %}
             {% include "forms/snippets/error_alert.html" with errors=form.non_field_errors %}
           {% endif %}
@@ -103,6 +102,7 @@
     </div>
   </div>
 {% include "partials/unsupported-browser-modal.html" %}
+{% include "partials/contact-info-confirmation-modal.html" %}
 {% endblock %}
 
 {% block footer_extra %}
@@ -121,16 +121,25 @@
       wordsRemainingText: "{{ word_count_text.wordsRemainingText }}",
       wordLimitReachedText: "{{ word_count_text.wordLimitReachedText }}"
     };
+    root.CRT.stageNumber = {{ stage_number }}
   })(window)
 </script>
 <script src="{% static 'js/word_count.js' %}"></script>
 <script src="{% static 'js/modal.js' %}"></script>
 <script src="{% static 'js/unsupported_browsers.js' %}"></script>
-<script nonce="{{request.csp_nonce}}">
+<script src="{% static 'js/contact_info_confirmation_modal.js' %}"></script>
+    <script nonce="{{request.csp_nonce}}">
   (function(root) {
+    {#if (root.CRT.stageNumber === 1) {#}
+    {#  var contactInfoConfirm = document.getElementById('contact-info-confirmation--modal');#}
+    {#  root.CRT.openModal(contactInfoConfirm);#}
+      {##}
+      {#var close_el = document.getElementById('ub_close');#}
+      {#root.CRT.cancelModal(modal, close_el);#}
+    {#}#}
     if (root.CRT.isUnsupportedBrowser()) {
-      var modal = document.getElementById('unsupported_browser_modal');
-      root.CRT.openModal(modal);
+      var unsupportedBrowserModal = document.getElementById('unsupported_browser_modal');
+      root.CRT.openModal(unsupportedBrowserModal);
 
       var close_el = document.getElementById('ub_close');
       root.CRT.cancelModal(modal, close_el);

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -78,14 +78,16 @@
 
           {% block bottom-navigation %}
           <div class="margin-top-5">
+          {%  block submit-button %}
             <input id="submit-next"
                   type="submit"
                   value={% if submit_button %}
-                          "{% trans 'Submit' %}"
+                          {% trans 'Submit' %}
                         {% else %}
-                          "{% trans 'Next' %}"
+                          {% trans 'Next' %}
                         {% endif %}
                   class="usa-button" />
+          {% endblock %}
 
             {% if wizard.steps.prev %}
               <button name="wizard_goto_step"
@@ -131,13 +133,6 @@
 <script src="{% static 'js/contact_info_confirmation_modal.js' %}"></script>
     <script nonce="{{request.csp_nonce}}">
   (function(root) {
-    {#if (root.CRT.stageNumber === 1) {#}
-    {#  var contactInfoConfirm = document.getElementById('contact-info-confirmation--modal');#}
-    {#  root.CRT.openModal(contactInfoConfirm);#}
-      {##}
-      {#var close_el = document.getElementById('ub_close');#}
-      {#root.CRT.cancelModal(modal, close_el);#}
-    {#}#}
     if (root.CRT.isUnsupportedBrowser()) {
       var unsupportedBrowserModal = document.getElementById('unsupported_browser_modal');
       root.CRT.openModal(unsupportedBrowserModal);

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -105,7 +105,6 @@
     </div>
   </div>
 {% include "partials/unsupported-browser-modal.html" %}
-{% include "partials/contact-info-confirmation-modal.html" %}
 {% endblock %}
 
 {% block footer_extra %}

--- a/crt_portal/cts_forms/templates/forms/report_contact_info.html
+++ b/crt_portal/cts_forms/templates/forms/report_contact_info.html
@@ -31,7 +31,7 @@
 {%  block submit-button %}
     <br />
     <a class="usa-button button--continue report-step-1-continue">
-        Next
+        {% trans 'Next' %}
     </a>
     <input hidden
            id="submit-next"

--- a/crt_portal/cts_forms/templates/forms/report_contact_info.html
+++ b/crt_portal/cts_forms/templates/forms/report_contact_info.html
@@ -27,6 +27,22 @@
   </div>
 {% endblock %}
 
+{%  block submit-button %}
+    <br />
+    <a class="usa-button button--continue report-step-1-continue">
+        Next
+    </a>
+    <input hidden
+           id="submit-next"
+           type="submit"
+           value={% if submit_button %}
+               {% trans 'Submit' %}
+           {% else %}
+               {% trans 'Next' %}
+           {% endif %}
+                   class="usa-button"
+    />
+{% endblock %}
 
 {% block contact-info-confirmation %}
     {% include "partials/contact_info_confirmation_modal.html" %}

--- a/crt_portal/cts_forms/templates/forms/report_contact_info.html
+++ b/crt_portal/cts_forms/templates/forms/report_contact_info.html
@@ -13,6 +13,7 @@
 {% endblock %}
 
 {% block form_questions %}
+{% include "partials/contact-info-confirmation-modal.html" %}
 <div class="crt-portal-card crt-portal-card">
   <div class="crt-portal-card__content crt-portal-card__content--lg">
     {{ block.super }}
@@ -42,8 +43,4 @@
            {% endif %}
                    class="usa-button"
     />
-{% endblock %}
-
-{% block contact-info-confirmation %}
-    {% include "partials/contact_info_confirmation_modal.html" %}
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_contact_info.html
+++ b/crt_portal/cts_forms/templates/forms/report_contact_info.html
@@ -1,5 +1,6 @@
 {% extends "forms/report_base.html" %}
 {% load i18n %}
+{% load static %}
 
 {% block page_info_card %}
   <div class="crt-portal-card crt-portal-card">
@@ -24,4 +25,9 @@
   <div role="group" aria-labelledby="servicemember-help-text">
     {% include "forms/question_cards/single_form.html" with field=form.servicemember ally_id="servicemember-help-text" %}
   </div>
+{% endblock %}
+
+
+{% block contact-info-confirmation %}
+    {% include "partials/contact_info_confirmation_modal.html" %}
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/report_review.html
+++ b/crt_portal/cts_forms/templates/forms/report_review.html
@@ -28,6 +28,7 @@
 
     {% if wizard.steps.prev %}
       <button name="wizard_goto_step"
+              id="submit-report"
               type="submit"
               label="{% trans "previous step" %}"
               value="{{ wizard.steps.prev }}"

--- a/crt_portal/cts_forms/templates/partials/contact-info-confirmation-modal.html
+++ b/crt_portal/cts_forms/templates/partials/contact-info-confirmation-modal.html
@@ -5,12 +5,12 @@
     <div class="modal-content modal-content--small">
       <div class="modal-header">
         <h1 id="modal_dialog_header" class="h2__display">
-            You are continuing your complaint without providing email or phone information.
+            {% trans "You are continuing your complaint without providing email or phone information." %}
         </h1>
       </div>
       <div class="modal-form">
         <p>
-            You do not have to provide contact information, however, we will not be able to contact you for any status updates or potential follow up. Would you like to add your contact information now? If you prefer not to, you will go to Step 2.
+            {% trans "You do not have to provide contact information, however, we will not be able to contact you for any status updates or potential follow up. Would you like to add your contact information now? If you prefer not to, you will go to Step 2." %}
         </p>
         <div class="modal-footer">
             <a id="external-link--continue" href="#" class="usa-button usa-button--outline button--cancel light-button">{% trans "No, I don't want to provide it" %}</a>

--- a/crt_portal/cts_forms/templates/partials/contact-info-confirmation-modal.html
+++ b/crt_portal/cts_forms/templates/partials/contact-info-confirmation-modal.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+
+<div id="contact-info-confirmation--modal" hidden>
+  <div class="modal-wrapper" role="dialog" aria-modal="true" aria-describedby="modal_dialog_header">
+    <div class="modal-content modal-content--small">
+      <div class="modal-header">
+        <h1 id="modal_dialog_header" class="h2__display">
+          Contact Information
+        </h1>
+      </div>
+      <div class="modal-form">
+        <p>
+          Add your contact information?
+        </p>
+        <div class="modal-footer">
+            <a id="external-link--cancel" href="#" class="usa-button usa-button--outline button--cancel light-button">{% trans "Back" %}</a>
+            <a id="external-link--continue" href="#" class="usa-button button--continue">{% trans "Continue" %}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/crt_portal/cts_forms/templates/partials/contact-info-confirmation-modal.html
+++ b/crt_portal/cts_forms/templates/partials/contact-info-confirmation-modal.html
@@ -5,16 +5,18 @@
     <div class="modal-content modal-content--small">
       <div class="modal-header">
         <h1 id="modal_dialog_header" class="h2__display">
-          Contact Information
+            You are continuing your complaint without providing email or phone information.
         </h1>
       </div>
       <div class="modal-form">
         <p>
-          Add your contact information?
+            {{ wizard }}
+
+            You do not have to provide contact information, however, we will not be able to contact you for any status updates or potential follow up. Would you like to add your contact information now? If you prefer not to, you will go to Step 2.
         </p>
         <div class="modal-footer">
-            <a id="external-link--cancel" href="#" class="usa-button usa-button--outline button--cancel light-button">{% trans "Back" %}</a>
-            <a id="external-link--continue" href="#" class="usa-button button--continue">{% trans "Continue" %}</a>
+            <a id="external-link--cancel" href="#" class="usa-button usa-button--outline button--cancel light-button">{% trans "No, I don't want to provide it" %}</a>
+            <a id="external-link--continue" href="#" class="usa-button button--continue">{% trans "Yes, I'd like to add it" %}</a>
         </div>
       </div>
     </div>

--- a/crt_portal/cts_forms/templates/partials/contact-info-confirmation-modal.html
+++ b/crt_portal/cts_forms/templates/partials/contact-info-confirmation-modal.html
@@ -10,13 +10,11 @@
       </div>
       <div class="modal-form">
         <p>
-            {{ wizard }}
-
             You do not have to provide contact information, however, we will not be able to contact you for any status updates or potential follow up. Would you like to add your contact information now? If you prefer not to, you will go to Step 2.
         </p>
         <div class="modal-footer">
-            <a id="external-link--cancel" href="#" class="usa-button usa-button--outline button--cancel light-button">{% trans "No, I don't want to provide it" %}</a>
-            <a id="external-link--continue" href="#" class="usa-button button--continue">{% trans "Yes, I'd like to add it" %}</a>
+            <a id="external-link--continue" href="#" class="usa-button usa-button--outline button--cancel light-button">{% trans "No, I don't want to provide it" %}</a>
+            <a id="external-link--cancel" href="#" class="usa-button button--continue">{% trans "Yes, I'd like to add it" %}</a>
         </div>
       </div>
     </div>

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -8,7 +8,6 @@ def test_error_if_form_refreshed(page, base_url):
     def next_step():
         with page.expect_navigation() as response:
             page.evaluate("document.getElementById('submit-next').click()")
-            # page.click('input[type="submit"]', force=True)
         return response.value
 
     page.goto("/report")
@@ -35,7 +34,7 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
-            page.click('input[type="submit"]')
+            page.evaluate("document.getElementById('submit-next').click()")
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -2,8 +2,6 @@
 import pytest
 import logging
 
-logger = logging.getLogger(__name__)
-
 
 @pytest.mark.only_browser("chromium")
 def test_error_if_form_refreshed(page, base_url):

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -34,6 +34,7 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
+            page.evaluate("console.log(document.getElementsByTagName('input'))")
             page.evaluate("document.getElementById('submit-report').click()")
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -34,7 +34,7 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
-            page.evaluate("document.getElementById('submit-next').click()")
+            page.evaluate("document.getElementById('submit-report').click()")
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,10 +7,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            if page.click('input[type="submit"]').is_hidden():
-                page.click('input[type="submit"]', {"force": "true"})
-            else:
-                page.click('input[type="submit"]')
+            page.click('input[type="submit"]', force=True)
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -4,7 +4,8 @@ import pytest
 
 @pytest.mark.only_browser("chromium")
 def test_error_if_form_refreshed(page, base_url):
-    print(page, base_url)
+    print('page is ', page)
+    print("base_url is ", base_url)
 
     def next_step():
         with page.expect_navigation() as response:

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            if page.click('input[type="submit"]').is_hidden:
+            if page.click('input[type="submit"]').is_hidden():
                 page.click('input[type="submit"]', {"force": "true"})
             else:
                 page.click('input[type="submit"]')

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,8 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.click('input[type="submit"]', force=True)
+            kwargs = {"force": True}
+            page.click('input[type="submit"]', **kwargs)
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -4,7 +4,7 @@ import pytest
 
 @pytest.mark.only_browser("chromium")
 def test_error_if_form_refreshed(page, base_url):
-
+    print(page, base_url)
     def next_step():
         with page.expect_navigation() as response:
             page.click('input[type="submit"]')

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -1,5 +1,8 @@
 
 import pytest
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.only_browser("chromium")
@@ -34,7 +37,8 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
-            page.evaluate("document.getElementById('submit-next-bottom').submit()")
+            logger.info(page)
+            page.evaluate("document.querySelector('input[type=/'submit/']').click()")
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -38,7 +38,7 @@ def test_report_complete_and_valid_submission(page):
     def next_step():
         with page.expect_navigation():
             logger.info(page)
-            page.evaluate("document.querySelector('input[type=/'submit/']').click()")
+            page.evaluate("document.querySelector('input[type=\"submit\"]').click()")
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.click('input[type="submit"]', delay=100)
+            page.click('input[type="submit"]', force=True)
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,8 +7,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            kwargs = {'delay': '100', 'force': 'True'}
-            page.click('input[type="submit"]', **kwargs)
+            page.click('input[type="submit"]', force=True)
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,8 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.click('input[type="submit"]', {'force': 'True'})
+            kwargs = {'delay': '100', 'force': 'True'}
+            page.click('input[type="submit"]', **kwargs)
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -8,7 +8,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.evaluate("document.getElementById('submit-next').click()")
+            page.evaluate("document.querySelector('input[type=\"submit\"]').click()")
         return response.value
 
     page.goto("/report")
@@ -35,7 +35,6 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
-            logger.info(page)
             page.evaluate("document.querySelector('input[type=\"submit\"]').click()")
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -4,12 +4,13 @@ import pytest
 
 @pytest.mark.only_browser("chromium")
 def test_error_if_form_refreshed(page, base_url):
-    print('page is ', page)
-    print("base_url is ", base_url)
 
     def next_step():
         with page.expect_navigation() as response:
-            page.click('input[type="submit"]')
+            if page.click('input[type="submit"]').is_hidden:
+                page.click('input[type="submit"]', {"force": "true"})
+            else:
+                page.click('input[type="submit"]')
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.click('input[type="submit"]', force=True)
+            page.click('input[type="submit"]', delay=100)
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,12 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.click(selector='input[type="submit"]', force=True)
+            # page.evaluate("document.getElementById('submit-next').click()")
+            kwargs = {
+                'selector': 'input[type="submit"]',
+                'force': True
+            }
+            page.click(**kwargs)
         return response.value
 
     page.goto("/report")
@@ -34,7 +39,7 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
-            page.click(selector='input[type="submit"]', force=True)
+            page.click('input[type="submit"]')
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -5,6 +5,7 @@ import pytest
 @pytest.mark.only_browser("chromium")
 def test_error_if_form_refreshed(page, base_url):
     print(page, base_url)
+
     def next_step():
         with page.expect_navigation() as response:
             page.click('input[type="submit"]')

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -33,8 +33,8 @@ def test_error_if_form_refreshed(page, base_url):
 def test_report_complete_and_valid_submission(page):
 
     def next_step():
-        with page.expect_navigation() as response:
-            page.click('input[type="submit"]')
+        with page.expect_navigation():
+            page.click('input[type="submit"]', force=True)
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -33,8 +33,8 @@ def test_error_if_form_refreshed(page, base_url):
 def test_report_complete_and_valid_submission(page):
 
     def next_step():
-        with page.expect_navigation():
-            page.evaluate("document.getElementById('submit-next').click()")
+        with page.expect_navigation() as response:
+            page.click('input[type="submit"]')
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -34,7 +34,7 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
-            page.evaluate("document.getElementById('submit-next').click()")
+            page.evaluate("document.getElementById('submit').click()")
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,8 +7,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            kwargs = {"force": True}
-            page.click('input[type="submit"]', **kwargs)
+            page.click('input[type="submit"]', {'force': 'True'})
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,8 +7,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            # page.evaluate("document.getElementById('submit-next').click()")
-            page.evaluate("document.getElementsByTagName('[type=\"submit\"]')")
+            page.evaluate("document.getElementById('submit-next').click()")
         return response.value
 
     page.goto("/report")
@@ -35,7 +34,7 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
-            page.evaluate("document.getElementsByTagName('[type=\"submit\"]')")
+            page.evaluate("document.getElementById('submit-next').click()")
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.evaluate("() => document.getElementById('submit-next').click()")
+            page.click(selector='input[type="submit"]', force=True)
         return response.value
 
     page.goto("/report")
@@ -34,7 +34,7 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
-            page.evaluate("() => document.getElementById('submit-next').click()")
+            page.click(selector='input[type="submit"]', force=True)
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -34,8 +34,7 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
-            page.evaluate("console.log(document.getElementsByTagName('input'))")
-            page.evaluate("document.getElementById('submit-report').click()")
+            page.evaluate("document.getElementById('submit-next-bottom').submit()")
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,8 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.click('input[type="submit"]', force=True)
+            page.evaluate("document.getElementById('submit-next').click()")
+            # page.click('input[type="submit"]', force=True)
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.click('input[type="submit"]', force=True)
+            page.click('input[type="submit"]', {"force": True})
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,8 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.evaluate("document.getElementById('submit-next').click()")
+            # page.evaluate("document.getElementById('submit-next').click()")
+            page.evaluate("document.getElementsByTagName('[type=\"submit\"]')")
         return response.value
 
     page.goto("/report")
@@ -34,7 +35,7 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
-            page.evaluate("document.getElementById('submit').click()")
+            page.evaluate("document.getElementsByTagName('[type=\"submit\"]')")
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.click('input[type="submit"]', {"force": True})
+            page.click('input[type="submit"]', force=True)
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,12 +7,8 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            # page.evaluate("document.getElementById('submit-next').click()")
-            kwargs = {
-                'selector': 'input[type="submit"]',
-                'force': True
-            }
-            page.click(**kwargs)
+            page.evaluate("document.getElementById('submit-next').click()")
+            # page.click('input[type="submit"]', force=True)
         return response.value
 
     page.goto("/report")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -1,6 +1,5 @@
 
 import pytest
-import logging
 
 
 @pytest.mark.only_browser("chromium")

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -7,7 +7,7 @@ def test_error_if_form_refreshed(page, base_url):
 
     def next_step():
         with page.expect_navigation() as response:
-            page.evaluate("document.getElementById('submit-next').click()")
+            page.evaluate("() => document.getElementById('submit-next').click()")
         return response.value
 
     page.goto("/report")
@@ -34,7 +34,7 @@ def test_report_complete_and_valid_submission(page):
 
     def next_step():
         with page.expect_navigation():
-            page.click('input[type="submit"]', force=True)
+            page.evaluate("() => document.getElementById('submit-next').click()")
 
     page.goto("/report")
     assert page.title() == "Step 1: Contact - Contact the Civil Rights Division | Department of Justice"

--- a/crt_portal/static/js/contact_info_confirmation_modal.js
+++ b/crt_portal/static/js/contact_info_confirmation_modal.js
@@ -33,7 +33,7 @@
   }
 
   if (root.CRT.stageNumber === 1) {
-    stepOneSubmitButton = document.getElementsByClassName('report-step-1-continue')
+    var stepOneSubmitButton = document.getElementsByClassName('report-step-1-continue')
     if (stepOneSubmitButton.length) {
       var submitNextButton = document.getElementById('submit-next')
       var continue_modal_button = document.getElementById('external-link--continue');

--- a/crt_portal/static/js/contact_info_confirmation_modal.js
+++ b/crt_portal/static/js/contact_info_confirmation_modal.js
@@ -1,0 +1,47 @@
+(function(root) {
+  // note that modal.js must be loaded beforehand
+  var modal_el = document.getElementById('contact-info-confirmation--modal');
+  var span = document.getElementById('external-link--address');
+  var links = document.getElementById('submit-next');
+  console.log('links', links)
+  var continue_button = document.getElementById('external-link--continue');
+  var redirect;
+
+  console.log('in contact-info-confirmaton-model')
+  for (var i = 0; i < links.length; i++) {
+    var link = links[i];
+    console.log('links', links);
+    link.onclick = function(event) {
+      console.log('in link.onclick')
+      var href = event.target.href;
+      event.preventDefault();
+      // display the actual redirect link
+      span.innerHTML = '<a href="' + href + '">' + href + '</a>';
+      root.CRT.openModal(modal_el);
+      // set timeout for redirect
+      clearTimeout(redirect);
+      redirect = setTimeout(function() {
+        // only redirect if modal is still visible
+        if (modal_el.getAttribute('hidden') === null) {
+          window.location.href = href;
+        }
+      }, 20000);
+
+      // set up "continue" button to immediately redirect
+      continue_button.onclick = function(event) {
+        event.preventDefault();
+        var href = span.children[0].href;
+        window.location.href = href;
+      };
+    };
+  }
+  var cancel_modal = document.getElementById('external-link--cancel');
+  root.CRT.cancelModal(modal_el, cancel_modal);
+
+  if (root.CRT.stageNumber === 1) {
+
+    var contactInfoConfirm = document.getElementById('contact-info-confirmation--modal');
+    root.CRT.openModal(contactInfoConfirm);
+  }
+
+})(window);

--- a/crt_portal/static/js/contact_info_confirmation_modal.js
+++ b/crt_portal/static/js/contact_info_confirmation_modal.js
@@ -2,16 +2,14 @@
   // note that modal.js must be loaded beforehand
   var modal_el = document.getElementById('contact-info-confirmation--modal');
   var span = document.getElementById('external-link--address');
-  var links = document.getElementById('submit-next');
-  console.log('links', links)
+  var links = document.querySelectorAll('.external-link--popup');
   var continue_button = document.getElementById('external-link--continue');
   var redirect;
-
-  console.log('in contact-info-confirmaton-model')
   for (var i = 0; i < links.length; i++) {
     var link = links[i];
     console.log('links', links);
     link.onclick = function(event) {
+      console.log('document.getElementsByName(\'0-contact_email\')[0].value', document.getElementsByName('0-contact_email')[0].value)
       console.log('in link.onclick')
       var href = event.target.href;
       event.preventDefault();
@@ -39,9 +37,12 @@
   root.CRT.cancelModal(modal_el, cancel_modal);
 
   if (root.CRT.stageNumber === 1) {
-
+    submitButton = document.getElementById('submit-next')
+    submitButton.onclick((event) => {
+      console.log(event)
+      // root.CRT.openModal(contactInfoConfirm);
+    })
     var contactInfoConfirm = document.getElementById('contact-info-confirmation--modal');
-    root.CRT.openModal(contactInfoConfirm);
   }
 
 })(window);

--- a/crt_portal/static/js/contact_info_confirmation_modal.js
+++ b/crt_portal/static/js/contact_info_confirmation_modal.js
@@ -9,10 +9,10 @@
       var requiredFieldSelected =
         document.getElementsByName('0-servicemember')[0].checked ||
         document.getElementsByName('0-servicemember')[1].checked;
-      var noContactInfo = phone_el.value && email_el.value;
+      var noContactInfo = !phone_el.value && !email_el.value;
 
       // If there is contact information OR if the required field is not filled out, no modal is needed
-      if (noContactInfo || !requiredFieldSelected) {
+      if (!noContactInfo || !requiredFieldSelected) {
         event.preventDefault();
         submitNextButton.click();
       } else {

--- a/crt_portal/static/js/contact_info_confirmation_modal.js
+++ b/crt_portal/static/js/contact_info_confirmation_modal.js
@@ -3,46 +3,45 @@
   var modal_el = document.getElementById('contact-info-confirmation--modal');
 
   function clickSubmit(stepOneSubmitButton) {
-    stepOneSubmitButton[0].addEventListener("click",(event) => {
-      var phone_el = document.getElementsByName('0-contact_phone')[0]
-      var email_el = document.getElementsByName('0-contact_email')[0]
-      var requiredFieldSelected = document.getElementsByName('0-servicemember')[0].checked  ||  document.getElementsByName('0-servicemember')[1].checked
-      var noContactInfo = (phone_el.value && email_el.value)
+    stepOneSubmitButton[0].addEventListener('click', event => {
+      var phone_el = document.getElementsByName('0-contact_phone')[0];
+      var email_el = document.getElementsByName('0-contact_email')[0];
+      var requiredFieldSelected =
+        document.getElementsByName('0-servicemember')[0].checked ||
+        document.getElementsByName('0-servicemember')[1].checked;
+      var noContactInfo = phone_el.value && email_el.value;
 
       // If there is contact information OR if the required field is not filled out, no modal is needed
-      if ( noContactInfo || !requiredFieldSelected) {
+      if (noContactInfo || !requiredFieldSelected) {
         event.preventDefault();
-        submitNextButton.click()
-      }
-      else {
+        submitNextButton.click();
+      } else {
         event.preventDefault();
         var cancelModalButton = document.getElementById('external-link--cancel');
 
         // field_el is the field element that will need to be filled out.  We want to focus that field and scroll to it.
-        var field_el = {}
+        var field_el = {};
         if (noContactInfo || !email_el.value) {
-          field_el = email_el
-        }
-        else if (!phone_el.value) {
-          field_el = phone_el
+          field_el = email_el;
+        } else if (!phone_el.value) {
+          field_el = phone_el;
         }
         root.CRT.cancelModal(modal_el, cancelModalButton, field_el);
         root.CRT.openModal(modal_el);
       }
-    })
+    });
   }
 
   if (root.CRT.stageNumber === 1) {
-    var stepOneSubmitButton = document.getElementsByClassName('report-step-1-continue')
+    var stepOneSubmitButton = document.getElementsByClassName('report-step-1-continue');
     if (stepOneSubmitButton.length) {
-      var submitNextButton = document.getElementById('submit-next')
+      var submitNextButton = document.getElementById('submit-next');
       var continue_modal_button = document.getElementById('external-link--continue');
       continue_modal_button.onclick = function(event) {
         event.preventDefault();
         submitNextButton.click();
       };
-      clickSubmit(stepOneSubmitButton)
+      clickSubmit(stepOneSubmitButton);
     }
   }
-
 })(window);

--- a/crt_portal/static/js/contact_info_confirmation_modal.js
+++ b/crt_portal/static/js/contact_info_confirmation_modal.js
@@ -1,48 +1,48 @@
 (function(root) {
   // note that modal.js must be loaded beforehand
   var modal_el = document.getElementById('contact-info-confirmation--modal');
-  var span = document.getElementById('external-link--address');
-  var links = document.querySelectorAll('.external-link--popup');
-  var continue_button = document.getElementById('external-link--continue');
-  var redirect;
-  for (var i = 0; i < links.length; i++) {
-    var link = links[i];
-    console.log('links', links);
-    link.onclick = function(event) {
-      console.log('document.getElementsByName(\'0-contact_email\')[0].value', document.getElementsByName('0-contact_email')[0].value)
-      console.log('in link.onclick')
-      var href = event.target.href;
-      event.preventDefault();
-      // display the actual redirect link
-      span.innerHTML = '<a href="' + href + '">' + href + '</a>';
-      root.CRT.openModal(modal_el);
-      // set timeout for redirect
-      clearTimeout(redirect);
-      redirect = setTimeout(function() {
-        // only redirect if modal is still visible
-        if (modal_el.getAttribute('hidden') === null) {
-          window.location.href = href;
-        }
-      }, 20000);
 
-      // set up "continue" button to immediately redirect
-      continue_button.onclick = function(event) {
+  function clickSubmit(stepOneSubmitButton) {
+    stepOneSubmitButton[0].addEventListener("click",(event) => {
+      var phone_el = document.getElementsByName('0-contact_phone')[0]
+      var email_el = document.getElementsByName('0-contact_email')[0]
+      var requiredFieldSelected = document.getElementsByName('0-servicemember')[0].checked  ||  document.getElementsByName('0-servicemember')[1].checked
+      var noContactInfo = (phone_el.value && email_el.value)
+
+      // If there is contact information OR if the required field is not filled out, no modal is needed
+      if ( noContactInfo || !requiredFieldSelected) {
         event.preventDefault();
-        var href = span.children[0].href;
-        window.location.href = href;
-      };
-    };
+        submitNextButton.click()
+      }
+      else {
+        event.preventDefault();
+        var cancelModalButton = document.getElementById('external-link--cancel');
+
+        // field_el is the field element that will need to be filled out.  We want to focus that field and scroll to it.
+        var field_el = {}
+        if (noContactInfo || !email_el.value) {
+          field_el = email_el
+        }
+        else if (!phone_el.value) {
+          field_el = phone_el
+        }
+        root.CRT.cancelModal(modal_el, cancelModalButton, field_el);
+        root.CRT.openModal(modal_el);
+      }
+    })
   }
-  var cancel_modal = document.getElementById('external-link--cancel');
-  root.CRT.cancelModal(modal_el, cancel_modal);
 
   if (root.CRT.stageNumber === 1) {
-    submitButton = document.getElementById('submit-next')
-    submitButton.onclick((event) => {
-      console.log(event)
-      // root.CRT.openModal(contactInfoConfirm);
-    })
-    var contactInfoConfirm = document.getElementById('contact-info-confirmation--modal');
+    stepOneSubmitButton = document.getElementsByClassName('report-step-1-continue')
+    if (stepOneSubmitButton.length) {
+      var submitNextButton = document.getElementById('submit-next')
+      var continue_modal_button = document.getElementById('external-link--continue');
+      continue_modal_button.onclick = function(event) {
+        event.preventDefault();
+        submitNextButton.click();
+      };
+      clickSubmit(stepOneSubmitButton)
+    }
   }
 
 })(window);

--- a/crt_portal/static/js/modal.js
+++ b/crt_portal/static/js/modal.js
@@ -58,8 +58,8 @@
   root.CRT.cancelModal = function(modal_el, cancel_el, form_el = {}) {
     var dismissModal = function(event) {
       if (form_el) {
-        form_el.scrollIntoView({behavior: "smooth", block: "end", inline: "nearest"});
-        form_el.focus()
+        form_el.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
+        form_el.focus();
       }
       event.preventDefault();
       root.CRT.closeModal(modal_el);

--- a/crt_portal/static/js/modal.js
+++ b/crt_portal/static/js/modal.js
@@ -55,8 +55,12 @@
     dom.body.classList.remove('is-modal');
   };
 
-  root.CRT.cancelModal = function(modal_el, cancel_el) {
+  root.CRT.cancelModal = function(modal_el, cancel_el, form_el = {}) {
     var dismissModal = function(event) {
+      if (form_el) {
+        form_el.scrollIntoView({behavior: "smooth", block: "end", inline: "nearest"});
+        form_el.focus()
+      }
       event.preventDefault();
       root.CRT.closeModal(modal_el);
     };

--- a/crt_portal/static/sass/custom/modal.scss
+++ b/crt_portal/static/sass/custom/modal.scss
@@ -289,3 +289,10 @@ body.is-modal {
     }
   }
 }
+
+
+#contact-info-confirmation--modal {
+  .button--cancel {
+    margin: 1rem 1rem 1rem 0;
+  }
+}


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/982)

## What does this change?

We have added a modal window if a user does not fill out contact information.  

**NOTE**:  We might want to consider either changing the language on the modal OR only showing the modal if a user does not fill out a phone OR an email.  Currently, if either are missing, the modal pops, which might be confusing.

## Screenshots (for front-end PR):

![image](https://user-images.githubusercontent.com/6232068/126393217-79796012-5c22-4ae9-93e2-1707c9bb8c8e.png)


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
