### PR TITLE
Korean language translation - contact nudge modal

### DIFF
--- a/crt_portal/cts_forms/locale/ko/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/ko/LC_MESSAGES/django.po
@@ -1,24 +1,24 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 19:27+0000\n"
+"POT-Creation-Date: 2021-07-27 19:06+0000\n"
 "Language: Korean\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:161 forms.py:1546
+#: forms.py:182 forms.py:1577
 msgid " - Select - "
 msgstr " - 선택 - "
 
 #. Translators: This is help text for the question asking if someone is a service member
-#: forms.py:173
+#: forms.py:194
 msgid ""
 "If you’re reporting on behalf of someone else, please select their status."
 msgstr "누군가를 대신하여 신고하는 경우라면 그 사람의 신분을 선택하십시오."
 
-#: forms.py:190 templates/forms/report_contact_info.html:8
+#: forms.py:211 templates/forms/report_contact_info.html:9
 msgid ""
 "If you believe you or someone else has experienced a civil rights violation, "
 "please tell us what happened."
@@ -26,7 +26,7 @@ msgstr ""
 "귀하 또는 다른 누군가가 민권 침해를 경험했다고 생각되면, 어떤 일이 있었는지 "
 "저희에게 알려주십시오."
 
-#: forms.py:216
+#: forms.py:237
 msgid ""
 "Select the reason that best describes your concern. Each reason lists "
 "examples of civil rights violations that may relate to your incident. In "
@@ -38,21 +38,21 @@ msgstr ""
 "의 다른 섹션에서는 우려하는 바를 귀하 스스로의 표현으로 설명할 수 있습니다."
 
 #. Translators: notes that this page is the same form step as the page before
-#: forms.py:239
+#: forms.py:260
 msgid "Continued"
 msgstr "계속"
 
-#: forms.py:295
+#: forms.py:317
 msgid ""
 "Examples: Name of business, school, intersection, prison, polling place, "
 "website, etc."
 msgstr "예: 사업체, 학교, 교차로, 교도소, 투표소, 웹사이트 등의 이름"
 
-#: forms.py:317 question_text.py:29
+#: forms.py:339 question_text.py:29
 msgid "Where did this happen?"
 msgstr "이 일이 발생한 것은 언제입니까?"
 
-#: forms.py:329
+#: forms.py:351
 msgid ""
 "Please tell us the city, state, and name of the location where this incident "
 "took place. This ensures your report is reviewed by the right people within "
@@ -61,7 +61,7 @@ msgstr ""
 "이 일이 일어난 장소의 이름과 시, 주를 알려 주십시오. 이 정보를 바탕으로 민권"
 "국(Civil Rights Division) 내의 적합한 사람이 귀하의 신고를 검토하게 됩니다."
 
-#: forms.py:392
+#: forms.py:414
 msgid ""
 "Public employers include organizations funded by the government like the "
 "military, post office, fire department, courthouse, DMV, or public school. "
@@ -70,7 +70,7 @@ msgstr ""
 "공공 고용주에는 군대, 우체국, 소방서, 법원, DMV 또는 공립학교와 같은 정부 예"
 "산이 투입되는 조직이 포함됩니다. 이는 지방 또는 주(state) 차원일 수 있습니다."
 
-#: forms.py:393
+#: forms.py:415
 msgid ""
 "Private employers are business or non-profits not funded by the government "
 "such as retail stores, banks, or restaurants."
@@ -79,11 +79,11 @@ msgstr ""
 "는 비영리 조직을 말합니다."
 
 #. Translators: describe the "other" option for commercial or public place question
-#: forms.py:439
+#: forms.py:461
 msgid "Please describe"
 msgstr "기술해 주십시오"
 
-#: forms.py:506
+#: forms.py:528
 msgid ""
 "Includes schools, educational programs, or educational activities, like "
 "training programs, sports teams, clubs, or other school-sponsored activities"
@@ -91,11 +91,11 @@ msgstr ""
 "학교, 교육 프로그램 또는 훈련 프로그램, 스포츠팀, 클럽, 기타 학교 후원 활동 "
 "등과 같은 교육 활동이 포함됩니다"
 
-#: forms.py:517
+#: forms.py:539
 msgid "Please select the type of school or educational program."
 msgstr "학교 또는 교육 프로그램의 유형을 선택하십시오."
 
-#: forms.py:540
+#: forms.py:562
 msgid ""
 "There are federal and state laws that protect people from discrimination "
 "based on their personal characteristics. Here is a list of the most common "
@@ -107,11 +107,11 @@ msgstr ""
 "경우에 적용되는 것을 선택하십시오."
 
 #. Translators: This is to explain an "other" choice for personal characteristics
-#: forms.py:545
+#: forms.py:567
 msgid "Please describe \"Other reason\""
 msgstr "“기타 이유”를 기술해 주십시오"
 
-#: forms.py:627
+#: forms.py:649
 msgid ""
 "It is important for us to know how recently this incident happened so we can "
 "take the appropriate action. If this happened over a period of time or is "
@@ -121,19 +121,19 @@ msgstr ""
 "조치를 취할 수 있습니다. 이 일이 일정 기간 동안 일어났거나 현재도 일어나고 있"
 "다면, 가장 최근 날짜를 알려주십시오."
 
-#: forms.py:915
+#: forms.py:937
 msgid "Primary classification"
 msgstr "주요 분류"
 
-#: forms.py:937
+#: forms.py:959
 msgid "Assigned to"
 msgstr "다음에 배정됨:"
 
-#: forms.py:1104
+#: forms.py:1134
 msgid "Create date cannot be in the future."
 msgstr "생성 날짜는 미래일 수 없습니다."
 
-#: forms.py:1286
+#: forms.py:1317
 msgid "Comment cannot be empty"
 msgstr "설명란은 비어 있을 수 없습니다"
 
@@ -1181,7 +1181,7 @@ msgstr "민권국"
 #: templates/forms/question_cards/police_location.html:4
 #: templates/forms/question_cards/single_form.html:16
 #: templates/forms/question_cards/single_question.html:13
-#: templates/forms/report_class.html:14 templates/forms/report_details.html:13
+#: templates/forms/report_class.html:14 templates/forms/report_details.html:12
 #: templates/forms/report_location.html:33
 #: templates/forms/report_location.html:39
 #: templates/forms/report_primary_complaint.html:11
@@ -1519,19 +1519,21 @@ msgstr[1] ""
 "                  %(counter)s개의 오류 발견\n"
 "                "
 
-#: templates/forms/report_base.html:84
+#: templates/forms/report_base.html:85
+#: templates/forms/report_contact_info.html:40
 msgid "Submit"
 msgstr "제출"
 
-#: templates/forms/report_base.html:86
+#: templates/forms/report_base.html:87
+#: templates/forms/report_contact_info.html:42
 msgid "Next"
 msgstr "다음"
 
-#: templates/forms/report_base.html:93 templates/forms/report_review.html:32
+#: templates/forms/report_base.html:95 templates/forms/report_review.html:33
 msgid "previous step"
 msgstr "이전 단계"
 
-#: templates/forms/report_base.html:96 templates/forms/report_review.html:35
+#: templates/forms/report_base.html:98 templates/forms/report_review.html:36
 #: templates/partials/redirect-modal.html:21
 msgid "Back"
 msgstr "뒤로"
@@ -1640,8 +1642,8 @@ msgstr "침해 신고"
 msgid "Already submitted?"
 msgstr "이미 제출하셨습니까?"
 
-#: templates/landing.html:58 templates/partials/footer.html:9 views.py:951
-#: views.py:1030 views.py:1049
+#: templates/landing.html:58 templates/partials/footer.html:9
+#: views_public.py:145 views_public.py:224 views_public.py:243
 msgid "Contact"
 msgstr "연락처"
 
@@ -1668,7 +1670,7 @@ msgstr ""
 "귀하 또는 다른 누군가의 민권이 침해되었다고 믿는 경우, 온라인 양식을 이용해 "
 "신고서를 제출하십시오."
 
-#: templates/landing.html:88
+#: templates/landing.html:88 templates/landing.html:326
 msgid "Start a report"
 msgstr "신고서 작성을 시작하거나"
 
@@ -1898,10 +1900,6 @@ msgstr ""
 msgid "Have you or someone you know experienced a civil rights violation?"
 msgstr "귀하 또는 지인이 민권 침해를 경험했습니까?"
 
-#: templates/landing.html:326
-msgid "Submit a report"
-msgstr "신고서를 제출하십시오."
-
 #: templates/landing.html:331
 msgid ""
 "If you cannot access the online form, you can <a href=\"#phone-footer"
@@ -2017,6 +2015,33 @@ msgstr "미국 정부의 공식 웹사이트"
 #: templates/partials/banner/usa_banner_header.html:13
 msgid "Here’s how you know"
 msgstr "알 수 있는 방법이 있습니다"
+
+#: templates/partials/contact-info-confirmation-modal.html:8
+msgid ""
+"You are continuing your complaint without providing email or phone "
+"information."
+msgstr ""
+"귀하께서는 이메일 또는 전화 정보를 제공하지 않은 채 계속 불만을 보고하고 계십"
+"니다."
+
+#: templates/partials/contact-info-confirmation-modal.html:13
+msgid ""
+"You do not have to provide contact information, however, we will not be able "
+"to contact you for any status updates or potential follow up. Would you like "
+"to add your contact information now? If you prefer not to, you will go to "
+"Step 2."
+msgstr ""
+"연락 정보를 제공하지 않으셔도 되지만 상황 업데이트 또는 잠재적 후속조치를 위"
+"해 귀하에게 연락을 취할 수 없게 됩니다. 지금 연락 정보를 추가하시겠습니까? 원"
+"하시지 않을 경우, 2단계로 가십시오."
+
+#: templates/partials/contact-info-confirmation-modal.html:16
+msgid "No, I don't want to provide it"
+msgstr "아니요, 제공하고 싶지 않습니다."
+
+#: templates/partials/contact-info-confirmation-modal.html:17
+msgid "Yes, I'd like to add it"
+msgstr "예, 추가하고 싶습니다."
 
 #: templates/partials/footer.html:47
 msgid "Availability of Language Assistance Services"
@@ -2493,23 +2518,75 @@ msgstr ""
 "해 철회됨); 82 Fed. Reg. 24147 (5-25-2017).\n"
 "                "
 
-#: validators.py:101
+#: validators.py:106
 msgid "Enter a valid email address."
 msgstr "유효한 이메일 주소를 입력하십시오."
 
-#: views.py:78
+#: views_public.py:146 views_public.py:225 views_public.py:226
+#: views_public.py:244 views_public.py:245 views_public.py:280
+msgid "Primary concern"
+msgstr "주요 우려사항"
+
+#: views_public.py:147 views_public.py:227 views_public.py:228
+#: views_public.py:229 views_public.py:230 views_public.py:231
+#: views_public.py:232
+msgid "Location"
+msgstr "장소"
+
+#: views_public.py:148 views_public.py:233 views_public.py:252
+msgid "Personal characteristics"
+msgstr "인적 특성"
+
+#: views_public.py:149 views_public.py:234 views_public.py:253
+msgid "Date"
+msgstr "날짜"
+
+#: views_public.py:150 views_public.py:235 views_public.py:254
+msgid "Personal description"
+msgstr "개인적 설명"
+
+#: views_public.py:151 views_public.py:236 views_public.py:285
+msgid "Review"
+msgstr "검토"
+
+#: views_public.py:246 views_public.py:247 views_public.py:248
+#: views_public.py:249 views_public.py:250 views_public.py:251
+msgid "Location details"
+msgstr "장소 세부사항"
+
+#: views_public.py:255
+msgid "Review your report"
+msgstr "신고 내용을 검토하십시오"
+
+#: views_public.py:271
+msgid "word remaining"
+msgstr "단어 수 남아 있음"
+
+#: views_public.py:272
+msgid " words remaining"
+msgstr " 단어 수 남아 있음"
+
+#: views_public.py:273
+msgid " word limit reached"
+msgstr " 단어 수 제한에 도달"
+
+#: views_public.py:283
+msgid "Please select if any that apply to your situation (optional)"
+msgstr "귀하의 상황에 적용되는 것이 있다면 그것을 선택하십시오.(선택사항)"
+
+#: views_public.py:359
 msgid "404 | Page not found"
 msgstr "404 | 페이지를 찾을 수 없음"
 
-#: views.py:79
+#: views_public.py:360
 msgid "We can't find the page you are looking for"
 msgstr "찾고 계신 페이지를 찾을 수가 없습니다"
 
-#: views.py:138
+#: views_public.py:419
 msgid "Your browser couldn't create a secure cookie"
 msgstr "브라우저가 안전한 쿠키를 생성할 수 없었습니다"
 
-#: views.py:139
+#: views_public.py:420
 msgid ""
 "We use security cookies to protect your information from attackers. Make "
 "sure you allow cookies for this site. Having the page open for long periods "
@@ -2523,53 +2600,5 @@ msgstr ""
 "면, 새로운 브라우저 탭이나 창에서 이 페이지로 가 보십시오. 이렇게 하면 새로"
 "운 보안 쿠키를 만들어 문제가 해결될 것입니다."
 
-#: views.py:826 views.py:1077
-msgid "word remaining"
-msgstr "단어 수 남아 있음"
-
-#: views.py:827 views.py:1078
-msgid " words remaining"
-msgstr " 단어 수 남아 있음"
-
-#: views.py:828 views.py:1079
-msgid " word limit reached"
-msgstr " 단어 수 제한에 도달"
-
-#: views.py:952 views.py:1031 views.py:1032 views.py:1050 views.py:1051
-#: views.py:1086
-msgid "Primary concern"
-msgstr "주요 우려사항"
-
-#: views.py:953 views.py:1033 views.py:1034 views.py:1035 views.py:1036
-#: views.py:1037 views.py:1038
-msgid "Location"
-msgstr "장소"
-
-#: views.py:954 views.py:1039 views.py:1058
-msgid "Personal characteristics"
-msgstr "인적 특성"
-
-#: views.py:955 views.py:1040 views.py:1059
-msgid "Date"
-msgstr "날짜"
-
-#: views.py:956 views.py:1041 views.py:1060
-msgid "Personal description"
-msgstr "개인적 설명"
-
-#: views.py:957 views.py:1042 views.py:1091
-msgid "Review"
-msgstr "검토"
-
-#: views.py:1052 views.py:1053 views.py:1054 views.py:1055 views.py:1056
-#: views.py:1057
-msgid "Location details"
-msgstr "장소 세부사항"
-
-#: views.py:1061
-msgid "Review your report"
-msgstr "신고 내용을 검토하십시오"
-
-#: views.py:1089
-msgid "Please select if any that apply to your situation (optional)"
-msgstr "귀하의 상황에 적용되는 것이 있다면 그것을 선택하십시오.(선택사항)"
+#~ msgid "Submit a report"
+#~ msgstr "신고서를 제출하십시오."


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/992)

## What does this change?

Korean translation for the contact info nudge.  

## Screenshots (for front-end PR):
<img width="737" alt="Screen Shot 2021-07-27 at 3 07 36 PM" src="https://user-images.githubusercontent.com/6232068/127213377-6d0f2c9a-a676-48ea-a734-cddd8a755936.png">

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
