### PR TITLE
Chinese traditional language translation - contact info nudge

### DIFF
--- a/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
@@ -1,30 +1,30 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-19 20:44+0000\n"
+"POT-Creation-Date: 2021-07-27 19:15+0000\n"
 "Language: Chinese Traditional\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:161 forms.py:1546
+#: forms.py:182 forms.py:1577
 msgid " - Select - "
 msgstr " - 選擇 - "
 
 #. Translators: This is help text for the question asking if someone is a service member
-#: forms.py:173
+#: forms.py:194
 msgid ""
 "If you’re reporting on behalf of someone else, please select their status."
 msgstr "如果您是代表他人舉報，請選擇其身分。"
 
-#: forms.py:190 templates/forms/report_contact_info.html:8
+#: forms.py:211 templates/forms/report_contact_info.html:9
 msgid ""
 "If you believe you or someone else has experienced a civil rights violation, "
 "please tell us what happened."
 msgstr "如果您認為自己或其他人的民權曾受到侵犯，請告訴我們事發經過。"
 
-#: forms.py:216
+#: forms.py:237
 msgid ""
 "Select the reason that best describes your concern. Each reason lists "
 "examples of civil rights violations that may relate to your incident. In "
@@ -35,21 +35,21 @@ msgstr ""
 "子。在本報告的另一個部分，您將可使用您自己的話語來描述您擔憂的問題。"
 
 #. Translators: notes that this page is the same form step as the page before
-#: forms.py:239
+#: forms.py:260
 msgid "Continued"
 msgstr "（續）"
 
-#: forms.py:295
+#: forms.py:317
 msgid ""
 "Examples: Name of business, school, intersection, prison, polling place, "
 "website, etc."
 msgstr "例子：公司、學校、十字路口、監獄、投票所、網站等的名稱。"
 
-#: forms.py:317 question_text.py:29
+#: forms.py:339 question_text.py:29
 msgid "Where did this happen?"
 msgstr "此事件是發生在什麼地點？"
 
-#: forms.py:329
+#: forms.py:351
 msgid ""
 "Please tell us the city, state, and name of the location where this incident "
 "took place. This ensures your report is reviewed by the right people within "
@@ -58,7 +58,7 @@ msgstr ""
 "請告訴我們此事件發生的城市、州及地點名稱。這可確保您的報告由民權科的適當人員"
 "進行審查。"
 
-#: forms.py:392
+#: forms.py:414
 msgid ""
 "Public employers include organizations funded by the government like the "
 "military, post office, fire department, courthouse, DMV, or public school. "
@@ -68,7 +68,7 @@ msgstr ""
 "理局 (Department of Motor Vehicles, DMV) 或公立學校。其中可能包括地方組織或州"
 "政府組織。"
 
-#: forms.py:393
+#: forms.py:415
 msgid ""
 "Private employers are business or non-profits not funded by the government "
 "such as retail stores, banks, or restaurants."
@@ -76,11 +76,11 @@ msgstr ""
 "私人雇主包括不是由政府提供資金的企業或非營利組織，如零售商店、銀行或餐廳。"
 
 #. Translators: describe the "other" option for commercial or public place question
-#: forms.py:439
+#: forms.py:461
 msgid "Please describe"
 msgstr "請說明"
 
-#: forms.py:506
+#: forms.py:528
 msgid ""
 "Includes schools, educational programs, or educational activities, like "
 "training programs, sports teams, clubs, or other school-sponsored activities"
@@ -88,11 +88,11 @@ msgstr ""
 "包括學校、教育計畫或教育活動（如培訓計畫）、體育隊、俱樂部或由學校贊助的其他"
 "活動"
 
-#: forms.py:517
+#: forms.py:539
 msgid "Please select the type of school or educational program."
 msgstr "請選擇學校或教育計畫的類型。"
 
-#: forms.py:540
+#: forms.py:562
 msgid ""
 "There are federal and state laws that protect people from discrimination "
 "based on their personal characteristics. Here is a list of the most common "
@@ -103,11 +103,11 @@ msgstr ""
 "的最常見特徵清單。請選擇適用於您事件的所有選項。"
 
 #. Translators: This is to explain an "other" choice for personal characteristics
-#: forms.py:545
+#: forms.py:567
 msgid "Please describe \"Other reason\""
 msgstr "請說明「其他理由」"
 
-#: forms.py:627
+#: forms.py:649
 msgid ""
 "It is important for us to know how recently this incident happened so we can "
 "take the appropriate action. If this happened over a period of time or is "
@@ -116,19 +116,19 @@ msgstr ""
 "讓我們知道此事件是在最近多久發生非常重要，這樣我們才能採取適當行動。如果此事"
 "件是發生在一段時間或者現在仍持續發生，請提供最近一次發生的日期。"
 
-#: forms.py:915
+#: forms.py:937
 msgid "Primary classification"
 msgstr "主要分類"
 
-#: forms.py:937
+#: forms.py:959
 msgid "Assigned to"
 msgstr "指定給"
 
-#: forms.py:1104
+#: forms.py:1134
 msgid "Create date cannot be in the future."
 msgstr "建立日期不得是未來日期。"
 
-#: forms.py:1286
+#: forms.py:1317
 msgid "Comment cannot be empty"
 msgstr "意見欄位不得空白"
 
@@ -137,11 +137,11 @@ msgstr "意見欄位不得空白"
 msgid "- Select -"
 msgstr "- 選擇 -"
 
-#: model_variables.py:9 model_variables.py:119 model_variables.py:223
+#: model_variables.py:9 model_variables.py:119 model_variables.py:287
 msgid "Yes"
 msgstr "是"
 
-#: model_variables.py:10 model_variables.py:120 model_variables.py:222
+#: model_variables.py:10 model_variables.py:120 model_variables.py:286
 msgid "No"
 msgstr "否"
 
@@ -385,7 +385,7 @@ msgstr ""
 "由於受到身體虐待或人身侵犯、性虐待或性侵害、其他傷害威脅或監禁而被迫從事性工"
 "作以換取利益"
 
-#: model_variables.py:102 model_variables.py:229
+#: model_variables.py:102 model_variables.py:293
 msgid "Federal"
 msgstr "聯邦"
 
@@ -398,8 +398,8 @@ msgstr "州或地方"
 msgid "Both"
 msgstr "兩者"
 
-#: model_variables.py:106 model_variables.py:231 model_variables.py:246
-#: model_variables.py:254 model_variables.py:271
+#: model_variables.py:106 model_variables.py:295 model_variables.py:310
+#: model_variables.py:318 model_variables.py:335
 msgid "I'm not sure"
 msgstr "我不確定"
 
@@ -495,57 +495,57 @@ msgstr ""
 "請選擇一個選項以繼續進行。如果以上所有選項都不適用於您的狀況，請選擇「以上所"
 "有項目都不適用於我」或「其他理由」並加以說明。"
 
-#: model_variables.py:194
+#: model_variables.py:258
 msgid "Place of worship or about a place of worship"
 msgstr "禮拜場所或與禮拜場所有關"
 
-#: model_variables.py:195
+#: model_variables.py:259
 msgid "Commercial or retail building"
 msgstr "商用建物或零售商店建物"
 
-#: model_variables.py:196 model_variables.py:207
+#: model_variables.py:260 model_variables.py:271
 msgid "Healthcare facility"
 msgstr "醫療保健設施"
 
-#: model_variables.py:197 model_variables.py:208
+#: model_variables.py:261 model_variables.py:272
 msgid "Financial institution"
 msgstr "金融機構"
 
-#: model_variables.py:198
+#: model_variables.py:262
 msgid "Public space"
 msgstr "公共場所"
 
-#: model_variables.py:199 templatetags/commercial_public_space_view.py:17
+#: model_variables.py:263 templatetags/commercial_public_space_view.py:17
 msgid "Other"
 msgstr "其他"
 
-#: model_variables.py:202
+#: model_variables.py:266
 msgid ""
 "Please select the type of location. If none of these apply to your "
 "situation, please select \"Other\"."
 msgstr "請選擇地點類型。如果以上所有選項都不適用於您的狀況，請選擇「其他」。"
 
-#: model_variables.py:205
+#: model_variables.py:269
 msgid "Place of worship"
 msgstr "禮拜場所"
 
-#: model_variables.py:206
+#: model_variables.py:270
 msgid "Commercial"
 msgstr "商業場所"
 
-#: model_variables.py:209
+#: model_variables.py:273
 msgid "Public outdoor space"
 msgstr "戶外公共場所"
 
-#: model_variables.py:213
+#: model_variables.py:277
 msgid "Church, synagogue, temple, religious community center"
 msgstr "教堂、猶太教堂、寺廟、宗教社區中心"
 
-#: model_variables.py:214
+#: model_variables.py:278
 msgid "Store, restaurant, bar, hotel, theater"
 msgstr "商店、餐廳、酒吧、飯店、電影院"
 
-#: model_variables.py:215
+#: model_variables.py:279
 msgid ""
 "Hospital or clinic (including inpatient and outpatient programs), "
 "reproductive care clinic, state developmental institution, nursing home"
@@ -553,387 +553,387 @@ msgstr ""
 "醫院或診所（包括住院和門診計畫）、生殖護理診所、州政府發展障礙人士收容機構、"
 "療養院"
 
-#: model_variables.py:216
+#: model_variables.py:280
 msgid "Bank, credit union, loan services"
 msgstr "銀行、信用合作社、貸款服務"
 
-#: model_variables.py:217
+#: model_variables.py:281
 msgid ""
 "Park, sidewalk, street, other public buildings (courthouse, DMV, city "
 "library)"
 msgstr "公園、人行道、街道、其他公共建物（法院、DMV、市立圖書館）"
 
-#: model_variables.py:228
+#: model_variables.py:292
 msgid "State/local"
 msgstr "州／地方"
 
-#: model_variables.py:230
+#: model_variables.py:294
 msgid "Private"
 msgstr "私人"
 
-#: model_variables.py:236
+#: model_variables.py:300
 msgid "Outside of prison"
 msgstr "監獄外"
 
-#: model_variables.py:238
+#: model_variables.py:302
 msgid "Prison (Federal)"
 msgstr "監獄（聯邦）"
 
-#: model_variables.py:239
+#: model_variables.py:303
 msgid "Prison (Private)"
 msgstr "監獄（私人經營）"
 
-#: model_variables.py:240
+#: model_variables.py:304
 msgid "Prison (I'm not sure)"
 msgstr "監獄（我不確定）"
 
-#: model_variables.py:244
+#: model_variables.py:308
 msgid "Public employer"
 msgstr "公家機關雇主"
 
-#: model_variables.py:245
+#: model_variables.py:309
 msgid "Private employer"
 msgstr "私人雇主"
 
-#: model_variables.py:249
+#: model_variables.py:313
 msgid "Please select what type of employer this is."
 msgstr "請選擇該雇主是屬於什麼類型。"
 
-#: model_variables.py:252
+#: model_variables.py:316
 msgid "Fewer than 15 employees"
 msgstr "少於 15 名員工"
 
-#: model_variables.py:253
+#: model_variables.py:317
 msgid "15 or more employees"
 msgstr "15 名員工以上"
 
-#: model_variables.py:257
+#: model_variables.py:321
 msgid "Please select how large the employer is."
 msgstr "請選擇雇主的組織規模。"
 
-#: model_variables.py:269
+#: model_variables.py:333
 msgid "Public school or educational program"
 msgstr "公立學校或教育計畫"
 
-#: model_variables.py:270
+#: model_variables.py:334
 msgid "Private school or educational program"
 msgstr "私立學校或教育計畫"
 
-#: model_variables.py:276
+#: model_variables.py:340
 msgid "Alabama"
 msgstr "阿拉巴馬州"
 
-#: model_variables.py:277
+#: model_variables.py:341
 msgid "Alaska"
 msgstr "阿拉斯加州"
 
-#: model_variables.py:278
+#: model_variables.py:342
 msgid "Arizona"
 msgstr "亞利桑那州"
 
-#: model_variables.py:279
+#: model_variables.py:343
 msgid "Arkansas"
 msgstr "阿肯色州"
 
-#: model_variables.py:280
+#: model_variables.py:344
 msgid "California"
 msgstr "加州"
 
-#: model_variables.py:281
+#: model_variables.py:345
 msgid "Colorado"
 msgstr "科羅拉多州"
 
-#: model_variables.py:282
+#: model_variables.py:346
 msgid "Connecticut"
 msgstr "康乃狄克州"
 
-#: model_variables.py:283
+#: model_variables.py:347
 msgid "Delaware"
 msgstr "特拉華州"
 
-#: model_variables.py:284
+#: model_variables.py:348
 msgid "District of Columbia"
 msgstr "哥倫比亞特區"
 
-#: model_variables.py:285
+#: model_variables.py:349
 msgid "Florida"
 msgstr "佛羅里達州"
 
-#: model_variables.py:286
+#: model_variables.py:350
 msgid "Georgia"
 msgstr "喬治亞州"
 
-#: model_variables.py:287
+#: model_variables.py:351
 msgid "Hawaii"
 msgstr "夏威夷州"
 
-#: model_variables.py:288
+#: model_variables.py:352
 msgid "Idaho"
 msgstr "愛達荷州"
 
-#: model_variables.py:289
+#: model_variables.py:353
 msgid "Illinois"
 msgstr "伊利諾州"
 
-#: model_variables.py:290
+#: model_variables.py:354
 msgid "Indiana"
 msgstr "印第安納州"
 
-#: model_variables.py:291
+#: model_variables.py:355
 msgid "Iowa"
 msgstr "愛荷華州"
 
-#: model_variables.py:292
+#: model_variables.py:356
 msgid "Kansas"
 msgstr "堪薩斯州"
 
-#: model_variables.py:293
+#: model_variables.py:357
 msgid "Kentucky"
 msgstr "肯塔基州"
 
-#: model_variables.py:294
+#: model_variables.py:358
 msgid "Louisiana"
 msgstr "路易斯安那州"
 
-#: model_variables.py:295
+#: model_variables.py:359
 msgid "Maine"
 msgstr "緬因州"
 
-#: model_variables.py:296
+#: model_variables.py:360
 msgid "Maryland"
 msgstr "馬里蘭州"
 
-#: model_variables.py:297
+#: model_variables.py:361
 msgid "Massachusetts"
 msgstr "麻州"
 
-#: model_variables.py:298
+#: model_variables.py:362
 msgid "Michigan"
 msgstr "密西根州"
 
-#: model_variables.py:299
+#: model_variables.py:363
 msgid "Minnesota"
 msgstr "明尼蘇達州"
 
-#: model_variables.py:300
+#: model_variables.py:364
 msgid "Mississippi"
 msgstr "密西西比州"
 
-#: model_variables.py:301
+#: model_variables.py:365
 msgid "Missouri"
 msgstr "密蘇里州"
 
-#: model_variables.py:302
+#: model_variables.py:366
 msgid "Montana"
 msgstr "蒙大拿州"
 
-#: model_variables.py:303
+#: model_variables.py:367
 msgid "Nebraska"
 msgstr "內布拉斯加州"
 
-#: model_variables.py:304
+#: model_variables.py:368
 msgid "Nevada"
 msgstr "內華達州"
 
-#: model_variables.py:305
+#: model_variables.py:369
 msgid "New Hampshire"
 msgstr "新罕布什爾州"
 
-#: model_variables.py:306
+#: model_variables.py:370
 msgid "New Jersey"
 msgstr "紐澤西州"
 
-#: model_variables.py:307
+#: model_variables.py:371
 msgid "New Mexico"
 msgstr "新墨西哥州"
 
-#: model_variables.py:308
+#: model_variables.py:372
 msgid "New York"
 msgstr "紐約州"
 
-#: model_variables.py:309
+#: model_variables.py:373
 msgid "North Carolina"
 msgstr "北卡羅萊納州"
 
-#: model_variables.py:310
+#: model_variables.py:374
 msgid "North Dakota"
 msgstr "北達科他州"
 
-#: model_variables.py:311
+#: model_variables.py:375
 msgid "Ohio"
 msgstr "俄亥俄州"
 
-#: model_variables.py:312
+#: model_variables.py:376
 msgid "Oklahoma"
 msgstr "奧克拉荷馬州"
 
-#: model_variables.py:313
+#: model_variables.py:377
 msgid "Oregon"
 msgstr "俄勒岡州"
 
-#: model_variables.py:314
+#: model_variables.py:378
 msgid "Pennsylvania"
 msgstr "賓州"
 
-#: model_variables.py:315
+#: model_variables.py:379
 msgid "Rhode Island"
 msgstr "羅得島州"
 
-#: model_variables.py:316
+#: model_variables.py:380
 msgid "South Carolina"
 msgstr "南卡羅萊納州"
 
-#: model_variables.py:317
+#: model_variables.py:381
 msgid "South Dakota"
 msgstr "南達科他州"
 
-#: model_variables.py:318
+#: model_variables.py:382
 msgid "Tennessee"
 msgstr "田納西州"
 
-#: model_variables.py:319
+#: model_variables.py:383
 msgid "Texas"
 msgstr "德州"
 
-#: model_variables.py:320
+#: model_variables.py:384
 msgid "Utah"
 msgstr "猶他州"
 
-#: model_variables.py:321
+#: model_variables.py:385
 msgid "Vermont"
 msgstr "佛蒙特州"
 
-#: model_variables.py:322
+#: model_variables.py:386
 msgid "Virginia"
 msgstr "維吉尼亞州"
 
-#: model_variables.py:323
+#: model_variables.py:387
 msgid "Washington"
 msgstr "華盛頓州"
 
-#: model_variables.py:324
+#: model_variables.py:388
 msgid "West Virginia"
 msgstr "西維吉尼亞州"
 
-#: model_variables.py:325
+#: model_variables.py:389
 msgid "Wisconsin"
 msgstr "威斯康辛州"
 
-#: model_variables.py:326
+#: model_variables.py:390
 msgid "Wyoming"
 msgstr "懷俄明州"
 
-#: model_variables.py:327
+#: model_variables.py:391
 msgid "American Samoa"
 msgstr "美屬薩摩亞"
 
-#: model_variables.py:328
+#: model_variables.py:392
 msgid "Guam"
 msgstr "關島"
 
-#: model_variables.py:329
+#: model_variables.py:393
 msgid "Northern Mariana Islands"
 msgstr "北馬利安納群島邦"
 
-#: model_variables.py:330
+#: model_variables.py:394
 msgid "Puerto Rico"
 msgstr "波多黎各"
 
-#: model_variables.py:331
+#: model_variables.py:395
 msgid "Virgin Islands"
 msgstr "維爾京群島"
 
-#: model_variables.py:332
+#: model_variables.py:396
 msgid "Armed Forces Africa"
 msgstr "非洲武裝部隊"
 
-#: model_variables.py:333
+#: model_variables.py:397
 msgid "Armed Forces Americas"
 msgstr "美國武裝部隊"
 
-#: model_variables.py:334
+#: model_variables.py:398
 msgid "Armed Forces Canada"
 msgstr "加拿大武裝部隊"
 
-#: model_variables.py:335
+#: model_variables.py:399
 msgid "Armed Forces Europe"
 msgstr "歐洲武裝部隊"
 
-#: model_variables.py:336
+#: model_variables.py:400
 msgid "Armed Forces Middle East"
 msgstr "中東武裝部隊"
 
-#: model_variables.py:337
+#: model_variables.py:401
 msgid "Armed Forces Pacific"
 msgstr "太平洋地區武裝部隊"
 
-#: model_variables.py:340
+#: model_variables.py:404
 msgid "Please provide description to continue"
 msgstr "請提供說明以繼續進行"
 
-#: model_variables.py:341
+#: model_variables.py:405
 msgid "Please select a primary reason to continue."
 msgstr "請選擇一項主要理由以繼續進行。"
 
-#: model_variables.py:344
+#: model_variables.py:408
 msgid "Please enter the name of the location where this took place."
 msgstr "請輸入此事件發生的地點名稱。"
 
-#: model_variables.py:345
+#: model_variables.py:409
 msgid "Please enter the city or town where this took place."
 msgstr "請輸入此事件發生的城市或城鎮。"
 
-#: model_variables.py:346
+#: model_variables.py:410
 msgid "Please select the state where this took place."
 msgstr "請選擇此事件發生的州。"
 
-#: model_variables.py:350
+#: model_variables.py:414
 msgid "Please select where this occurred"
 msgstr "請選擇此事件發生的地點"
 
-#: model_variables.py:351
+#: model_variables.py:415
 msgid "Please select the type of location"
 msgstr "請選擇地點類型"
 
-#: model_variables.py:363
+#: model_variables.py:427
 msgid "You must enter a month and year. Please use the format MM/DD/YYYY."
 msgstr "您必須輸入月份和年份。請使用月月／日日／年年年年的格式。"
 
-#: model_variables.py:366
+#: model_variables.py:430
 msgid "Please enter a month."
 msgstr "請輸入月份。"
 
-#: model_variables.py:367
+#: model_variables.py:431
 msgid "Please enter a valid month. Month must be between 1 and 12."
 msgstr "請輸入有效的月份。月份必須介於 1 至 12 之間。"
 
-#: model_variables.py:368
+#: model_variables.py:432
 msgid ""
 "Please enter a valid day of the month. Day must be between 1 and the last "
 "day of the month."
 msgstr "請輸入有效的日期。日期必須介於一個月的 1 號至一個月的最後一天。"
 
-#: model_variables.py:369
+#: model_variables.py:433
 msgid "Please enter a year."
 msgstr "請輸入年份。"
 
-#: model_variables.py:370
+#: model_variables.py:434
 msgid "Date can not be in the future."
 msgstr "日期不得是未來日期。"
 
-#: model_variables.py:371
+#: model_variables.py:435
 msgid "Please enter a year after 1900."
 msgstr "請輸入 1900 之後的年份。"
 
-#: model_variables.py:372
+#: model_variables.py:436
 msgid "Please enter a valid date. Use format MM/DD/YYYY."
 msgstr "請輸入有效的日期。請使用月月／日日／年年年年的格式。"
 
-#: model_variables.py:375
+#: model_variables.py:439
 msgid "Please select the type of election or voting activity."
 msgstr "請選擇選舉或投票活動的類型。"
 
-#: model_variables.py:415
+#: model_variables.py:479
 msgid ""
 "If you submit a phone number, please make sure to include between 7 and 15 "
 "digits. The characters \"+\", \")\", \"(\", \"-\", and \".\" are allowed. "
@@ -1110,12 +1110,12 @@ msgstr "涉及的人士姓名，包括目擊證人（如有）"
 msgid "Any supporting materials (please list and describe them)"
 msgstr "任何佐證資料（請列出並加以說明）"
 
-#: templates/base.html:33 templates/base.html:58
+#: templates/base.html:42 templates/base.html:67
 #: templates/forms/report_base.html:10 templates/forms/report_base.html:13
 msgid "Contact the Civil Rights Division | Department of Justice"
 msgstr "與民權科 | 司法部聯絡"
 
-#: templates/base.html:46
+#: templates/base.html:55
 msgid ""
 "Have you or someone you know experienced unlawful discrimination? The Civil "
 "Rights Division may be able to help. Civil rights laws can protect you from "
@@ -1127,16 +1127,16 @@ msgstr ""
 "於在各種場合遭受非法歧視、騷擾或虐待，如住房、職場、學校、投票、商店、醫療保"
 "健設施、公共場所等等。"
 
-#: templates/base.html:67
+#: templates/base.html:76
 msgid "Skip to main content"
 msgstr "跳到主要內容"
 
-#: templates/base.html:121 templates/forms/errors.html:13
+#: templates/base.html:130 templates/forms/errors.html:13
 #: templates/forms/report_maintenance.html:13 templates/landing.html:17
 msgid "U.S. Department of Justice"
 msgstr "美國司法部"
 
-#: templates/base.html:124 templates/forms/confirmation.html:21
+#: templates/base.html:133 templates/forms/confirmation.html:21
 #: templates/forms/errors.html:14 templates/forms/report_maintenance.html:14
 #: templates/landing.html:20
 msgid "Civil Rights Division"
@@ -1148,7 +1148,7 @@ msgstr "民權司"
 #: templates/forms/question_cards/police_location.html:4
 #: templates/forms/question_cards/single_form.html:16
 #: templates/forms/question_cards/single_question.html:13
-#: templates/forms/report_class.html:14 templates/forms/report_details.html:13
+#: templates/forms/report_class.html:14 templates/forms/report_details.html:12
 #: templates/forms/report_location.html:33
 #: templates/forms/report_location.html:39
 #: templates/forms/report_primary_complaint.html:11
@@ -1473,19 +1473,21 @@ msgstr[1] ""
 "                  發現 %(counter)s 項錯誤\n"
 "                "
 
-#: templates/forms/report_base.html:84
+#: templates/forms/report_base.html:85
+#: templates/forms/report_contact_info.html:40
 msgid "Submit"
 msgstr "提交"
 
-#: templates/forms/report_base.html:86
+#: templates/forms/report_base.html:87
+#: templates/forms/report_contact_info.html:42
 msgid "Next"
 msgstr "下一步"
 
-#: templates/forms/report_base.html:93 templates/forms/report_review.html:32
+#: templates/forms/report_base.html:95 templates/forms/report_review.html:33
 msgid "previous step"
 msgstr "上一步"
 
-#: templates/forms/report_base.html:96 templates/forms/report_review.html:35
+#: templates/forms/report_base.html:98 templates/forms/report_review.html:36
 #: templates/partials/redirect-modal.html:21
 msgid "Back"
 msgstr "返回"
@@ -1594,8 +1596,8 @@ msgstr "舉報侵權事件"
 msgid "Already submitted?"
 msgstr "已經提交？"
 
-#: templates/landing.html:58 templates/partials/footer.html:9 views.py:951
-#: views.py:1030 views.py:1049
+#: templates/landing.html:58 templates/partials/footer.html:9
+#: views_public.py:145 views_public.py:224 views_public.py:243
 msgid "Contact"
 msgstr "聯絡"
 
@@ -1619,7 +1621,7 @@ msgid ""
 "submit a report using our online form."
 msgstr "如果您認為自己或他人的民權受到侵犯，請使用我們的線上表格提交報告。"
 
-#: templates/landing.html:88
+#: templates/landing.html:88 templates/landing.html:326
 msgid "Start a report"
 msgstr "開始提交報告"
 
@@ -1841,10 +1843,6 @@ msgstr ""
 msgid "Have you or someone you know experienced a civil rights violation?"
 msgstr "您或您所認識的人是否曾遭遇民權侵權事件？"
 
-#: templates/landing.html:326
-msgid "Submit a report"
-msgstr "提交報告"
-
 #: templates/landing.html:331
 msgid ""
 "If you cannot access the online form, you can <a href=\"#phone-footer"
@@ -1956,6 +1954,30 @@ msgstr "美國政府官方網站"
 #: templates/partials/banner/usa_banner_header.html:13
 msgid "Here’s how you know"
 msgstr "以下為您說明辨識方式"
+
+#: templates/partials/contact-info-confirmation-modal.html:8
+msgid ""
+"You are continuing your complaint without providing email or phone "
+"information."
+msgstr "您在繼續填寫您的報告，但尚未提供電子郵件或電話信息。"
+
+#: templates/partials/contact-info-confirmation-modal.html:13
+msgid ""
+"You do not have to provide contact information, however, we will not be able "
+"to contact you for any status updates or potential follow up. Would you like "
+"to add your contact information now? If you prefer not to, you will go to "
+"Step 2."
+msgstr ""
+"您不一定要提供聯繫信息，但是，我們將無法與你聯繫，以提供任何狀態更新或進行後"
+"續跟進。您想現在添加聯繫信息嗎？如果不願意，您將進入第2步。"
+
+#: templates/partials/contact-info-confirmation-modal.html:16
+msgid "No, I don't want to provide it"
+msgstr "不，我不想提供聯繫方式"
+
+#: templates/partials/contact-info-confirmation-modal.html:17
+msgid "Yes, I'd like to add it"
+msgstr "好，我想添加聯繫方式"
 
 #: templates/partials/footer.html:47
 msgid "Availability of Language Assistance Services"
@@ -2385,23 +2407,75 @@ msgstr ""
 "82 Fed. Reg. 24147 (5-25-2017)。\n"
 "                "
 
-#: validators.py:101
+#: validators.py:106
 msgid "Enter a valid email address."
 msgstr "輸入一个有效的電子郵件地址"
 
-#: views.py:78
+#: views_public.py:146 views_public.py:225 views_public.py:226
+#: views_public.py:244 views_public.py:245 views_public.py:280
+msgid "Primary concern"
+msgstr "主要擔憂問題"
+
+#: views_public.py:147 views_public.py:227 views_public.py:228
+#: views_public.py:229 views_public.py:230 views_public.py:231
+#: views_public.py:232
+msgid "Location"
+msgstr "地點"
+
+#: views_public.py:148 views_public.py:233 views_public.py:252
+msgid "Personal characteristics"
+msgstr "個人特徵"
+
+#: views_public.py:149 views_public.py:234 views_public.py:253
+msgid "Date"
+msgstr "日期"
+
+#: views_public.py:150 views_public.py:235 views_public.py:254
+msgid "Personal description"
+msgstr "個人描述"
+
+#: views_public.py:151 views_public.py:236 views_public.py:285
+msgid "Review"
+msgstr "審查"
+
+#: views_public.py:246 views_public.py:247 views_public.py:248
+#: views_public.py:249 views_public.py:250 views_public.py:251
+msgid "Location details"
+msgstr "地點詳細資訊"
+
+#: views_public.py:255
+msgid "Review your report"
+msgstr "審查您的報告"
+
+#: views_public.py:271
+msgid "word remaining"
+msgstr "仍有剩餘字數"
+
+#: views_public.py:272
+msgid " words remaining"
+msgstr " 仍有剩餘字數"
+
+#: views_public.py:273
+msgid " word limit reached"
+msgstr " 已達字數限制"
+
+#: views_public.py:283
+msgid "Please select if any that apply to your situation (optional)"
+msgstr "請選擇任何適用於您情況的選項（選填）"
+
+#: views_public.py:359
 msgid "404 | Page not found"
 msgstr "404 | 找不到網頁"
 
-#: views.py:79
+#: views_public.py:360
 msgid "We can't find the page you are looking for"
 msgstr "我們找不到您要尋找的網頁"
 
-#: views.py:138
+#: views_public.py:419
 msgid "Your browser couldn't create a secure cookie"
 msgstr "您的瀏覽器無法建立安全 cookie"
 
-#: views.py:139
+#: views_public.py:420
 msgid ""
 "We use security cookies to protect your information from attackers. Make "
 "sure you allow cookies for this site. Having the page open for long periods "
@@ -2414,53 +2488,5 @@ msgstr ""
 "cookies，但您仍發生此問題，請嘗試使用新的瀏覽器分頁或視窗開啟此網頁。這將可讓"
 "您使用新的安全 cookie 且應能解決問題。"
 
-#: views.py:826 views.py:1077
-msgid "word remaining"
-msgstr "仍有剩餘字數"
-
-#: views.py:827 views.py:1078
-msgid " words remaining"
-msgstr " 仍有剩餘字數"
-
-#: views.py:828 views.py:1079
-msgid " word limit reached"
-msgstr " 已達字數限制"
-
-#: views.py:952 views.py:1031 views.py:1032 views.py:1050 views.py:1051
-#: views.py:1086
-msgid "Primary concern"
-msgstr "主要擔憂問題"
-
-#: views.py:953 views.py:1033 views.py:1034 views.py:1035 views.py:1036
-#: views.py:1037 views.py:1038
-msgid "Location"
-msgstr "地點"
-
-#: views.py:954 views.py:1039 views.py:1058
-msgid "Personal characteristics"
-msgstr "個人特徵"
-
-#: views.py:955 views.py:1040 views.py:1059
-msgid "Date"
-msgstr "日期"
-
-#: views.py:956 views.py:1041 views.py:1060
-msgid "Personal description"
-msgstr "個人描述"
-
-#: views.py:957 views.py:1042 views.py:1091
-msgid "Review"
-msgstr "審查"
-
-#: views.py:1052 views.py:1053 views.py:1054 views.py:1055 views.py:1056
-#: views.py:1057
-msgid "Location details"
-msgstr "地點詳細資訊"
-
-#: views.py:1061
-msgid "Review your report"
-msgstr "審查您的報告"
-
-#: views.py:1089
-msgid "Please select if any that apply to your situation (optional)"
-msgstr "請選擇任何適用於您情況的選項（選填）"
+#~ msgid "Submit a report"
+#~ msgstr "提交報告"


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/991)

## What does this change?

Chinese, traditional language translation for the contact info nudge modal

## Screenshots (for front-end PR):

![image](https://user-images.githubusercontent.com/6232068/127214943-a701ab4a-1ebf-45fb-aad9-fb928d6e8c19.png)


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
