### PR TITLE
Tagalog language translation

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -40,6 +40,7 @@ filter_options = {
     'reported_reason': 'reported_reason',
     'referred': 'eq',
     'language': '__in',
+    'correctional_facility_type': '__in',
 }
 
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1042,6 +1042,13 @@ class Filters(ModelForm):
             'name': 'referred'
         }),
     )
+    correctional_facility_type = MultipleChoiceField(
+        required=False,
+        choices=CORRECTIONAL_FACILITY_LOCATION_TYPE_CHOICES,
+        widget=UsaCheckboxSelectMultiple(attrs={
+            'name': 'correctional_facility_type',
+        }),
+    )
 
     class Meta:
         model = Report
@@ -1064,7 +1071,8 @@ class Filters(ModelForm):
             'intake_format',
             'contact_email',
             'referred',
-            'language'
+            'language',
+            'correctional_facility_type',
         ]
 
         labels = {
@@ -1082,6 +1090,7 @@ class Filters(ModelForm):
             'create_date_start': 'Created Date Start',
             'create_date_end': 'Created Date End',
             'contact_email': 'Contact email',
+            'correctional_facility_type': 'Prison Type',
         }
 
         widgets = {

--- a/crt_portal/cts_forms/locale/ko/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/ko/LC_MESSAGES/django.po
@@ -1,24 +1,24 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 19:27+0000\n"
+"POT-Creation-Date: 2021-07-27 19:06+0000\n"
 "Language: Korean\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:161 forms.py:1546
+#: forms.py:182 forms.py:1577
 msgid " - Select - "
 msgstr " - 선택 - "
 
 #. Translators: This is help text for the question asking if someone is a service member
-#: forms.py:173
+#: forms.py:194
 msgid ""
 "If you’re reporting on behalf of someone else, please select their status."
 msgstr "누군가를 대신하여 신고하는 경우라면 그 사람의 신분을 선택하십시오."
 
-#: forms.py:190 templates/forms/report_contact_info.html:8
+#: forms.py:211 templates/forms/report_contact_info.html:9
 msgid ""
 "If you believe you or someone else has experienced a civil rights violation, "
 "please tell us what happened."
@@ -26,7 +26,7 @@ msgstr ""
 "귀하 또는 다른 누군가가 민권 침해를 경험했다고 생각되면, 어떤 일이 있었는지 "
 "저희에게 알려주십시오."
 
-#: forms.py:216
+#: forms.py:237
 msgid ""
 "Select the reason that best describes your concern. Each reason lists "
 "examples of civil rights violations that may relate to your incident. In "
@@ -38,21 +38,21 @@ msgstr ""
 "의 다른 섹션에서는 우려하는 바를 귀하 스스로의 표현으로 설명할 수 있습니다."
 
 #. Translators: notes that this page is the same form step as the page before
-#: forms.py:239
+#: forms.py:260
 msgid "Continued"
 msgstr "계속"
 
-#: forms.py:295
+#: forms.py:317
 msgid ""
 "Examples: Name of business, school, intersection, prison, polling place, "
 "website, etc."
 msgstr "예: 사업체, 학교, 교차로, 교도소, 투표소, 웹사이트 등의 이름"
 
-#: forms.py:317 question_text.py:29
+#: forms.py:339 question_text.py:29
 msgid "Where did this happen?"
 msgstr "이 일이 발생한 것은 언제입니까?"
 
-#: forms.py:329
+#: forms.py:351
 msgid ""
 "Please tell us the city, state, and name of the location where this incident "
 "took place. This ensures your report is reviewed by the right people within "
@@ -61,7 +61,7 @@ msgstr ""
 "이 일이 일어난 장소의 이름과 시, 주를 알려 주십시오. 이 정보를 바탕으로 민권"
 "국(Civil Rights Division) 내의 적합한 사람이 귀하의 신고를 검토하게 됩니다."
 
-#: forms.py:392
+#: forms.py:414
 msgid ""
 "Public employers include organizations funded by the government like the "
 "military, post office, fire department, courthouse, DMV, or public school. "
@@ -70,7 +70,7 @@ msgstr ""
 "공공 고용주에는 군대, 우체국, 소방서, 법원, DMV 또는 공립학교와 같은 정부 예"
 "산이 투입되는 조직이 포함됩니다. 이는 지방 또는 주(state) 차원일 수 있습니다."
 
-#: forms.py:393
+#: forms.py:415
 msgid ""
 "Private employers are business or non-profits not funded by the government "
 "such as retail stores, banks, or restaurants."
@@ -79,11 +79,11 @@ msgstr ""
 "는 비영리 조직을 말합니다."
 
 #. Translators: describe the "other" option for commercial or public place question
-#: forms.py:439
+#: forms.py:461
 msgid "Please describe"
 msgstr "기술해 주십시오"
 
-#: forms.py:506
+#: forms.py:528
 msgid ""
 "Includes schools, educational programs, or educational activities, like "
 "training programs, sports teams, clubs, or other school-sponsored activities"
@@ -91,11 +91,11 @@ msgstr ""
 "학교, 교육 프로그램 또는 훈련 프로그램, 스포츠팀, 클럽, 기타 학교 후원 활동 "
 "등과 같은 교육 활동이 포함됩니다"
 
-#: forms.py:517
+#: forms.py:539
 msgid "Please select the type of school or educational program."
 msgstr "학교 또는 교육 프로그램의 유형을 선택하십시오."
 
-#: forms.py:540
+#: forms.py:562
 msgid ""
 "There are federal and state laws that protect people from discrimination "
 "based on their personal characteristics. Here is a list of the most common "
@@ -107,11 +107,11 @@ msgstr ""
 "경우에 적용되는 것을 선택하십시오."
 
 #. Translators: This is to explain an "other" choice for personal characteristics
-#: forms.py:545
+#: forms.py:567
 msgid "Please describe \"Other reason\""
 msgstr "“기타 이유”를 기술해 주십시오"
 
-#: forms.py:627
+#: forms.py:649
 msgid ""
 "It is important for us to know how recently this incident happened so we can "
 "take the appropriate action. If this happened over a period of time or is "
@@ -121,19 +121,19 @@ msgstr ""
 "조치를 취할 수 있습니다. 이 일이 일정 기간 동안 일어났거나 현재도 일어나고 있"
 "다면, 가장 최근 날짜를 알려주십시오."
 
-#: forms.py:915
+#: forms.py:937
 msgid "Primary classification"
 msgstr "주요 분류"
 
-#: forms.py:937
+#: forms.py:959
 msgid "Assigned to"
 msgstr "다음에 배정됨:"
 
-#: forms.py:1104
+#: forms.py:1134
 msgid "Create date cannot be in the future."
 msgstr "생성 날짜는 미래일 수 없습니다."
 
-#: forms.py:1286
+#: forms.py:1317
 msgid "Comment cannot be empty"
 msgstr "설명란은 비어 있을 수 없습니다"
 
@@ -1181,7 +1181,7 @@ msgstr "민권국"
 #: templates/forms/question_cards/police_location.html:4
 #: templates/forms/question_cards/single_form.html:16
 #: templates/forms/question_cards/single_question.html:13
-#: templates/forms/report_class.html:14 templates/forms/report_details.html:13
+#: templates/forms/report_class.html:14 templates/forms/report_details.html:12
 #: templates/forms/report_location.html:33
 #: templates/forms/report_location.html:39
 #: templates/forms/report_primary_complaint.html:11
@@ -1519,19 +1519,21 @@ msgstr[1] ""
 "                  %(counter)s개의 오류 발견\n"
 "                "
 
-#: templates/forms/report_base.html:84
+#: templates/forms/report_base.html:85
+#: templates/forms/report_contact_info.html:40
 msgid "Submit"
 msgstr "제출"
 
-#: templates/forms/report_base.html:86
+#: templates/forms/report_base.html:87
+#: templates/forms/report_contact_info.html:42
 msgid "Next"
 msgstr "다음"
 
-#: templates/forms/report_base.html:93 templates/forms/report_review.html:32
+#: templates/forms/report_base.html:95 templates/forms/report_review.html:33
 msgid "previous step"
 msgstr "이전 단계"
 
-#: templates/forms/report_base.html:96 templates/forms/report_review.html:35
+#: templates/forms/report_base.html:98 templates/forms/report_review.html:36
 #: templates/partials/redirect-modal.html:21
 msgid "Back"
 msgstr "뒤로"
@@ -1640,8 +1642,8 @@ msgstr "침해 신고"
 msgid "Already submitted?"
 msgstr "이미 제출하셨습니까?"
 
-#: templates/landing.html:58 templates/partials/footer.html:9 views.py:951
-#: views.py:1030 views.py:1049
+#: templates/landing.html:58 templates/partials/footer.html:9
+#: views_public.py:145 views_public.py:224 views_public.py:243
 msgid "Contact"
 msgstr "연락처"
 
@@ -1668,7 +1670,7 @@ msgstr ""
 "귀하 또는 다른 누군가의 민권이 침해되었다고 믿는 경우, 온라인 양식을 이용해 "
 "신고서를 제출하십시오."
 
-#: templates/landing.html:88
+#: templates/landing.html:88 templates/landing.html:326
 msgid "Start a report"
 msgstr "신고서 작성을 시작하거나"
 
@@ -1898,10 +1900,6 @@ msgstr ""
 msgid "Have you or someone you know experienced a civil rights violation?"
 msgstr "귀하 또는 지인이 민권 침해를 경험했습니까?"
 
-#: templates/landing.html:326
-msgid "Submit a report"
-msgstr "신고서를 제출하십시오."
-
 #: templates/landing.html:331
 msgid ""
 "If you cannot access the online form, you can <a href=\"#phone-footer"
@@ -2017,6 +2015,33 @@ msgstr "미국 정부의 공식 웹사이트"
 #: templates/partials/banner/usa_banner_header.html:13
 msgid "Here’s how you know"
 msgstr "알 수 있는 방법이 있습니다"
+
+#: templates/partials/contact-info-confirmation-modal.html:8
+msgid ""
+"You are continuing your complaint without providing email or phone "
+"information."
+msgstr ""
+"귀하께서는 이메일 또는 전화 정보를 제공하지 않은 채 계속 불만을 보고하고 계십"
+"니다."
+
+#: templates/partials/contact-info-confirmation-modal.html:13
+msgid ""
+"You do not have to provide contact information, however, we will not be able "
+"to contact you for any status updates or potential follow up. Would you like "
+"to add your contact information now? If you prefer not to, you will go to "
+"Step 2."
+msgstr ""
+"연락 정보를 제공하지 않으셔도 되지만 상황 업데이트 또는 잠재적 후속조치를 위"
+"해 귀하에게 연락을 취할 수 없게 됩니다. 지금 연락 정보를 추가하시겠습니까? 원"
+"하시지 않을 경우, 2단계로 가십시오."
+
+#: templates/partials/contact-info-confirmation-modal.html:16
+msgid "No, I don't want to provide it"
+msgstr "아니요, 제공하고 싶지 않습니다."
+
+#: templates/partials/contact-info-confirmation-modal.html:17
+msgid "Yes, I'd like to add it"
+msgstr "예, 추가하고 싶습니다."
 
 #: templates/partials/footer.html:47
 msgid "Availability of Language Assistance Services"
@@ -2493,23 +2518,75 @@ msgstr ""
 "해 철회됨); 82 Fed. Reg. 24147 (5-25-2017).\n"
 "                "
 
-#: validators.py:101
+#: validators.py:106
 msgid "Enter a valid email address."
 msgstr "유효한 이메일 주소를 입력하십시오."
 
-#: views.py:78
+#: views_public.py:146 views_public.py:225 views_public.py:226
+#: views_public.py:244 views_public.py:245 views_public.py:280
+msgid "Primary concern"
+msgstr "주요 우려사항"
+
+#: views_public.py:147 views_public.py:227 views_public.py:228
+#: views_public.py:229 views_public.py:230 views_public.py:231
+#: views_public.py:232
+msgid "Location"
+msgstr "장소"
+
+#: views_public.py:148 views_public.py:233 views_public.py:252
+msgid "Personal characteristics"
+msgstr "인적 특성"
+
+#: views_public.py:149 views_public.py:234 views_public.py:253
+msgid "Date"
+msgstr "날짜"
+
+#: views_public.py:150 views_public.py:235 views_public.py:254
+msgid "Personal description"
+msgstr "개인적 설명"
+
+#: views_public.py:151 views_public.py:236 views_public.py:285
+msgid "Review"
+msgstr "검토"
+
+#: views_public.py:246 views_public.py:247 views_public.py:248
+#: views_public.py:249 views_public.py:250 views_public.py:251
+msgid "Location details"
+msgstr "장소 세부사항"
+
+#: views_public.py:255
+msgid "Review your report"
+msgstr "신고 내용을 검토하십시오"
+
+#: views_public.py:271
+msgid "word remaining"
+msgstr "단어 수 남아 있음"
+
+#: views_public.py:272
+msgid " words remaining"
+msgstr " 단어 수 남아 있음"
+
+#: views_public.py:273
+msgid " word limit reached"
+msgstr " 단어 수 제한에 도달"
+
+#: views_public.py:283
+msgid "Please select if any that apply to your situation (optional)"
+msgstr "귀하의 상황에 적용되는 것이 있다면 그것을 선택하십시오.(선택사항)"
+
+#: views_public.py:359
 msgid "404 | Page not found"
 msgstr "404 | 페이지를 찾을 수 없음"
 
-#: views.py:79
+#: views_public.py:360
 msgid "We can't find the page you are looking for"
 msgstr "찾고 계신 페이지를 찾을 수가 없습니다"
 
-#: views.py:138
+#: views_public.py:419
 msgid "Your browser couldn't create a secure cookie"
 msgstr "브라우저가 안전한 쿠키를 생성할 수 없었습니다"
 
-#: views.py:139
+#: views_public.py:420
 msgid ""
 "We use security cookies to protect your information from attackers. Make "
 "sure you allow cookies for this site. Having the page open for long periods "
@@ -2523,53 +2600,5 @@ msgstr ""
 "면, 새로운 브라우저 탭이나 창에서 이 페이지로 가 보십시오. 이렇게 하면 새로"
 "운 보안 쿠키를 만들어 문제가 해결될 것입니다."
 
-#: views.py:826 views.py:1077
-msgid "word remaining"
-msgstr "단어 수 남아 있음"
-
-#: views.py:827 views.py:1078
-msgid " words remaining"
-msgstr " 단어 수 남아 있음"
-
-#: views.py:828 views.py:1079
-msgid " word limit reached"
-msgstr " 단어 수 제한에 도달"
-
-#: views.py:952 views.py:1031 views.py:1032 views.py:1050 views.py:1051
-#: views.py:1086
-msgid "Primary concern"
-msgstr "주요 우려사항"
-
-#: views.py:953 views.py:1033 views.py:1034 views.py:1035 views.py:1036
-#: views.py:1037 views.py:1038
-msgid "Location"
-msgstr "장소"
-
-#: views.py:954 views.py:1039 views.py:1058
-msgid "Personal characteristics"
-msgstr "인적 특성"
-
-#: views.py:955 views.py:1040 views.py:1059
-msgid "Date"
-msgstr "날짜"
-
-#: views.py:956 views.py:1041 views.py:1060
-msgid "Personal description"
-msgstr "개인적 설명"
-
-#: views.py:957 views.py:1042 views.py:1091
-msgid "Review"
-msgstr "검토"
-
-#: views.py:1052 views.py:1053 views.py:1054 views.py:1055 views.py:1056
-#: views.py:1057
-msgid "Location details"
-msgstr "장소 세부사항"
-
-#: views.py:1061
-msgid "Review your report"
-msgstr "신고 내용을 검토하십시오"
-
-#: views.py:1089
-msgid "Please select if any that apply to your situation (optional)"
-msgstr "귀하의 상황에 적용되는 것이 있다면 그것을 선택하십시오.(선택사항)"
+#~ msgid "Submit a report"
+#~ msgstr "신고서를 제출하십시오."

--- a/crt_portal/cts_forms/locale/tl/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/tl/LC_MESSAGES/django.po
@@ -1,25 +1,25 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-29 21:00+0000\n"
+"POT-Creation-Date: 2021-08-09 15:33+0000\n"
 "Language: Tagalog\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:161 forms.py:1546
+#: forms.py:182 forms.py:1586
 msgid " - Select - "
 msgstr " - Pumili - "
 
 #. Translators: This is help text for the question asking if someone is a service member
-#: forms.py:173
+#: forms.py:194
 msgid ""
 "If you’re reporting on behalf of someone else, please select their status."
 msgstr ""
 "Kung ikaw ay nag-uulat sa ngalan ng ibang tao, mangyaring piliin ang "
 "kanilang katayuan."
 
-#: forms.py:190 templates/forms/report_contact_info.html:8
+#: forms.py:211 templates/forms/report_contact_info.html:9
 msgid ""
 "If you believe you or someone else has experienced a civil rights violation, "
 "please tell us what happened."
@@ -27,7 +27,7 @@ msgstr ""
 "Kung sa paniniwala mo na ikaw o ang ibang tao ay nakaranas ng isang paglabag "
 "sa mga karapatang sibil, mangyaring sabihin sa amin kung ano ang nangyari."
 
-#: forms.py:216
+#: forms.py:237
 msgid ""
 "Select the reason that best describes your concern. Each reason lists "
 "examples of civil rights violations that may relate to your incident. In "
@@ -40,11 +40,11 @@ msgstr ""
 "maaari mong ilarawan ang iyong pagkabahala sa sarili mong mga salita."
 
 #. Translators: notes that this page is the same form step as the page before
-#: forms.py:239
+#: forms.py:260
 msgid "Continued"
 msgstr "Pagpapatuloy"
 
-#: forms.py:295
+#: forms.py:317
 msgid ""
 "Examples: Name of business, school, intersection, prison, polling place, "
 "website, etc."
@@ -52,11 +52,11 @@ msgstr ""
 "Mga halimbawa: Pangalan ng negosyo, paaralan, interseksyon, kulungan, lugar "
 "kung saan maaaring bomoto, website, at iba pa."
 
-#: forms.py:317 question_text.py:29
+#: forms.py:339 question_text.py:29
 msgid "Where did this happen?"
 msgstr "Saan ito nangyari?"
 
-#: forms.py:329
+#: forms.py:351
 msgid ""
 "Please tell us the city, state, and name of the location where this incident "
 "took place. This ensures your report is reviewed by the right people within "
@@ -66,7 +66,7 @@ msgstr ""
 "saan naganap ang panyayaring ito. Tinitiyak nito na ang iyong ulat ay "
 "masusuri ng mga tamang tao sa loob ng Dibisyon sa mga Karapatang Sibil."
 
-#: forms.py:392
+#: forms.py:414
 msgid ""
 "Public employers include organizations funded by the government like the "
 "military, post office, fire department, courthouse, DMV, or public school. "
@@ -77,7 +77,7 @@ msgstr ""
 "korte, DMV, o pampublikong paaralan. Ito ay maaaring nasa lokal o estadong "
 "antas."
 
-#: forms.py:393
+#: forms.py:415
 msgid ""
 "Private employers are business or non-profits not funded by the government "
 "such as retail stores, banks, or restaurants."
@@ -87,11 +87,11 @@ msgstr ""
 "restawran."
 
 #. Translators: describe the "other" option for commercial or public place question
-#: forms.py:439
+#: forms.py:461
 msgid "Please describe"
 msgstr "Mangyaring ilarawan"
 
-#: forms.py:506
+#: forms.py:528
 msgid ""
 "Includes schools, educational programs, or educational activities, like "
 "training programs, sports teams, clubs, or other school-sponsored activities"
@@ -100,11 +100,11 @@ msgstr ""
 "na pang-edukasyon, katulad ng mga palatuntunan sa pagsasanay, mga koponan sa "
 "paglalaro, mga klab o ibang aktibidad na sinusuportahan ng paaralan"
 
-#: forms.py:517
+#: forms.py:539
 msgid "Please select the type of school or educational program."
 msgstr "Mangyaring piliin ang uri ng paaralan o palatuntunang pang-edukasyon."
 
-#: forms.py:540
+#: forms.py:562
 msgid ""
 "There are federal and state laws that protect people from discrimination "
 "based on their personal characteristics. Here is a list of the most common "
@@ -117,11 +117,11 @@ msgstr ""
 "na pamamaraan. Pumili ng anuman na nababagay sa iyong insidente."
 
 #. Translators: This is to explain an "other" choice for personal characteristics
-#: forms.py:545
+#: forms.py:567
 msgid "Please describe \"Other reason\""
 msgstr "Mangyaring ilarawan ang “Ibang dahilan”"
 
-#: forms.py:627
+#: forms.py:649
 msgid ""
 "It is important for us to know how recently this incident happened so we can "
 "take the appropriate action. If this happened over a period of time or is "
@@ -132,19 +132,19 @@ msgstr ""
 "kasalukuyan pa ring nangyayari, mangyaring ibigay ang pinaka-kamakailan na "
 "petsa."
 
-#: forms.py:915
+#: forms.py:937
 msgid "Primary classification"
 msgstr "Pangunahing pag-uuri"
 
-#: forms.py:937
+#: forms.py:959
 msgid "Assigned to"
 msgstr "Naitalaga kay"
 
-#: forms.py:1104
+#: forms.py:1143
 msgid "Create date cannot be in the future."
 msgstr "Ang petsa na inilikha ay hindi maaaring sa hinaharap."
 
-#: forms.py:1286
+#: forms.py:1326
 msgid "Comment cannot be empty"
 msgstr "Ang puna ay hindi maaaring walang laman"
 
@@ -1219,13 +1219,13 @@ msgid "Any supporting materials (please list and describe them)"
 msgstr ""
 "Anumang pang-suportang materyales (mangyaring ilista at ilarawan ang mga ito)"
 
-#: templates/base.html:33 templates/base.html:58
+#: templates/base.html:42 templates/base.html:67
 #: templates/forms/report_base.html:10 templates/forms/report_base.html:13
 msgid "Contact the Civil Rights Division | Department of Justice"
 msgstr ""
 "Makipag-ugnay sa Dibisyon sa mga Karapatang Sibil | Kagawaran ng Katarungan"
 
-#: templates/base.html:46
+#: templates/base.html:55
 msgid ""
 "Have you or someone you know experienced unlawful discrimination? The Civil "
 "Rights Division may be able to help. Civil rights laws can protect you from "
@@ -1240,16 +1240,16 @@ msgstr ""
 "katulad ng pabahay, lugar ng pinagtratrabahuhan, paaralan, botohan, mga "
 "negosyo, pangangalaga sa kalusugan, pamublikong puwang, at iba pa."
 
-#: templates/base.html:67
+#: templates/base.html:76
 msgid "Skip to main content"
 msgstr "Lampasan upang mapunta sa pangunahing nilalaman"
 
-#: templates/base.html:121 templates/forms/errors.html:13
+#: templates/base.html:130 templates/forms/errors.html:13
 #: templates/forms/report_maintenance.html:13 templates/landing.html:17
 msgid "U.S. Department of Justice"
 msgstr "Kagawaran ng Katarungan ng Estados Unidos"
 
-#: templates/base.html:124 templates/forms/confirmation.html:21
+#: templates/base.html:133 templates/forms/confirmation.html:21
 #: templates/forms/errors.html:14 templates/forms/report_maintenance.html:14
 #: templates/landing.html:20
 msgid "Civil Rights Division"
@@ -1261,7 +1261,7 @@ msgstr "Dibisyon sa mga Karapatang Sibil"
 #: templates/forms/question_cards/police_location.html:4
 #: templates/forms/question_cards/single_form.html:16
 #: templates/forms/question_cards/single_question.html:13
-#: templates/forms/report_class.html:14 templates/forms/report_details.html:13
+#: templates/forms/report_class.html:14 templates/forms/report_details.html:12
 #: templates/forms/report_location.html:33
 #: templates/forms/report_location.html:39
 #: templates/forms/report_primary_complaint.html:11
@@ -1611,19 +1611,22 @@ msgstr[1] ""
 "\n"
 "                  %(counter)s kamaliang natagpuan                "
 
-#: templates/forms/report_base.html:84
+#: templates/forms/report_base.html:85
+#: templates/forms/report_contact_info.html:40
 msgid "Submit"
 msgstr "i-sumite"
 
-#: templates/forms/report_base.html:86
+#: templates/forms/report_base.html:87
+#: templates/forms/report_contact_info.html:34
+#: templates/forms/report_contact_info.html:42
 msgid "Next"
 msgstr "Kasunod"
 
-#: templates/forms/report_base.html:93 templates/forms/report_review.html:32
+#: templates/forms/report_base.html:95 templates/forms/report_review.html:33
 msgid "previous step"
 msgstr "nakaraang hakbang"
 
-#: templates/forms/report_base.html:96 templates/forms/report_review.html:35
+#: templates/forms/report_base.html:98 templates/forms/report_review.html:36
 #: templates/partials/redirect-modal.html:21
 msgid "Back"
 msgstr "Balik"
@@ -1738,8 +1741,8 @@ msgstr "Mag-ulat ng paglabag"
 msgid "Already submitted?"
 msgstr "Naisumite na?"
 
-#: templates/landing.html:58 templates/partials/footer.html:9 views.py:951
-#: views.py:1030 views.py:1049
+#: templates/landing.html:58 templates/partials/footer.html:9
+#: views_public.py:145 views_public.py:224 views_public.py:243
 msgid "Contact"
 msgstr "Makipag-ugnay"
 
@@ -1770,7 +1773,7 @@ msgstr ""
 "Kung naniniwala ka na ang iyong mga karapatang sibil o ng ibang tao ay "
 "nalabag, magsumite ng ulat gamit ang aming online na pormularyo."
 
-#: templates/landing.html:88
+#: templates/landing.html:88 templates/landing.html:326
 msgid "Start a report"
 msgstr "Mag-umpisa ng isang ulat"
 
@@ -2029,10 +2032,6 @@ msgstr ""
 "Ikaw ba o isang kakilala mo ay nakaranas ng isang paglabag sa mga karapatang "
 "sibil?"
 
-#: templates/landing.html:326
-msgid "Submit a report"
-msgstr "Magsumite ng ulat"
-
 #: templates/landing.html:331
 msgid ""
 "If you cannot access the online form, you can <a href=\"#phone-footer"
@@ -2154,6 +2153,35 @@ msgstr "Isang opisyal na website ng gobyerno ng Estados Unidos"
 #: templates/partials/banner/usa_banner_header.html:13
 msgid "Here’s how you know"
 msgstr "Ito ay kung paano mo malalaman"
+
+#: templates/partials/contact-info-confirmation-modal.html:8
+msgid ""
+"You are continuing your complaint without providing email or phone "
+"information."
+msgstr ""
+"Ipinagpapatuloy mo ang iyong pag-uulat nang hindi nagbibigay ng impormasyon "
+"sa iyong email o telepono."
+
+#: templates/partials/contact-info-confirmation-modal.html:13
+msgid ""
+"You do not have to provide contact information, however, we will not be able "
+"to contact you for any status updates or potential follow up. Would you like "
+"to add your contact information now? If you prefer not to, you will go to "
+"Step 2."
+msgstr ""
+"Hindi mo kinakailangang magbigay ng impormasyon sa pakikipag-ugnay, subalit, "
+"hindi naming magagawang makipag-ugnay sayo para sa anumang update sa "
+"katayuan o potensiyal na pag-follow up. Nais mo bang idagdag ang iyong "
+"impormasyon sa pakikipag-ugnay ngayon? Kung pipiliin mo na hindi, mapupunta "
+"ka sa Hakbang 2."
+
+#: templates/partials/contact-info-confirmation-modal.html:16
+msgid "No, I don't want to provide it"
+msgstr "Hindi, ayaw kong ibigay ito."
+
+#: templates/partials/contact-info-confirmation-modal.html:17
+msgid "Yes, I'd like to add it"
+msgstr "Oo, gusto kong idagdag ito."
 
 #: templates/partials/footer.html:47
 msgid "Availability of Language Assistance Services"
@@ -2649,23 +2677,76 @@ msgstr ""
 "(5-25-2017).\n"
 "                "
 
-#: validators.py:101
+#: validators.py:106
 msgid "Enter a valid email address."
 msgstr "Maglagay ng wastong email address."
 
-#: views.py:78
+#: views_public.py:146 views_public.py:225 views_public.py:226
+#: views_public.py:244 views_public.py:245 views_public.py:280
+msgid "Primary concern"
+msgstr "Pangunahing pagkabahala"
+
+#: views_public.py:147 views_public.py:227 views_public.py:228
+#: views_public.py:229 views_public.py:230 views_public.py:231
+#: views_public.py:232
+msgid "Location"
+msgstr "Lugar"
+
+#: views_public.py:148 views_public.py:233 views_public.py:252
+msgid "Personal characteristics"
+msgstr "Personal na mga katangian"
+
+#: views_public.py:149 views_public.py:234 views_public.py:253
+msgid "Date"
+msgstr "Petsa"
+
+#: views_public.py:150 views_public.py:235 views_public.py:254
+msgid "Personal description"
+msgstr "Personal na paglalarawan"
+
+#: views_public.py:151 views_public.py:236 views_public.py:285
+msgid "Review"
+msgstr "Pagsusuri"
+
+#: views_public.py:246 views_public.py:247 views_public.py:248
+#: views_public.py:249 views_public.py:250 views_public.py:251
+msgid "Location details"
+msgstr "Mga detalye ng lugar"
+
+#: views_public.py:255
+msgid "Review your report"
+msgstr "Suriin ang iyong ulat"
+
+#: views_public.py:271
+msgid "word remaining"
+msgstr "natitirang salita"
+
+#: views_public.py:272
+msgid " words remaining"
+msgstr " natitirang mga salita"
+
+#: views_public.py:273
+msgid " word limit reached"
+msgstr " naabot na ang hangganan ng salita"
+
+#: views_public.py:283
+msgid "Please select if any that apply to your situation (optional)"
+msgstr ""
+"Mangyaring pumili kung mayroong naaangkop  sa iyong sitwasyon (opsyonal)"
+
+#: views_public.py:359
 msgid "404 | Page not found"
 msgstr "404 | Pahina ay hindi makita"
 
-#: views.py:79
+#: views_public.py:360
 msgid "We can't find the page you are looking for"
 msgstr "Hindi namin makita ang pahina na iyong hinahanap"
 
-#: views.py:138
+#: views_public.py:419
 msgid "Your browser couldn't create a secure cookie"
 msgstr "Ang iyong browser ay hindi makalikha ng matatag na cookie"
 
-#: views.py:139
+#: views_public.py:420
 msgid ""
 "We use security cookies to protect your information from attackers. Make "
 "sure you allow cookies for this site. Having the page open for long periods "
@@ -2681,54 +2762,5 @@ msgstr ""
 "panibagong tab o window ng browser. Magbibigay ito ng isang panibagong "
 "security cookie sayo at maaaring maglutas sa problema."
 
-#: views.py:826 views.py:1077
-msgid "word remaining"
-msgstr "natitirang salita"
-
-#: views.py:827 views.py:1078
-msgid " words remaining"
-msgstr " natitirang mga salita"
-
-#: views.py:828 views.py:1079
-msgid " word limit reached"
-msgstr " naabot na ang hangganan ng salita"
-
-#: views.py:952 views.py:1031 views.py:1032 views.py:1050 views.py:1051
-#: views.py:1086
-msgid "Primary concern"
-msgstr "Pangunahing pagkabahala"
-
-#: views.py:953 views.py:1033 views.py:1034 views.py:1035 views.py:1036
-#: views.py:1037 views.py:1038
-msgid "Location"
-msgstr "Lugar"
-
-#: views.py:954 views.py:1039 views.py:1058
-msgid "Personal characteristics"
-msgstr "Personal na mga katangian"
-
-#: views.py:955 views.py:1040 views.py:1059
-msgid "Date"
-msgstr "Petsa"
-
-#: views.py:956 views.py:1041 views.py:1060
-msgid "Personal description"
-msgstr "Personal na paglalarawan"
-
-#: views.py:957 views.py:1042 views.py:1091
-msgid "Review"
-msgstr "Pagsusuri"
-
-#: views.py:1052 views.py:1053 views.py:1054 views.py:1055 views.py:1056
-#: views.py:1057
-msgid "Location details"
-msgstr "Mga detalye ng lugar"
-
-#: views.py:1061
-msgid "Review your report"
-msgstr "Suriin ang iyong ulat"
-
-#: views.py:1089
-msgid "Please select if any that apply to your situation (optional)"
-msgstr ""
-"Mangyaring pumili kung mayroong naaangkop  sa iyong sitwasyon (opsyonal)"
+#~ msgid "Submit a report"
+#~ msgstr "Magsumite ng ulat"

--- a/crt_portal/cts_forms/locale/vi/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/vi/LC_MESSAGES/django.po
@@ -1,26 +1,26 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-28 19:02+0000\n"
+"POT-Creation-Date: 2021-07-27 20:52+0000\n"
 "Language: Vietnamese\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:161 forms.py:1546
+#: forms.py:182 forms.py:1577
 msgid " - Select - "
 msgstr " - Chọn - "
 
 #. Translators: This is help text for the question asking if someone is a service member
-#: forms.py:173
+#: forms.py:194
 msgid ""
 "If you’re reporting on behalf of someone else, please select their status."
 msgstr ""
 "Nếu quý vị đang báo cáo thay mặt cho người khác, vui lòng chọn tình trạng "
 "của họ."
 
-#: forms.py:190 templates/forms/report_contact_info.html:8
+#: forms.py:211 templates/forms/report_contact_info.html:9
 msgid ""
 "If you believe you or someone else has experienced a civil rights violation, "
 "please tell us what happened."
@@ -28,7 +28,7 @@ msgstr ""
 "Nếu quý vị cho rằng quý vị hoặc một người nào đó đã bị vi phạm dân quyền, "
 "vui lòng cho chúng tôi biết điều gì đã xảy ra."
 
-#: forms.py:216
+#: forms.py:237
 msgid ""
 "Select the reason that best describes your concern. Each reason lists "
 "examples of civil rights violations that may relate to your incident. In "
@@ -41,11 +41,11 @@ msgstr ""
 "quan ngại của mình qua lời lẽ riêng của quý vị."
 
 #. Translators: notes that this page is the same form step as the page before
-#: forms.py:239
+#: forms.py:260
 msgid "Continued"
 msgstr "Tiếp tục"
 
-#: forms.py:295
+#: forms.py:317
 msgid ""
 "Examples: Name of business, school, intersection, prison, polling place, "
 "website, etc."
@@ -53,11 +53,11 @@ msgstr ""
 "Ví dụ: Tên doanh nghiệp, trường học, giao lộ, nhà tù, điểm bỏ phiếu, trang "
 "web, v.v."
 
-#: forms.py:317 question_text.py:29
+#: forms.py:339 question_text.py:29
 msgid "Where did this happen?"
 msgstr "Việc này đã xảy ra ở đâu?"
 
-#: forms.py:329
+#: forms.py:351
 msgid ""
 "Please tell us the city, state, and name of the location where this incident "
 "took place. This ensures your report is reviewed by the right people within "
@@ -67,7 +67,7 @@ msgstr ""
 "ra vụ việc này. Điều này nhằm đảm bảo báo cáo của quý vị được đánh giá bởi "
 "những người phù hợp trong Ban Dân quyền."
 
-#: forms.py:392
+#: forms.py:414
 msgid ""
 "Public employers include organizations funded by the government like the "
 "military, post office, fire department, courthouse, DMV, or public school. "
@@ -78,7 +78,7 @@ msgstr ""
 "phương tiện cơ giới (DMV) hoặc trường công lập. Đơn vị này có thể là ở cấp "
 "địa phương hoặc tiểu bang."
 
-#: forms.py:393
+#: forms.py:415
 msgid ""
 "Private employers are business or non-profits not funded by the government "
 "such as retail stores, banks, or restaurants."
@@ -87,11 +87,11 @@ msgstr ""
 "chính phủ tài trợ, chẳng hạn như cửa hàng bán lẻ, ngân hàng, hoặc nhà hàng."
 
 #. Translators: describe the "other" option for commercial or public place question
-#: forms.py:439
+#: forms.py:461
 msgid "Please describe"
 msgstr "Vui lòng mô tả"
 
-#: forms.py:506
+#: forms.py:528
 msgid ""
 "Includes schools, educational programs, or educational activities, like "
 "training programs, sports teams, clubs, or other school-sponsored activities"
@@ -100,11 +100,11 @@ msgstr ""
 "chương trình đào tạo, các đội thể thao, câu lạc bộ, hoặc các hoạt động khác "
 "do trường bảo trợ"
 
-#: forms.py:517
+#: forms.py:539
 msgid "Please select the type of school or educational program."
 msgstr "Vui lòng chọn loại hình trường học hoặc chương trình giáo dục."
 
-#: forms.py:540
+#: forms.py:562
 msgid ""
 "There are federal and state laws that protect people from discrimination "
 "based on their personal characteristics. Here is a list of the most common "
@@ -117,11 +117,11 @@ msgstr ""
 "vụ việc của quý vị."
 
 #. Translators: This is to explain an "other" choice for personal characteristics
-#: forms.py:545
+#: forms.py:567
 msgid "Please describe \"Other reason\""
 msgstr "Vui lòng mô tả “Lý do khác”"
 
-#: forms.py:627
+#: forms.py:649
 msgid ""
 "It is important for us to know how recently this incident happened so we can "
 "take the appropriate action. If this happened over a period of time or is "
@@ -132,19 +132,19 @@ msgstr ""
 "diễn ra trong một khoảng thời gian hoặc vẫn đang diễn ra, vui lòng cho biết "
 "ngày gần đây nhất."
 
-#: forms.py:915
+#: forms.py:937
 msgid "Primary classification"
 msgstr "Phân loại chính"
 
-#: forms.py:937
+#: forms.py:959
 msgid "Assigned to"
 msgstr "Được giao cho"
 
-#: forms.py:1104
+#: forms.py:1134
 msgid "Create date cannot be in the future."
 msgstr "Ngày tạo không được là ngày trong tương lai."
 
-#: forms.py:1286
+#: forms.py:1317
 msgid "Comment cannot be empty"
 msgstr "Nhận xét không được để trống"
 
@@ -153,11 +153,11 @@ msgstr "Nhận xét không được để trống"
 msgid "- Select -"
 msgstr "- Chọn -"
 
-#: model_variables.py:9 model_variables.py:119 model_variables.py:262
+#: model_variables.py:9 model_variables.py:119 model_variables.py:287
 msgid "Yes"
 msgstr "Có"
 
-#: model_variables.py:10 model_variables.py:120 model_variables.py:261
+#: model_variables.py:10 model_variables.py:120 model_variables.py:286
 msgid "No"
 msgstr "Không"
 
@@ -441,7 +441,7 @@ msgstr ""
 "tấn công thân thể, lạm dụng hoặc tấn công tình dục, các mối đe dọa gây tổn "
 "hại khác, hoặc bị giam giữ"
 
-#: model_variables.py:102 model_variables.py:268
+#: model_variables.py:102 model_variables.py:293
 msgid "Federal"
 msgstr "Liên Bang"
 
@@ -454,8 +454,8 @@ msgstr "Tiểu bang hoặc địa phương"
 msgid "Both"
 msgstr "Cả hai"
 
-#: model_variables.py:106 model_variables.py:270 model_variables.py:285
-#: model_variables.py:293 model_variables.py:310
+#: model_variables.py:106 model_variables.py:295 model_variables.py:310
+#: model_variables.py:318 model_variables.py:335
 msgid "I'm not sure"
 msgstr "Tôi không chắc"
 
@@ -557,31 +557,31 @@ msgstr ""
 "này phù hợp với tình huống của quý vị, vui lòng chọn “Không có lý do nào "
 "trong số này phù hợp với tôi” hoặc “Lý do khác” và giải thích."
 
-#: model_variables.py:233
+#: model_variables.py:258
 msgid "Place of worship or about a place of worship"
 msgstr "Nơi thờ phượng hoặc về một nơi thờ phượng"
 
-#: model_variables.py:234
+#: model_variables.py:259
 msgid "Commercial or retail building"
 msgstr "Tòa nhà thương mại hoặc bán lẻ"
 
-#: model_variables.py:235 model_variables.py:246
+#: model_variables.py:260 model_variables.py:271
 msgid "Healthcare facility"
 msgstr "Cơ sở chăm sóc sức khỏe"
 
-#: model_variables.py:236 model_variables.py:247
+#: model_variables.py:261 model_variables.py:272
 msgid "Financial institution"
 msgstr "Tổ chức tài chính"
 
-#: model_variables.py:237
+#: model_variables.py:262
 msgid "Public space"
 msgstr "Không gian công cộng"
 
-#: model_variables.py:238 templatetags/commercial_public_space_view.py:17
+#: model_variables.py:263 templatetags/commercial_public_space_view.py:17
 msgid "Other"
 msgstr "Khác"
 
-#: model_variables.py:241
+#: model_variables.py:266
 msgid ""
 "Please select the type of location. If none of these apply to your "
 "situation, please select \"Other\"."
@@ -589,27 +589,27 @@ msgstr ""
 "Vui lòng chọn loại địa điểm. Nếu không có địa điểm nào trong số các địa điểm "
 "này phù hợp với tình huống của quý vị, vui lòng chọn “Khác”."
 
-#: model_variables.py:244
+#: model_variables.py:269
 msgid "Place of worship"
 msgstr "Nơi thờ phượng"
 
-#: model_variables.py:245
+#: model_variables.py:270
 msgid "Commercial"
 msgstr "Thương mại"
 
-#: model_variables.py:248
+#: model_variables.py:273
 msgid "Public outdoor space"
 msgstr "Không gian công cộng ngoài trời"
 
-#: model_variables.py:252
+#: model_variables.py:277
 msgid "Church, synagogue, temple, religious community center"
 msgstr "Nhà thờ, đền thờ do thái, đền thờ, trung tâm cộng đồng tôn giáo"
 
-#: model_variables.py:253
+#: model_variables.py:278
 msgid "Store, restaurant, bar, hotel, theater"
 msgstr "Cửa hàng, nhà hàng, quán bar, khách sạn, rạp chiếu phim"
 
-#: model_variables.py:254
+#: model_variables.py:279
 msgid ""
 "Hospital or clinic (including inpatient and outpatient programs), "
 "reproductive care clinic, state developmental institution, nursing home"
@@ -617,11 +617,11 @@ msgstr ""
 "Bệnh viện hoặc phòng khám (bao gồm các chương trình nội trú và ngoại trú), "
 "phòng khám chăm sóc sinh sản, tổ chức phát triển tiểu bang, viện dưỡng lão"
 
-#: model_variables.py:255
+#: model_variables.py:280
 msgid "Bank, credit union, loan services"
 msgstr "Ngân hàng, tổ chức tín dụng, dịch vụ cho vay"
 
-#: model_variables.py:256
+#: model_variables.py:281
 msgid ""
 "Park, sidewalk, street, other public buildings (courthouse, DMV, city "
 "library)"
@@ -629,353 +629,353 @@ msgstr ""
 "Công viên, vỉa hè, đường phố, các tòa nhà công cộng khác (trụ sở tòa án, "
 "DMV, thư viện thành phố)"
 
-#: model_variables.py:267
+#: model_variables.py:292
 msgid "State/local"
 msgstr "Tiểu bang/địa phương"
 
-#: model_variables.py:269
+#: model_variables.py:294
 msgid "Private"
 msgstr "Tư nhân"
 
-#: model_variables.py:275
+#: model_variables.py:300
 msgid "Outside of prison"
 msgstr "Bên ngoài nhà tù"
 
-#: model_variables.py:277
+#: model_variables.py:302
 msgid "Prison (Federal)"
 msgstr "Nhà tù (Liên bang)"
 
-#: model_variables.py:278
+#: model_variables.py:303
 msgid "Prison (Private)"
 msgstr "Nhà tù (Tư nhân)"
 
-#: model_variables.py:279
+#: model_variables.py:304
 msgid "Prison (I'm not sure)"
 msgstr "Nhà tù (Tôi không chắc)"
 
-#: model_variables.py:283
+#: model_variables.py:308
 msgid "Public employer"
 msgstr "Cơ quan tuyển dụng công"
 
-#: model_variables.py:284
+#: model_variables.py:309
 msgid "Private employer"
 msgstr "Cơ quan tuyển dụng tư nhân"
 
-#: model_variables.py:288
+#: model_variables.py:313
 msgid "Please select what type of employer this is."
 msgstr "Vui lòng chọn loại hình cơ quan tuyển dụng này."
 
-#: model_variables.py:291
+#: model_variables.py:316
 msgid "Fewer than 15 employees"
 msgstr "Ít hơn 15 nhân viên"
 
-#: model_variables.py:292
+#: model_variables.py:317
 msgid "15 or more employees"
 msgstr "Từ 15 nhân viên trở lên"
 
-#: model_variables.py:296
+#: model_variables.py:321
 msgid "Please select how large the employer is."
 msgstr "Vui lòng chọn quy mô của cơ quan tuyển dụng."
 
-#: model_variables.py:308
+#: model_variables.py:333
 msgid "Public school or educational program"
 msgstr "Trường hoặc chương trình giáo dục công lập"
 
-#: model_variables.py:309
+#: model_variables.py:334
 msgid "Private school or educational program"
 msgstr "Trường hoặc chương trình giáo dục tư"
 
-#: model_variables.py:315
+#: model_variables.py:340
 msgid "Alabama"
 msgstr "Alabama"
 
-#: model_variables.py:316
+#: model_variables.py:341
 msgid "Alaska"
 msgstr "Alaska"
 
-#: model_variables.py:317
+#: model_variables.py:342
 msgid "Arizona"
 msgstr "Arizona"
 
-#: model_variables.py:318
+#: model_variables.py:343
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: model_variables.py:319
+#: model_variables.py:344
 msgid "California"
 msgstr "California"
 
-#: model_variables.py:320
+#: model_variables.py:345
 msgid "Colorado"
 msgstr "Colorado"
 
-#: model_variables.py:321
+#: model_variables.py:346
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#: model_variables.py:322
+#: model_variables.py:347
 msgid "Delaware"
 msgstr "Delaware"
 
-#: model_variables.py:323
+#: model_variables.py:348
 msgid "District of Columbia"
 msgstr "District of Columbia"
 
-#: model_variables.py:324
+#: model_variables.py:349
 msgid "Florida"
 msgstr "Florida"
 
-#: model_variables.py:325
+#: model_variables.py:350
 msgid "Georgia"
 msgstr "Georgia"
 
-#: model_variables.py:326
+#: model_variables.py:351
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#: model_variables.py:327
+#: model_variables.py:352
 msgid "Idaho"
 msgstr "Idaho"
 
-#: model_variables.py:328
+#: model_variables.py:353
 msgid "Illinois"
 msgstr "Illinois"
 
-#: model_variables.py:329
+#: model_variables.py:354
 msgid "Indiana"
 msgstr "Indiana"
 
-#: model_variables.py:330
+#: model_variables.py:355
 msgid "Iowa"
 msgstr "Iowa"
 
-#: model_variables.py:331
+#: model_variables.py:356
 msgid "Kansas"
 msgstr "Kansas"
 
-#: model_variables.py:332
+#: model_variables.py:357
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#: model_variables.py:333
+#: model_variables.py:358
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#: model_variables.py:334
+#: model_variables.py:359
 msgid "Maine"
 msgstr "Maine"
 
-#: model_variables.py:335
+#: model_variables.py:360
 msgid "Maryland"
 msgstr "Maryland"
 
-#: model_variables.py:336
+#: model_variables.py:361
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: model_variables.py:337
+#: model_variables.py:362
 msgid "Michigan"
 msgstr "Michigan"
 
-#: model_variables.py:338
+#: model_variables.py:363
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#: model_variables.py:339
+#: model_variables.py:364
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#: model_variables.py:340
+#: model_variables.py:365
 msgid "Missouri"
 msgstr "Missouri"
 
-#: model_variables.py:341
+#: model_variables.py:366
 msgid "Montana"
 msgstr "Montana"
 
-#: model_variables.py:342
+#: model_variables.py:367
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#: model_variables.py:343
+#: model_variables.py:368
 msgid "Nevada"
 msgstr "Nevada"
 
-#: model_variables.py:344
+#: model_variables.py:369
 msgid "New Hampshire"
 msgstr "New Hampshire"
 
-#: model_variables.py:345
+#: model_variables.py:370
 msgid "New Jersey"
 msgstr "New Jersey"
 
-#: model_variables.py:346
+#: model_variables.py:371
 msgid "New Mexico"
 msgstr "New Mexico"
 
-#: model_variables.py:347
+#: model_variables.py:372
 msgid "New York"
 msgstr "New York"
 
-#: model_variables.py:348
+#: model_variables.py:373
 msgid "North Carolina"
 msgstr "North Carolina"
 
-#: model_variables.py:349
+#: model_variables.py:374
 msgid "North Dakota"
 msgstr "North Dakota"
 
-#: model_variables.py:350
+#: model_variables.py:375
 msgid "Ohio"
 msgstr "Ohio"
 
-#: model_variables.py:351
+#: model_variables.py:376
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#: model_variables.py:352
+#: model_variables.py:377
 msgid "Oregon"
 msgstr "Oregon"
 
-#: model_variables.py:353
+#: model_variables.py:378
 msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
-#: model_variables.py:354
+#: model_variables.py:379
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-#: model_variables.py:355
+#: model_variables.py:380
 msgid "South Carolina"
 msgstr "South Carolina"
 
-#: model_variables.py:356
+#: model_variables.py:381
 msgid "South Dakota"
 msgstr "South Dakota"
 
-#: model_variables.py:357
+#: model_variables.py:382
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#: model_variables.py:358
+#: model_variables.py:383
 msgid "Texas"
 msgstr "Texas"
 
-#: model_variables.py:359
+#: model_variables.py:384
 msgid "Utah"
 msgstr "Utah"
 
-#: model_variables.py:360
+#: model_variables.py:385
 msgid "Vermont"
 msgstr "Vermont"
 
-#: model_variables.py:361
+#: model_variables.py:386
 msgid "Virginia"
 msgstr "Virginia"
 
-#: model_variables.py:362
+#: model_variables.py:387
 msgid "Washington"
 msgstr "Washington"
 
-#: model_variables.py:363
+#: model_variables.py:388
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#: model_variables.py:364
+#: model_variables.py:389
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#: model_variables.py:365
+#: model_variables.py:390
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#: model_variables.py:366
+#: model_variables.py:391
 msgid "American Samoa"
 msgstr "American Samoa"
 
-#: model_variables.py:367
+#: model_variables.py:392
 msgid "Guam"
 msgstr "Guam"
 
-#: model_variables.py:368
+#: model_variables.py:393
 msgid "Northern Mariana Islands"
 msgstr "Northern Mariana Islands"
 
-#: model_variables.py:369
+#: model_variables.py:394
 msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
-#: model_variables.py:370
+#: model_variables.py:395
 msgid "Virgin Islands"
 msgstr "Virgin Islands"
 
-#: model_variables.py:371
+#: model_variables.py:396
 msgid "Armed Forces Africa"
 msgstr "Lực Lượng Vũ Trang Châu Phi"
 
-#: model_variables.py:372
+#: model_variables.py:397
 msgid "Armed Forces Americas"
 msgstr "Lực Lượng Vũ Trang Hoa Kỳ"
 
-#: model_variables.py:373
+#: model_variables.py:398
 msgid "Armed Forces Canada"
 msgstr "Lực Lượng Vũ Trang Canada"
 
-#: model_variables.py:374
+#: model_variables.py:399
 msgid "Armed Forces Europe"
 msgstr "Lực Lượng Vũ Trang Châu Âu"
 
-#: model_variables.py:375
+#: model_variables.py:400
 msgid "Armed Forces Middle East"
 msgstr "Lực Lượng Vũ Trang Trung Đông"
 
-#: model_variables.py:376
+#: model_variables.py:401
 msgid "Armed Forces Pacific"
 msgstr "Lực Lượng Vũ Trang Thái Bình Dương"
 
-#: model_variables.py:379
+#: model_variables.py:404
 msgid "Please provide description to continue"
 msgstr "Vui lòng cung cấp mô tả để tiếp tục"
 
-#: model_variables.py:380
+#: model_variables.py:405
 msgid "Please select a primary reason to continue."
 msgstr "Vui lòng chọn một lý do chính để tiếp tục."
 
-#: model_variables.py:383
+#: model_variables.py:408
 msgid "Please enter the name of the location where this took place."
 msgstr "Vui lòng nhập tên địa điểm nơi việc này xảy ra."
 
-#: model_variables.py:384
+#: model_variables.py:409
 msgid "Please enter the city or town where this took place."
 msgstr "Vui lòng nhập thành phố hoặc thị trấn nơi việc này xảy ra."
 
-#: model_variables.py:385
+#: model_variables.py:410
 msgid "Please select the state where this took place."
 msgstr "Vui lòng nhập tiểu bang nơi việc này xảy ra."
 
-#: model_variables.py:389
+#: model_variables.py:414
 msgid "Please select where this occurred"
 msgstr "Vui lòng chọn nơi việc này xảy ra"
 
-#: model_variables.py:390
+#: model_variables.py:415
 msgid "Please select the type of location"
 msgstr "Vui lòng chọn loại địa điểm"
 
-#: model_variables.py:402
+#: model_variables.py:427
 msgid "You must enter a month and year. Please use the format MM/DD/YYYY."
 msgstr ""
 "Quý vị phải nhập tháng và năm. Vui lòng sử dụng định dạng tháng( MM)/ngày "
 "(DD)/năm (YYYY)."
 
-#: model_variables.py:405
+#: model_variables.py:430
 msgid "Please enter a month."
 msgstr "Vui lòng nhập tháng."
 
-#: model_variables.py:406
+#: model_variables.py:431
 msgid "Please enter a valid month. Month must be between 1 and 12."
 msgstr "Vui lòng nhập một tháng hợp lệ. Tháng phải từ 1 đến 12."
 
-#: model_variables.py:407
+#: model_variables.py:432
 msgid ""
 "Please enter a valid day of the month. Day must be between 1 and the last "
 "day of the month."
@@ -983,27 +983,27 @@ msgstr ""
 "Vui lòng nhập một ngày hợp lệ trong tháng. Ngày phải từ ngày 1 đến ngày cuối "
 "cùng của tháng."
 
-#: model_variables.py:408
+#: model_variables.py:433
 msgid "Please enter a year."
 msgstr "Vui lòng nhập một năm."
 
-#: model_variables.py:409
+#: model_variables.py:434
 msgid "Date can not be in the future."
 msgstr "Ngày không được là ngày trong tương lai."
 
-#: model_variables.py:410
+#: model_variables.py:435
 msgid "Please enter a year after 1900."
 msgstr "Vui lòng nhập một năm sau 1900."
 
-#: model_variables.py:411
+#: model_variables.py:436
 msgid "Please enter a valid date. Use format MM/DD/YYYY."
 msgstr "Vui lòng nhập một ngày hợp lệ. Sử dụng định dạng MM/DD/YYYY."
 
-#: model_variables.py:414
+#: model_variables.py:439
 msgid "Please select the type of election or voting activity."
 msgstr "Vui lòng chọn hình thức bầu cử hoặc hoạt động bỏ phiếu."
 
-#: model_variables.py:454
+#: model_variables.py:479
 msgid ""
 "If you submit a phone number, please make sure to include between 7 and 15 "
 "digits. The characters \"+\", \")\", \"(\", \"-\", and \".\" are allowed. "
@@ -1191,12 +1191,12 @@ msgstr "Tên của những người liên quan bao gồm cả nhân chứng nế
 msgid "Any supporting materials (please list and describe them)"
 msgstr "Mọi tài liệu hỗ trợ (vui lòng liệt kê và mô tả chúng)"
 
-#: templates/base.html:33 templates/base.html:58
+#: templates/base.html:42 templates/base.html:67
 #: templates/forms/report_base.html:10 templates/forms/report_base.html:13
 msgid "Contact the Civil Rights Division | Department of Justice"
 msgstr "Liên hệ với Ban Dân Quyền | Bộ Tư pháp"
 
-#: templates/base.html:46
+#: templates/base.html:55
 msgid ""
 "Have you or someone you know experienced unlawful discrimination? The Civil "
 "Rights Division may be able to help. Civil rights laws can protect you from "
@@ -1210,16 +1210,16 @@ msgstr ""
 "trong nhiều môi trường khác nhau như nhà ở, nơi làm việc, trường học, hoạt "
 "động bỏ phiếu, doanh nghiệp, chăm sóc sức khỏe, không gian công cộng, v.v."
 
-#: templates/base.html:67
+#: templates/base.html:76
 msgid "Skip to main content"
 msgstr "Đi thẳng đến nội dung chính"
 
-#: templates/base.html:121 templates/forms/errors.html:13
+#: templates/base.html:130 templates/forms/errors.html:13
 #: templates/forms/report_maintenance.html:13 templates/landing.html:17
 msgid "U.S. Department of Justice"
 msgstr "Bộ Tư pháp Hoa Kỳ"
 
-#: templates/base.html:124 templates/forms/confirmation.html:21
+#: templates/base.html:133 templates/forms/confirmation.html:21
 #: templates/forms/errors.html:14 templates/forms/report_maintenance.html:14
 #: templates/landing.html:20
 msgid "Civil Rights Division"
@@ -1231,7 +1231,7 @@ msgstr "Ban Dân Quyền"
 #: templates/forms/question_cards/police_location.html:4
 #: templates/forms/question_cards/single_form.html:16
 #: templates/forms/question_cards/single_question.html:13
-#: templates/forms/report_class.html:14 templates/forms/report_details.html:13
+#: templates/forms/report_class.html:14 templates/forms/report_details.html:12
 #: templates/forms/report_location.html:33
 #: templates/forms/report_location.html:39
 #: templates/forms/report_primary_complaint.html:11
@@ -1581,19 +1581,22 @@ msgstr[1] ""
 "                  %(counter)s lỗi được tìm thấy\n"
 "                "
 
-#: templates/forms/report_base.html:84
+#: templates/forms/report_base.html:85
+#: templates/forms/report_contact_info.html:40
 msgid "Submit"
 msgstr "Gửi"
 
-#: templates/forms/report_base.html:86
+#: templates/forms/report_base.html:87
+#: templates/forms/report_contact_info.html:34
+#: templates/forms/report_contact_info.html:42
 msgid "Next"
 msgstr "Tiếp theo"
 
-#: templates/forms/report_base.html:93 templates/forms/report_review.html:32
+#: templates/forms/report_base.html:95 templates/forms/report_review.html:33
 msgid "previous step"
 msgstr "bước trước"
 
-#: templates/forms/report_base.html:96 templates/forms/report_review.html:35
+#: templates/forms/report_base.html:98 templates/forms/report_review.html:36
 #: templates/partials/redirect-modal.html:21
 msgid "Back"
 msgstr "Quay lại"
@@ -1707,8 +1710,8 @@ msgstr "Báo cáo một vi phạm"
 msgid "Already submitted?"
 msgstr "Đã gửi?"
 
-#: templates/landing.html:58 templates/partials/footer.html:9 views.py:951
-#: views.py:1030 views.py:1049
+#: templates/landing.html:58 templates/partials/footer.html:9
+#: views_public.py:145 views_public.py:224 views_public.py:243
 msgid "Contact"
 msgstr "Liên Hệ"
 
@@ -1737,7 +1740,7 @@ msgstr ""
 "Nếu quý vị tin rằng dân quyền của mình hoặc của người khác đã bị vi phạm, "
 "hãy gửi báo cáo bằng cách sử dụng mẫu trực tuyến của chúng tôi."
 
-#: templates/landing.html:88
+#: templates/landing.html:88 templates/landing.html:326
 msgid "Start a report"
 msgstr "Bắt đầu báo cáo"
 
@@ -1983,10 +1986,6 @@ msgstr ""
 "Quý vị hoặc một người nào đó mà quý vị biết có từng bị vi phạm dân quyền "
 "không?"
 
-#: templates/landing.html:326
-msgid "Submit a report"
-msgstr "Gửi báo cáo"
-
 #: templates/landing.html:331
 msgid ""
 "If you cannot access the online form, you can <a href=\"#phone-footer"
@@ -2107,6 +2106,34 @@ msgstr "Một trang web chính thức của chính phủ Hoa Kỳ"
 #: templates/partials/banner/usa_banner_header.html:13
 msgid "Here’s how you know"
 msgstr "Đây là cách để quý vị biết"
+
+#: templates/partials/contact-info-confirmation-modal.html:8
+msgid ""
+"You are continuing your complaint without providing email or phone "
+"information."
+msgstr ""
+"Quý vị đang tiếp tục báo cáo mà không cung cấp địa chỉ email hoặc số điện "
+"thoại."
+
+#: templates/partials/contact-info-confirmation-modal.html:13
+msgid ""
+"You do not have to provide contact information, however, we will not be able "
+"to contact you for any status updates or potential follow up. Would you like "
+"to add your contact information now? If you prefer not to, you will go to "
+"Step 2."
+msgstr ""
+"Quý vị không cần phải cung cấp thông tin liên lạc, tuy nhiên, chúng tôi sẽ "
+"không thể liên lạc với quý vị để cập nhật tình trạng hồ sơ hoặc trong trường "
+"hợp có thể cần thêm thông tin.  Quý vị có muốn cung cấp thông tin liên lạc "
+"của quý vị bây giờ hay không? Nếu không muốn, quý vị sẽ chuyển sang Bước 2."
+
+#: templates/partials/contact-info-confirmation-modal.html:16
+msgid "No, I don't want to provide it"
+msgstr "Không, tôi không muốn cung cấp."
+
+#: templates/partials/contact-info-confirmation-modal.html:17
+msgid "Yes, I'd like to add it"
+msgstr "Có, tôi muốn cung cấp."
 
 #: templates/partials/footer.html:47
 msgid "Availability of Language Assistance Services"
@@ -2597,23 +2624,77 @@ msgstr ""
 "(5-25-2017).\n"
 "                "
 
-#: validators.py:101
+#: validators.py:106
 msgid "Enter a valid email address."
 msgstr "điền vào địa chỉ email hợp lệ"
 
-#: views.py:78
+#: views_public.py:146 views_public.py:225 views_public.py:226
+#: views_public.py:244 views_public.py:245 views_public.py:280
+msgid "Primary concern"
+msgstr "Mối quan ngại chính"
+
+#: views_public.py:147 views_public.py:227 views_public.py:228
+#: views_public.py:229 views_public.py:230 views_public.py:231
+#: views_public.py:232
+msgid "Location"
+msgstr "Địa điểm"
+
+#: views_public.py:148 views_public.py:233 views_public.py:252
+msgid "Personal characteristics"
+msgstr "Các đặc điểm cá nhân"
+
+#: views_public.py:149 views_public.py:234 views_public.py:253
+msgid "Date"
+msgstr "Ngày"
+
+#: views_public.py:150 views_public.py:235 views_public.py:254
+msgid "Personal description"
+msgstr "Mô tả cá nhân"
+
+#: views_public.py:151 views_public.py:236 views_public.py:285
+msgid "Review"
+msgstr "Đánh giá"
+
+#: views_public.py:246 views_public.py:247 views_public.py:248
+#: views_public.py:249 views_public.py:250 views_public.py:251
+msgid "Location details"
+msgstr "Thông tin chi tiết về địa điểm"
+
+#: views_public.py:255
+msgid "Review your report"
+msgstr "Đánh giá báo cáo của quý vị"
+
+#: views_public.py:271
+msgid "word remaining"
+msgstr "từ còn lại"
+
+#: views_public.py:272
+msgid " words remaining"
+msgstr " các từ còn lại"
+
+#: views_public.py:273
+msgid " word limit reached"
+msgstr " đã đạt đến giới hạn từ"
+
+#: views_public.py:283
+msgid "Please select if any that apply to your situation (optional)"
+msgstr ""
+"Vui lòng chọn nếu có bất kỳ câu trả lời nào phù hợp với tình huống của quý "
+"vị (tùy chọn)"
+
+#: views_public.py:359
 msgid "404 | Page not found"
 msgstr "404 | Không tìm thấy trang"
 
-#: views.py:79
+#: views_public.py:360
 msgid "We can't find the page you are looking for"
 msgstr "Chúng tôi không thể tìm thấy trang quý vị đang tìm kiếm"
 
-#: views.py:138
+#: views_public.py:419
 msgid "Your browser couldn't create a secure cookie"
 msgstr "Trình duyệt của quý vị không thể tạo cookie an toàn"
 
-#: views.py:139
+#: views_public.py:420
 msgid ""
 "We use security cookies to protect your information from attackers. Make "
 "sure you allow cookies for this site. Having the page open for long periods "
@@ -2628,55 +2709,5 @@ msgstr ""
 "này trong cửa sổ hoặc tab trình duyệt mới. Điều đó sẽ tạo cho quý vị một "
 "cookie bảo mật mới và sẽ giải quyết được sự cố."
 
-#: views.py:826 views.py:1077
-msgid "word remaining"
-msgstr "từ còn lại"
-
-#: views.py:827 views.py:1078
-msgid " words remaining"
-msgstr " các từ còn lại"
-
-#: views.py:828 views.py:1079
-msgid " word limit reached"
-msgstr " đã đạt đến giới hạn từ"
-
-#: views.py:952 views.py:1031 views.py:1032 views.py:1050 views.py:1051
-#: views.py:1086
-msgid "Primary concern"
-msgstr "Mối quan ngại chính"
-
-#: views.py:953 views.py:1033 views.py:1034 views.py:1035 views.py:1036
-#: views.py:1037 views.py:1038
-msgid "Location"
-msgstr "Địa điểm"
-
-#: views.py:954 views.py:1039 views.py:1058
-msgid "Personal characteristics"
-msgstr "Các đặc điểm cá nhân"
-
-#: views.py:955 views.py:1040 views.py:1059
-msgid "Date"
-msgstr "Ngày"
-
-#: views.py:956 views.py:1041 views.py:1060
-msgid "Personal description"
-msgstr "Mô tả cá nhân"
-
-#: views.py:957 views.py:1042 views.py:1091
-msgid "Review"
-msgstr "Đánh giá"
-
-#: views.py:1052 views.py:1053 views.py:1054 views.py:1055 views.py:1056
-#: views.py:1057
-msgid "Location details"
-msgstr "Thông tin chi tiết về địa điểm"
-
-#: views.py:1061
-msgid "Review your report"
-msgstr "Đánh giá báo cáo của quý vị"
-
-#: views.py:1089
-msgid "Please select if any that apply to your situation (optional)"
-msgstr ""
-"Vui lòng chọn nếu có bất kỳ câu trả lời nào phù hợp với tình huống của quý "
-"vị (tùy chọn)"
+#~ msgid "Submit a report"
+#~ msgstr "Gửi báo cáo"

--- a/crt_portal/cts_forms/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1,29 +1,29 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-28 19:03+0000\n"
+"POT-Creation-Date: 2021-07-27 17:47+0000\n"
 "Language: Chinese Simplified\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:161 forms.py:1546
+#: forms.py:182 forms.py:1577
 msgid " - Select - "
 msgstr " - 选择 - "
 
 #. Translators: This is help text for the question asking if someone is a service member
-#: forms.py:173
+#: forms.py:194
 msgid ""
 "If you’re reporting on behalf of someone else, please select their status."
 msgstr "如果您代表其他人报告，请选择他们的状态。"
 
-#: forms.py:190 templates/forms/report_contact_info.html:8
+#: forms.py:211 templates/forms/report_contact_info.html:9
 msgid ""
 "If you believe you or someone else has experienced a civil rights violation, "
 "please tell us what happened."
 msgstr "如果您认为自己或他人的民事权利受到了侵犯，请告诉我们发生了什么。"
 
-#: forms.py:216
+#: forms.py:237
 msgid ""
 "Select the reason that best describes your concern. Each reason lists "
 "examples of civil rights violations that may relate to your incident. In "
@@ -34,21 +34,21 @@ msgstr ""
 "利的例子。在本报告的另一部分中，您将可以用自己的语言描述您的顾虑。"
 
 #. Translators: notes that this page is the same form step as the page before
-#: forms.py:239
+#: forms.py:260
 msgid "Continued"
 msgstr "继续"
 
-#: forms.py:295
+#: forms.py:317
 msgid ""
 "Examples: Name of business, school, intersection, prison, polling place, "
 "website, etc."
 msgstr "例如：公司、学校、路口、监狱、投票站、网站等名称。"
 
-#: forms.py:317 question_text.py:29
+#: forms.py:339 question_text.py:29
 msgid "Where did this happen?"
 msgstr "这是在哪里发生的？"
 
-#: forms.py:329
+#: forms.py:351
 msgid ""
 "Please tell us the city, state, and name of the location where this incident "
 "took place. This ensures your report is reviewed by the right people within "
@@ -57,7 +57,7 @@ msgstr ""
 "请告诉我们这一事件发生的城市、州以及地点的名称。这样可以确保您的报告会由民权"
 "司的适当人员进行审阅。"
 
-#: forms.py:392
+#: forms.py:414
 msgid ""
 "Public employers include organizations funded by the government like the "
 "military, post office, fire department, courthouse, DMV, or public school. "
@@ -66,18 +66,18 @@ msgstr ""
 "公共雇主包括由政府资助的组织，例如军队、邮局、消防局、法院、机动车管理局"
 "（DMV）或公立学校。可能是地方或州一级部门。"
 
-#: forms.py:393
+#: forms.py:415
 msgid ""
 "Private employers are business or non-profits not funded by the government "
 "such as retail stores, banks, or restaurants."
 msgstr "私人雇主是指不受政府资助的企业或非营利组织，如零售商店、银行或餐馆。"
 
 #. Translators: describe the "other" option for commercial or public place question
-#: forms.py:439
+#: forms.py:461
 msgid "Please describe"
 msgstr "请描述"
 
-#: forms.py:506
+#: forms.py:528
 msgid ""
 "Includes schools, educational programs, or educational activities, like "
 "training programs, sports teams, clubs, or other school-sponsored activities"
@@ -85,11 +85,11 @@ msgstr ""
 "包括学校、教育项目或教育活动，例如培训项目、运动团体、俱乐部或其他学校资助的"
 "活动"
 
-#: forms.py:517
+#: forms.py:539
 msgid "Please select the type of school or educational program."
 msgstr "请选择学校或教育项目的类型。"
 
-#: forms.py:540
+#: forms.py:562
 msgid ""
 "There are federal and state laws that protect people from discrimination "
 "based on their personal characteristics. Here is a list of the most common "
@@ -100,11 +100,11 @@ msgstr ""
 "特征。选择任何适用于您的事件的选项。"
 
 #. Translators: This is to explain an "other" choice for personal characteristics
-#: forms.py:545
+#: forms.py:567
 msgid "Please describe \"Other reason\""
 msgstr "请说明“其他原因”"
 
-#: forms.py:627
+#: forms.py:649
 msgid ""
 "It is important for us to know how recently this incident happened so we can "
 "take the appropriate action. If this happened over a period of time or is "
@@ -113,19 +113,19 @@ msgstr ""
 "让我们知道这起事件是在最近何时发生的很重要，这样我们才能采取适当的行动。如果"
 "该事件发生在一段时间里，或者现在仍然在发生，请提供最近一次发生的日期。"
 
-#: forms.py:915
+#: forms.py:937
 msgid "Primary classification"
 msgstr "主要分类"
 
-#: forms.py:937
+#: forms.py:959
 msgid "Assigned to"
 msgstr "分配给"
 
-#: forms.py:1104
+#: forms.py:1134
 msgid "Create date cannot be in the future."
 msgstr "创建日期不能为未来时间。"
 
-#: forms.py:1286
+#: forms.py:1317
 msgid "Comment cannot be empty"
 msgstr "评论不能为空"
 
@@ -134,11 +134,11 @@ msgstr "评论不能为空"
 msgid "- Select -"
 msgstr "- 选择 -"
 
-#: model_variables.py:9 model_variables.py:119 model_variables.py:262
+#: model_variables.py:9 model_variables.py:119 model_variables.py:287
 msgid "Yes"
 msgstr "是"
 
-#: model_variables.py:10 model_variables.py:120 model_variables.py:261
+#: model_variables.py:10 model_variables.py:120 model_variables.py:286
 msgid "No"
 msgstr "否"
 
@@ -377,7 +377,7 @@ msgstr ""
 "由于受到身体虐待或攻击、性虐待或侵害、其他伤害威胁或监禁而被迫从事性工作以牟"
 "利"
 
-#: model_variables.py:102 model_variables.py:268
+#: model_variables.py:102 model_variables.py:293
 msgid "Federal"
 msgstr "联邦"
 
@@ -390,8 +390,8 @@ msgstr "州或地方"
 msgid "Both"
 msgstr "二者都有"
 
-#: model_variables.py:106 model_variables.py:270 model_variables.py:285
-#: model_variables.py:293 model_variables.py:310
+#: model_variables.py:106 model_variables.py:295 model_variables.py:310
+#: model_variables.py:318 model_variables.py:335
 msgid "I'm not sure"
 msgstr "我不确定"
 
@@ -485,444 +485,444 @@ msgstr ""
 "请做选择，然后继续。如果这些都不适用于您的情况，请选择“这些都不适用”或“其他原"
 "因”并做解释。"
 
-#: model_variables.py:233
+#: model_variables.py:258
 msgid "Place of worship or about a place of worship"
 msgstr "礼拜场所或和礼拜场所有关"
 
-#: model_variables.py:234
+#: model_variables.py:259
 msgid "Commercial or retail building"
 msgstr "商业或零售大楼"
 
-#: model_variables.py:235 model_variables.py:246
+#: model_variables.py:260 model_variables.py:271
 msgid "Healthcare facility"
 msgstr "医疗设施"
 
-#: model_variables.py:236 model_variables.py:247
+#: model_variables.py:261 model_variables.py:272
 msgid "Financial institution"
 msgstr "金融机构"
 
-#: model_variables.py:237
+#: model_variables.py:262
 msgid "Public space"
 msgstr "公共场所"
 
-#: model_variables.py:238 templatetags/commercial_public_space_view.py:17
+#: model_variables.py:263 templatetags/commercial_public_space_view.py:17
 msgid "Other"
 msgstr "其他"
 
-#: model_variables.py:241
+#: model_variables.py:266
 msgid ""
 "Please select the type of location. If none of these apply to your "
 "situation, please select \"Other\"."
 msgstr "请选择地点类型。如果这些都不适用于您的情况，请选择“其他”。"
 
-#: model_variables.py:244
+#: model_variables.py:269
 msgid "Place of worship"
 msgstr "礼拜场所"
 
-#: model_variables.py:245
+#: model_variables.py:270
 msgid "Commercial"
 msgstr "商业场所"
 
-#: model_variables.py:248
+#: model_variables.py:273
 msgid "Public outdoor space"
 msgstr "室外公共空间"
 
-#: model_variables.py:252
+#: model_variables.py:277
 msgid "Church, synagogue, temple, religious community center"
 msgstr "教堂、犹太教堂、寺庙、宗教社区中心"
 
-#: model_variables.py:253
+#: model_variables.py:278
 msgid "Store, restaurant, bar, hotel, theater"
 msgstr "商店、餐馆、酒吧、酒店、剧院"
 
-#: model_variables.py:254
+#: model_variables.py:279
 msgid ""
 "Hospital or clinic (including inpatient and outpatient programs), "
 "reproductive care clinic, state developmental institution, nursing home"
 msgstr "医院或诊所（包括住院和门诊）、生殖保健诊所、州立发展机构、疗养院"
 
-#: model_variables.py:255
+#: model_variables.py:280
 msgid "Bank, credit union, loan services"
 msgstr "银行、信用合作社、贷款服务"
 
-#: model_variables.py:256
+#: model_variables.py:281
 msgid ""
 "Park, sidewalk, street, other public buildings (courthouse, DMV, city "
 "library)"
 msgstr ""
 "公园、人行道、街道、其他公共建筑（法院、机动车管理局（DMV）、市图书馆）"
 
-#: model_variables.py:267
+#: model_variables.py:292
 msgid "State/local"
 msgstr "州/地方"
 
-#: model_variables.py:269
+#: model_variables.py:294
 msgid "Private"
 msgstr "私人"
 
-#: model_variables.py:275
+#: model_variables.py:300
 msgid "Outside of prison"
 msgstr "监狱外"
 
-#: model_variables.py:277
+#: model_variables.py:302
 msgid "Prison (Federal)"
 msgstr "监狱（联邦）"
 
-#: model_variables.py:278
+#: model_variables.py:303
 msgid "Prison (Private)"
 msgstr "监狱（私人）"
 
-#: model_variables.py:279
+#: model_variables.py:304
 msgid "Prison (I'm not sure)"
 msgstr "监狱（我不确定）"
 
-#: model_variables.py:283
+#: model_variables.py:308
 msgid "Public employer"
 msgstr "公共雇主"
 
-#: model_variables.py:284
+#: model_variables.py:309
 msgid "Private employer"
 msgstr "私人雇主"
 
-#: model_variables.py:288
+#: model_variables.py:313
 msgid "Please select what type of employer this is."
 msgstr "请选择这是哪种类型的雇主。"
 
-#: model_variables.py:291
+#: model_variables.py:316
 msgid "Fewer than 15 employees"
 msgstr "少于 15 名员工"
 
-#: model_variables.py:292
+#: model_variables.py:317
 msgid "15 or more employees"
 msgstr "15 名或 15 名以上员工 "
 
-#: model_variables.py:296
+#: model_variables.py:321
 msgid "Please select how large the employer is."
 msgstr "请选择雇主的规模。"
 
-#: model_variables.py:308
+#: model_variables.py:333
 msgid "Public school or educational program"
 msgstr "公立学校或教育项目"
 
-#: model_variables.py:309
+#: model_variables.py:334
 msgid "Private school or educational program"
 msgstr "私立学校或教育项目"
 
-#: model_variables.py:315
+#: model_variables.py:340
 msgid "Alabama"
 msgstr "阿拉巴马州"
 
-#: model_variables.py:316
+#: model_variables.py:341
 msgid "Alaska"
 msgstr "阿拉斯加州"
 
-#: model_variables.py:317
+#: model_variables.py:342
 msgid "Arizona"
 msgstr "亚利桑那州"
 
-#: model_variables.py:318
+#: model_variables.py:343
 msgid "Arkansas"
 msgstr "阿肯色州"
 
-#: model_variables.py:319
+#: model_variables.py:344
 msgid "California"
 msgstr "加利福尼亚州"
 
-#: model_variables.py:320
+#: model_variables.py:345
 msgid "Colorado"
 msgstr "科罗拉多州"
 
-#: model_variables.py:321
+#: model_variables.py:346
 msgid "Connecticut"
 msgstr "康涅狄格州"
 
-#: model_variables.py:322
+#: model_variables.py:347
 msgid "Delaware"
 msgstr "特拉华州"
 
-#: model_variables.py:323
+#: model_variables.py:348
 msgid "District of Columbia"
 msgstr "哥伦比亚特区"
 
-#: model_variables.py:324
+#: model_variables.py:349
 msgid "Florida"
 msgstr "佛罗里达州"
 
-#: model_variables.py:325
+#: model_variables.py:350
 msgid "Georgia"
 msgstr "乔治亚州"
 
-#: model_variables.py:326
+#: model_variables.py:351
 msgid "Hawaii"
 msgstr "夏威夷州"
 
-#: model_variables.py:327
+#: model_variables.py:352
 msgid "Idaho"
 msgstr "爱达荷州"
 
-#: model_variables.py:328
+#: model_variables.py:353
 msgid "Illinois"
 msgstr "伊利诺伊州"
 
-#: model_variables.py:329
+#: model_variables.py:354
 msgid "Indiana"
 msgstr "印第安纳州"
 
-#: model_variables.py:330
+#: model_variables.py:355
 msgid "Iowa"
 msgstr "爱荷华州"
 
-#: model_variables.py:331
+#: model_variables.py:356
 msgid "Kansas"
 msgstr "堪萨斯州"
 
-#: model_variables.py:332
+#: model_variables.py:357
 msgid "Kentucky"
 msgstr "肯塔基州"
 
-#: model_variables.py:333
+#: model_variables.py:358
 msgid "Louisiana"
 msgstr "路易斯安那州"
 
-#: model_variables.py:334
+#: model_variables.py:359
 msgid "Maine"
 msgstr "缅因州"
 
-#: model_variables.py:335
+#: model_variables.py:360
 msgid "Maryland"
 msgstr "马里兰州"
 
-#: model_variables.py:336
+#: model_variables.py:361
 msgid "Massachusetts"
 msgstr "马萨诸塞州"
 
-#: model_variables.py:337
+#: model_variables.py:362
 msgid "Michigan"
 msgstr "密歇根州"
 
-#: model_variables.py:338
+#: model_variables.py:363
 msgid "Minnesota"
 msgstr "明尼苏达州"
 
-#: model_variables.py:339
+#: model_variables.py:364
 msgid "Mississippi"
 msgstr "密西西比州"
 
-#: model_variables.py:340
+#: model_variables.py:365
 msgid "Missouri"
 msgstr "密苏里州"
 
-#: model_variables.py:341
+#: model_variables.py:366
 msgid "Montana"
 msgstr "蒙大拿州"
 
-#: model_variables.py:342
+#: model_variables.py:367
 msgid "Nebraska"
 msgstr "内布拉斯加州"
 
-#: model_variables.py:343
+#: model_variables.py:368
 msgid "Nevada"
 msgstr "内华达州"
 
-#: model_variables.py:344
+#: model_variables.py:369
 msgid "New Hampshire"
 msgstr "新罕布什尔州"
 
-#: model_variables.py:345
+#: model_variables.py:370
 msgid "New Jersey"
 msgstr "新泽西州"
 
-#: model_variables.py:346
+#: model_variables.py:371
 msgid "New Mexico"
 msgstr "新墨西哥州"
 
-#: model_variables.py:347
+#: model_variables.py:372
 msgid "New York"
 msgstr "纽约州"
 
-#: model_variables.py:348
+#: model_variables.py:373
 msgid "North Carolina"
 msgstr "北卡罗莱纳州"
 
-#: model_variables.py:349
+#: model_variables.py:374
 msgid "North Dakota"
 msgstr "北达科他州"
 
-#: model_variables.py:350
+#: model_variables.py:375
 msgid "Ohio"
 msgstr "俄亥俄州"
 
-#: model_variables.py:351
+#: model_variables.py:376
 msgid "Oklahoma"
 msgstr "俄克拉荷马州"
 
-#: model_variables.py:352
+#: model_variables.py:377
 msgid "Oregon"
 msgstr "俄勒冈州"
 
-#: model_variables.py:353
+#: model_variables.py:378
 msgid "Pennsylvania"
 msgstr "宾夕法尼亚州"
 
-#: model_variables.py:354
+#: model_variables.py:379
 msgid "Rhode Island"
 msgstr "罗德岛州"
 
-#: model_variables.py:355
+#: model_variables.py:380
 msgid "South Carolina"
 msgstr "南卡罗来纳州"
 
-#: model_variables.py:356
+#: model_variables.py:381
 msgid "South Dakota"
 msgstr "南达科他州"
 
-#: model_variables.py:357
+#: model_variables.py:382
 msgid "Tennessee"
 msgstr "田纳西州"
 
-#: model_variables.py:358
+#: model_variables.py:383
 msgid "Texas"
 msgstr "得克萨斯州"
 
-#: model_variables.py:359
+#: model_variables.py:384
 msgid "Utah"
 msgstr "犹他州"
 
-#: model_variables.py:360
+#: model_variables.py:385
 msgid "Vermont"
 msgstr "佛蒙特州"
 
-#: model_variables.py:361
+#: model_variables.py:386
 msgid "Virginia"
 msgstr "弗吉尼亚州"
 
-#: model_variables.py:362
+#: model_variables.py:387
 msgid "Washington"
 msgstr "华盛顿州"
 
-#: model_variables.py:363
+#: model_variables.py:388
 msgid "West Virginia"
 msgstr "西弗吉尼亚州"
 
-#: model_variables.py:364
+#: model_variables.py:389
 msgid "Wisconsin"
 msgstr "威斯康星州"
 
-#: model_variables.py:365
+#: model_variables.py:390
 msgid "Wyoming"
 msgstr "怀俄明州"
 
-#: model_variables.py:366
+#: model_variables.py:391
 msgid "American Samoa"
 msgstr "美属萨摩亚"
 
-#: model_variables.py:367
+#: model_variables.py:392
 msgid "Guam"
 msgstr "关岛"
 
-#: model_variables.py:368
+#: model_variables.py:393
 msgid "Northern Mariana Islands"
 msgstr "北马里亚纳群岛"
 
-#: model_variables.py:369
+#: model_variables.py:394
 msgid "Puerto Rico"
 msgstr "波多黎各"
 
-#: model_variables.py:370
+#: model_variables.py:395
 msgid "Virgin Islands"
 msgstr "维尔京群岛"
 
-#: model_variables.py:371
+#: model_variables.py:396
 msgid "Armed Forces Africa"
 msgstr "非洲武装部队"
 
-#: model_variables.py:372
+#: model_variables.py:397
 msgid "Armed Forces Americas"
 msgstr "美洲武装部队"
 
-#: model_variables.py:373
+#: model_variables.py:398
 msgid "Armed Forces Canada"
 msgstr "加拿大武装部队"
 
-#: model_variables.py:374
+#: model_variables.py:399
 msgid "Armed Forces Europe"
 msgstr "欧洲武装部队"
 
-#: model_variables.py:375
+#: model_variables.py:400
 msgid "Armed Forces Middle East"
 msgstr "中东武装部队"
 
-#: model_variables.py:376
+#: model_variables.py:401
 msgid "Armed Forces Pacific"
 msgstr "太平洋武装部队"
 
-#: model_variables.py:379
+#: model_variables.py:404
 msgid "Please provide description to continue"
 msgstr "请提供说明，然后继续"
 
-#: model_variables.py:380
+#: model_variables.py:405
 msgid "Please select a primary reason to continue."
 msgstr "请选择主要原因，然后继续。"
 
-#: model_variables.py:383
+#: model_variables.py:408
 msgid "Please enter the name of the location where this took place."
 msgstr "请输入发生此事件地点的名称。"
 
-#: model_variables.py:384
+#: model_variables.py:409
 msgid "Please enter the city or town where this took place."
 msgstr "请输入发生此事件的城市或城镇。"
 
-#: model_variables.py:385
+#: model_variables.py:410
 msgid "Please select the state where this took place."
 msgstr "请选择发生此事件的州。"
 
-#: model_variables.py:389
+#: model_variables.py:414
 msgid "Please select where this occurred"
 msgstr "请选择发生此情况的地点"
 
-#: model_variables.py:390
+#: model_variables.py:415
 msgid "Please select the type of location"
 msgstr "请选择地点类型。"
 
-#: model_variables.py:402
+#: model_variables.py:427
 msgid "You must enter a month and year. Please use the format MM/DD/YYYY."
 msgstr "必须输入月和年。请使用 MM/DD/YYYY（月/日/年）的格式。"
 
-#: model_variables.py:405
+#: model_variables.py:430
 msgid "Please enter a month."
 msgstr "请输入月份。"
 
-#: model_variables.py:406
+#: model_variables.py:431
 msgid "Please enter a valid month. Month must be between 1 and 12."
 msgstr "请输入一个有效的月份。月份必须介于 1 和 12 之间。"
 
-#: model_variables.py:407
+#: model_variables.py:432
 msgid ""
 "Please enter a valid day of the month. Day must be between 1 and the last "
 "day of the month."
 msgstr "请输入当月的有效日期。日期必须介于 1 和当月最后一天之间。"
 
-#: model_variables.py:408
+#: model_variables.py:433
 msgid "Please enter a year."
 msgstr "请输入年份。"
 
-#: model_variables.py:409
+#: model_variables.py:434
 msgid "Date can not be in the future."
 msgstr "日期不能为将来的日期。"
 
-#: model_variables.py:410
+#: model_variables.py:435
 msgid "Please enter a year after 1900."
 msgstr "请输入一个 1900 年以后的年份。"
 
-#: model_variables.py:411
+#: model_variables.py:436
 msgid "Please enter a valid date. Use format MM/DD/YYYY."
 msgstr "请输入一个有效的日期。请使用 MM/DD/YYYY（月/日/年）格式。"
 
-#: model_variables.py:414
+#: model_variables.py:439
 msgid "Please select the type of election or voting activity."
 msgstr "请选择选举或投票活动的类型。"
 
-#: model_variables.py:454
+#: model_variables.py:479
 msgid ""
 "If you submit a phone number, please make sure to include between 7 and 15 "
 "digits. The characters \"+\", \")\", \"(\", \"-\", and \".\" are allowed. "
@@ -1099,12 +1099,12 @@ msgstr "涉案人员姓名，包括证人（如有）"
 msgid "Any supporting materials (please list and describe them)"
 msgstr "任何支持性材料（请列出并说明）"
 
-#: templates/base.html:33 templates/base.html:58
+#: templates/base.html:42 templates/base.html:67
 #: templates/forms/report_base.html:10 templates/forms/report_base.html:13
 msgid "Contact the Civil Rights Division | Department of Justice"
 msgstr "联系司法部民权司"
 
-#: templates/base.html:46
+#: templates/base.html:55
 msgid ""
 "Have you or someone you know experienced unlawful discrimination? The Civil "
 "Rights Division may be able to help. Civil rights laws can protect you from "
@@ -1116,16 +1116,16 @@ msgstr ""
 "种环境中免受非法歧视、骚扰或虐待，例如住所、工作场所、学校、投票站、企业、医"
 "疗保健机构、公共场所等。"
 
-#: templates/base.html:67
+#: templates/base.html:76
 msgid "Skip to main content"
 msgstr "跳转到主要内容"
 
-#: templates/base.html:121 templates/forms/errors.html:13
+#: templates/base.html:130 templates/forms/errors.html:13
 #: templates/forms/report_maintenance.html:13 templates/landing.html:17
 msgid "U.S. Department of Justice"
 msgstr "美国司法部"
 
-#: templates/base.html:124 templates/forms/confirmation.html:21
+#: templates/base.html:133 templates/forms/confirmation.html:21
 #: templates/forms/errors.html:14 templates/forms/report_maintenance.html:14
 #: templates/landing.html:20
 msgid "Civil Rights Division"
@@ -1137,7 +1137,7 @@ msgstr "民权司"
 #: templates/forms/question_cards/police_location.html:4
 #: templates/forms/question_cards/single_form.html:16
 #: templates/forms/question_cards/single_question.html:13
-#: templates/forms/report_class.html:14 templates/forms/report_details.html:13
+#: templates/forms/report_class.html:14 templates/forms/report_details.html:12
 #: templates/forms/report_location.html:33
 #: templates/forms/report_location.html:39
 #: templates/forms/report_primary_complaint.html:11
@@ -1460,19 +1460,21 @@ msgstr[1] ""
 "                  发现 %(counter)s 个错误\n"
 "                "
 
-#: templates/forms/report_base.html:84
+#: templates/forms/report_base.html:85
+#: templates/forms/report_contact_info.html:40
 msgid "Submit"
 msgstr "提交"
 
-#: templates/forms/report_base.html:86
+#: templates/forms/report_base.html:87
+#: templates/forms/report_contact_info.html:42
 msgid "Next"
 msgstr "下一步"
 
-#: templates/forms/report_base.html:93 templates/forms/report_review.html:32
+#: templates/forms/report_base.html:95 templates/forms/report_review.html:33
 msgid "previous step"
 msgstr "上一步"
 
-#: templates/forms/report_base.html:96 templates/forms/report_review.html:35
+#: templates/forms/report_base.html:98 templates/forms/report_review.html:36
 #: templates/partials/redirect-modal.html:21
 msgid "Back"
 msgstr "返回"
@@ -1579,8 +1581,8 @@ msgstr "举报一起违法行为"
 msgid "Already submitted?"
 msgstr "已经提交了？"
 
-#: templates/landing.html:58 templates/partials/footer.html:9 views.py:951
-#: views.py:1030 views.py:1049
+#: templates/landing.html:58 templates/partials/footer.html:9
+#: views_public.py:145 views_public.py:224 views_public.py:243
 msgid "Contact"
 msgstr "联系"
 
@@ -1604,7 +1606,7 @@ msgid ""
 "submit a report using our online form."
 msgstr "如果您认为您或他人的民事权利受到侵犯，请使用我们的在线表格提交报告。"
 
-#: templates/landing.html:88
+#: templates/landing.html:88 templates/landing.html:326
 msgid "Start a report"
 msgstr "开始报告"
 
@@ -1826,10 +1828,6 @@ msgstr ""
 msgid "Have you or someone you know experienced a civil rights violation?"
 msgstr "您或您认识的人是否有过侵犯公民权利的经历？"
 
-#: templates/landing.html:326
-msgid "Submit a report"
-msgstr "提交报告"
-
 #: templates/landing.html:331
 msgid ""
 "If you cannot access the online form, you can <a href=\"#phone-footer"
@@ -1941,6 +1939,30 @@ msgstr "美国政府的官方网站"
 #: templates/partials/banner/usa_banner_header.html:13
 msgid "Here’s how you know"
 msgstr "通过以下方式辨识"
+
+#: templates/partials/contact-info-confirmation-modal.html:8
+msgid ""
+"You are continuing your complaint without providing email or phone "
+"information."
+msgstr "您在继续填写您的报告，但尚未提供电子邮件或电话号码。"
+
+#: templates/partials/contact-info-confirmation-modal.html:13
+msgid ""
+"You do not have to provide contact information, however, we will not be able "
+"to contact you for any status updates or potential follow up. Would you like "
+"to add your contact information now? If you prefer not to, you will go to "
+"Step 2."
+msgstr ""
+"您不一定要提供联系方式，但是我们将无法与您联系，向您提供任何的新进展或进行后"
+"续跟进。您想现在添加您的联系方式吗？如果不愿意，您将进入第二步。"
+
+#: templates/partials/contact-info-confirmation-modal.html:16
+msgid "No, I don't want to provide it"
+msgstr "不，我不想提供联系方式"
+
+#: templates/partials/contact-info-confirmation-modal.html:17
+msgid "Yes, I'd like to add it"
+msgstr "好，我想添加联系方式"
 
 #: templates/partials/footer.html:47
 msgid "Availability of Language Assistance Services"
@@ -2402,23 +2424,75 @@ msgstr ""
 "(被 82 FR 24147 撤销)；82 Fed. Reg. 24147 (5-25-2017)。\n"
 "                "
 
-#: validators.py:101
+#: validators.py:106
 msgid "Enter a valid email address."
 msgstr "输入一个有效的电子邮件地址"
 
-#: views.py:78
+#: views_public.py:146 views_public.py:225 views_public.py:226
+#: views_public.py:244 views_public.py:245 views_public.py:280
+msgid "Primary concern"
+msgstr "主要顾虑"
+
+#: views_public.py:147 views_public.py:227 views_public.py:228
+#: views_public.py:229 views_public.py:230 views_public.py:231
+#: views_public.py:232
+msgid "Location"
+msgstr "地点"
+
+#: views_public.py:148 views_public.py:233 views_public.py:252
+msgid "Personal characteristics"
+msgstr "个人特征"
+
+#: views_public.py:149 views_public.py:234 views_public.py:253
+msgid "Date"
+msgstr "日期"
+
+#: views_public.py:150 views_public.py:235 views_public.py:254
+msgid "Personal description"
+msgstr "个人描述"
+
+#: views_public.py:151 views_public.py:236 views_public.py:285
+msgid "Review"
+msgstr "检查"
+
+#: views_public.py:246 views_public.py:247 views_public.py:248
+#: views_public.py:249 views_public.py:250 views_public.py:251
+msgid "Location details"
+msgstr "地点详情"
+
+#: views_public.py:255
+msgid "Review your report"
+msgstr "检查您的报告"
+
+#: views_public.py:271
+msgid "word remaining"
+msgstr "剩余字数"
+
+#: views_public.py:272
+msgid " words remaining"
+msgstr " 剩余字数"
+
+#: views_public.py:273
+msgid " word limit reached"
+msgstr " 已达到字数限制"
+
+#: views_public.py:283
+msgid "Please select if any that apply to your situation (optional)"
+msgstr "请选择任何适用于您的情况（可选）"
+
+#: views_public.py:359
 msgid "404 | Page not found"
 msgstr "404 | 未找到该页面"
 
-#: views.py:79
+#: views_public.py:360
 msgid "We can't find the page you are looking for"
 msgstr "我们找不到您要找的页面"
 
-#: views.py:138
+#: views_public.py:419
 msgid "Your browser couldn't create a secure cookie"
 msgstr "您的浏览器无法创建安全的 cookie"
 
-#: views.py:139
+#: views_public.py:420
 msgid ""
 "We use security cookies to protect your information from attackers. Make "
 "sure you allow cookies for this site. Having the page open for long periods "
@@ -2431,53 +2505,5 @@ msgstr ""
 "到此问题，请尝试在新的浏览器分页或窗口中前往此页。这将为您创建一个新的安全 "
 "cookie，应该可以解决该问题。"
 
-#: views.py:826 views.py:1077
-msgid "word remaining"
-msgstr "剩余字数"
-
-#: views.py:827 views.py:1078
-msgid " words remaining"
-msgstr " 剩余字数"
-
-#: views.py:828 views.py:1079
-msgid " word limit reached"
-msgstr " 已达到字数限制"
-
-#: views.py:952 views.py:1031 views.py:1032 views.py:1050 views.py:1051
-#: views.py:1086
-msgid "Primary concern"
-msgstr "主要顾虑"
-
-#: views.py:953 views.py:1033 views.py:1034 views.py:1035 views.py:1036
-#: views.py:1037 views.py:1038
-msgid "Location"
-msgstr "地点"
-
-#: views.py:954 views.py:1039 views.py:1058
-msgid "Personal characteristics"
-msgstr "个人特征"
-
-#: views.py:955 views.py:1040 views.py:1059
-msgid "Date"
-msgstr "日期"
-
-#: views.py:956 views.py:1041 views.py:1060
-msgid "Personal description"
-msgstr "个人描述"
-
-#: views.py:957 views.py:1042 views.py:1091
-msgid "Review"
-msgstr "检查"
-
-#: views.py:1052 views.py:1053 views.py:1054 views.py:1055 views.py:1056
-#: views.py:1057
-msgid "Location details"
-msgstr "地点详情"
-
-#: views.py:1061
-msgid "Review your report"
-msgstr "检查您的报告"
-
-#: views.py:1089
-msgid "Please select if any that apply to your situation (optional)"
-msgstr "请选择任何适用于您的情况（可选）"
+#~ msgid "Submit a report"
+#~ msgstr "提交报告"

--- a/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
@@ -1,30 +1,30 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-19 20:44+0000\n"
+"POT-Creation-Date: 2021-07-27 19:15+0000\n"
 "Language: Chinese Traditional\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Translators: this is the default- blank options for a drop-down menu where a user chooses a state
-#: forms.py:161 forms.py:1546
+#: forms.py:182 forms.py:1577
 msgid " - Select - "
 msgstr " - 選擇 - "
 
 #. Translators: This is help text for the question asking if someone is a service member
-#: forms.py:173
+#: forms.py:194
 msgid ""
 "If you’re reporting on behalf of someone else, please select their status."
 msgstr "如果您是代表他人舉報，請選擇其身分。"
 
-#: forms.py:190 templates/forms/report_contact_info.html:8
+#: forms.py:211 templates/forms/report_contact_info.html:9
 msgid ""
 "If you believe you or someone else has experienced a civil rights violation, "
 "please tell us what happened."
 msgstr "如果您認為自己或其他人的民權曾受到侵犯，請告訴我們事發經過。"
 
-#: forms.py:216
+#: forms.py:237
 msgid ""
 "Select the reason that best describes your concern. Each reason lists "
 "examples of civil rights violations that may relate to your incident. In "
@@ -35,21 +35,21 @@ msgstr ""
 "子。在本報告的另一個部分，您將可使用您自己的話語來描述您擔憂的問題。"
 
 #. Translators: notes that this page is the same form step as the page before
-#: forms.py:239
+#: forms.py:260
 msgid "Continued"
 msgstr "（續）"
 
-#: forms.py:295
+#: forms.py:317
 msgid ""
 "Examples: Name of business, school, intersection, prison, polling place, "
 "website, etc."
 msgstr "例子：公司、學校、十字路口、監獄、投票所、網站等的名稱。"
 
-#: forms.py:317 question_text.py:29
+#: forms.py:339 question_text.py:29
 msgid "Where did this happen?"
 msgstr "此事件是發生在什麼地點？"
 
-#: forms.py:329
+#: forms.py:351
 msgid ""
 "Please tell us the city, state, and name of the location where this incident "
 "took place. This ensures your report is reviewed by the right people within "
@@ -58,7 +58,7 @@ msgstr ""
 "請告訴我們此事件發生的城市、州及地點名稱。這可確保您的報告由民權科的適當人員"
 "進行審查。"
 
-#: forms.py:392
+#: forms.py:414
 msgid ""
 "Public employers include organizations funded by the government like the "
 "military, post office, fire department, courthouse, DMV, or public school. "
@@ -68,7 +68,7 @@ msgstr ""
 "理局 (Department of Motor Vehicles, DMV) 或公立學校。其中可能包括地方組織或州"
 "政府組織。"
 
-#: forms.py:393
+#: forms.py:415
 msgid ""
 "Private employers are business or non-profits not funded by the government "
 "such as retail stores, banks, or restaurants."
@@ -76,11 +76,11 @@ msgstr ""
 "私人雇主包括不是由政府提供資金的企業或非營利組織，如零售商店、銀行或餐廳。"
 
 #. Translators: describe the "other" option for commercial or public place question
-#: forms.py:439
+#: forms.py:461
 msgid "Please describe"
 msgstr "請說明"
 
-#: forms.py:506
+#: forms.py:528
 msgid ""
 "Includes schools, educational programs, or educational activities, like "
 "training programs, sports teams, clubs, or other school-sponsored activities"
@@ -88,11 +88,11 @@ msgstr ""
 "包括學校、教育計畫或教育活動（如培訓計畫）、體育隊、俱樂部或由學校贊助的其他"
 "活動"
 
-#: forms.py:517
+#: forms.py:539
 msgid "Please select the type of school or educational program."
 msgstr "請選擇學校或教育計畫的類型。"
 
-#: forms.py:540
+#: forms.py:562
 msgid ""
 "There are federal and state laws that protect people from discrimination "
 "based on their personal characteristics. Here is a list of the most common "
@@ -103,11 +103,11 @@ msgstr ""
 "的最常見特徵清單。請選擇適用於您事件的所有選項。"
 
 #. Translators: This is to explain an "other" choice for personal characteristics
-#: forms.py:545
+#: forms.py:567
 msgid "Please describe \"Other reason\""
 msgstr "請說明「其他理由」"
 
-#: forms.py:627
+#: forms.py:649
 msgid ""
 "It is important for us to know how recently this incident happened so we can "
 "take the appropriate action. If this happened over a period of time or is "
@@ -116,19 +116,19 @@ msgstr ""
 "讓我們知道此事件是在最近多久發生非常重要，這樣我們才能採取適當行動。如果此事"
 "件是發生在一段時間或者現在仍持續發生，請提供最近一次發生的日期。"
 
-#: forms.py:915
+#: forms.py:937
 msgid "Primary classification"
 msgstr "主要分類"
 
-#: forms.py:937
+#: forms.py:959
 msgid "Assigned to"
 msgstr "指定給"
 
-#: forms.py:1104
+#: forms.py:1134
 msgid "Create date cannot be in the future."
 msgstr "建立日期不得是未來日期。"
 
-#: forms.py:1286
+#: forms.py:1317
 msgid "Comment cannot be empty"
 msgstr "意見欄位不得空白"
 
@@ -137,11 +137,11 @@ msgstr "意見欄位不得空白"
 msgid "- Select -"
 msgstr "- 選擇 -"
 
-#: model_variables.py:9 model_variables.py:119 model_variables.py:223
+#: model_variables.py:9 model_variables.py:119 model_variables.py:287
 msgid "Yes"
 msgstr "是"
 
-#: model_variables.py:10 model_variables.py:120 model_variables.py:222
+#: model_variables.py:10 model_variables.py:120 model_variables.py:286
 msgid "No"
 msgstr "否"
 
@@ -385,7 +385,7 @@ msgstr ""
 "由於受到身體虐待或人身侵犯、性虐待或性侵害、其他傷害威脅或監禁而被迫從事性工"
 "作以換取利益"
 
-#: model_variables.py:102 model_variables.py:229
+#: model_variables.py:102 model_variables.py:293
 msgid "Federal"
 msgstr "聯邦"
 
@@ -398,8 +398,8 @@ msgstr "州或地方"
 msgid "Both"
 msgstr "兩者"
 
-#: model_variables.py:106 model_variables.py:231 model_variables.py:246
-#: model_variables.py:254 model_variables.py:271
+#: model_variables.py:106 model_variables.py:295 model_variables.py:310
+#: model_variables.py:318 model_variables.py:335
 msgid "I'm not sure"
 msgstr "我不確定"
 
@@ -495,57 +495,57 @@ msgstr ""
 "請選擇一個選項以繼續進行。如果以上所有選項都不適用於您的狀況，請選擇「以上所"
 "有項目都不適用於我」或「其他理由」並加以說明。"
 
-#: model_variables.py:194
+#: model_variables.py:258
 msgid "Place of worship or about a place of worship"
 msgstr "禮拜場所或與禮拜場所有關"
 
-#: model_variables.py:195
+#: model_variables.py:259
 msgid "Commercial or retail building"
 msgstr "商用建物或零售商店建物"
 
-#: model_variables.py:196 model_variables.py:207
+#: model_variables.py:260 model_variables.py:271
 msgid "Healthcare facility"
 msgstr "醫療保健設施"
 
-#: model_variables.py:197 model_variables.py:208
+#: model_variables.py:261 model_variables.py:272
 msgid "Financial institution"
 msgstr "金融機構"
 
-#: model_variables.py:198
+#: model_variables.py:262
 msgid "Public space"
 msgstr "公共場所"
 
-#: model_variables.py:199 templatetags/commercial_public_space_view.py:17
+#: model_variables.py:263 templatetags/commercial_public_space_view.py:17
 msgid "Other"
 msgstr "其他"
 
-#: model_variables.py:202
+#: model_variables.py:266
 msgid ""
 "Please select the type of location. If none of these apply to your "
 "situation, please select \"Other\"."
 msgstr "請選擇地點類型。如果以上所有選項都不適用於您的狀況，請選擇「其他」。"
 
-#: model_variables.py:205
+#: model_variables.py:269
 msgid "Place of worship"
 msgstr "禮拜場所"
 
-#: model_variables.py:206
+#: model_variables.py:270
 msgid "Commercial"
 msgstr "商業場所"
 
-#: model_variables.py:209
+#: model_variables.py:273
 msgid "Public outdoor space"
 msgstr "戶外公共場所"
 
-#: model_variables.py:213
+#: model_variables.py:277
 msgid "Church, synagogue, temple, religious community center"
 msgstr "教堂、猶太教堂、寺廟、宗教社區中心"
 
-#: model_variables.py:214
+#: model_variables.py:278
 msgid "Store, restaurant, bar, hotel, theater"
 msgstr "商店、餐廳、酒吧、飯店、電影院"
 
-#: model_variables.py:215
+#: model_variables.py:279
 msgid ""
 "Hospital or clinic (including inpatient and outpatient programs), "
 "reproductive care clinic, state developmental institution, nursing home"
@@ -553,387 +553,387 @@ msgstr ""
 "醫院或診所（包括住院和門診計畫）、生殖護理診所、州政府發展障礙人士收容機構、"
 "療養院"
 
-#: model_variables.py:216
+#: model_variables.py:280
 msgid "Bank, credit union, loan services"
 msgstr "銀行、信用合作社、貸款服務"
 
-#: model_variables.py:217
+#: model_variables.py:281
 msgid ""
 "Park, sidewalk, street, other public buildings (courthouse, DMV, city "
 "library)"
 msgstr "公園、人行道、街道、其他公共建物（法院、DMV、市立圖書館）"
 
-#: model_variables.py:228
+#: model_variables.py:292
 msgid "State/local"
 msgstr "州／地方"
 
-#: model_variables.py:230
+#: model_variables.py:294
 msgid "Private"
 msgstr "私人"
 
-#: model_variables.py:236
+#: model_variables.py:300
 msgid "Outside of prison"
 msgstr "監獄外"
 
-#: model_variables.py:238
+#: model_variables.py:302
 msgid "Prison (Federal)"
 msgstr "監獄（聯邦）"
 
-#: model_variables.py:239
+#: model_variables.py:303
 msgid "Prison (Private)"
 msgstr "監獄（私人經營）"
 
-#: model_variables.py:240
+#: model_variables.py:304
 msgid "Prison (I'm not sure)"
 msgstr "監獄（我不確定）"
 
-#: model_variables.py:244
+#: model_variables.py:308
 msgid "Public employer"
 msgstr "公家機關雇主"
 
-#: model_variables.py:245
+#: model_variables.py:309
 msgid "Private employer"
 msgstr "私人雇主"
 
-#: model_variables.py:249
+#: model_variables.py:313
 msgid "Please select what type of employer this is."
 msgstr "請選擇該雇主是屬於什麼類型。"
 
-#: model_variables.py:252
+#: model_variables.py:316
 msgid "Fewer than 15 employees"
 msgstr "少於 15 名員工"
 
-#: model_variables.py:253
+#: model_variables.py:317
 msgid "15 or more employees"
 msgstr "15 名員工以上"
 
-#: model_variables.py:257
+#: model_variables.py:321
 msgid "Please select how large the employer is."
 msgstr "請選擇雇主的組織規模。"
 
-#: model_variables.py:269
+#: model_variables.py:333
 msgid "Public school or educational program"
 msgstr "公立學校或教育計畫"
 
-#: model_variables.py:270
+#: model_variables.py:334
 msgid "Private school or educational program"
 msgstr "私立學校或教育計畫"
 
-#: model_variables.py:276
+#: model_variables.py:340
 msgid "Alabama"
 msgstr "阿拉巴馬州"
 
-#: model_variables.py:277
+#: model_variables.py:341
 msgid "Alaska"
 msgstr "阿拉斯加州"
 
-#: model_variables.py:278
+#: model_variables.py:342
 msgid "Arizona"
 msgstr "亞利桑那州"
 
-#: model_variables.py:279
+#: model_variables.py:343
 msgid "Arkansas"
 msgstr "阿肯色州"
 
-#: model_variables.py:280
+#: model_variables.py:344
 msgid "California"
 msgstr "加州"
 
-#: model_variables.py:281
+#: model_variables.py:345
 msgid "Colorado"
 msgstr "科羅拉多州"
 
-#: model_variables.py:282
+#: model_variables.py:346
 msgid "Connecticut"
 msgstr "康乃狄克州"
 
-#: model_variables.py:283
+#: model_variables.py:347
 msgid "Delaware"
 msgstr "特拉華州"
 
-#: model_variables.py:284
+#: model_variables.py:348
 msgid "District of Columbia"
 msgstr "哥倫比亞特區"
 
-#: model_variables.py:285
+#: model_variables.py:349
 msgid "Florida"
 msgstr "佛羅里達州"
 
-#: model_variables.py:286
+#: model_variables.py:350
 msgid "Georgia"
 msgstr "喬治亞州"
 
-#: model_variables.py:287
+#: model_variables.py:351
 msgid "Hawaii"
 msgstr "夏威夷州"
 
-#: model_variables.py:288
+#: model_variables.py:352
 msgid "Idaho"
 msgstr "愛達荷州"
 
-#: model_variables.py:289
+#: model_variables.py:353
 msgid "Illinois"
 msgstr "伊利諾州"
 
-#: model_variables.py:290
+#: model_variables.py:354
 msgid "Indiana"
 msgstr "印第安納州"
 
-#: model_variables.py:291
+#: model_variables.py:355
 msgid "Iowa"
 msgstr "愛荷華州"
 
-#: model_variables.py:292
+#: model_variables.py:356
 msgid "Kansas"
 msgstr "堪薩斯州"
 
-#: model_variables.py:293
+#: model_variables.py:357
 msgid "Kentucky"
 msgstr "肯塔基州"
 
-#: model_variables.py:294
+#: model_variables.py:358
 msgid "Louisiana"
 msgstr "路易斯安那州"
 
-#: model_variables.py:295
+#: model_variables.py:359
 msgid "Maine"
 msgstr "緬因州"
 
-#: model_variables.py:296
+#: model_variables.py:360
 msgid "Maryland"
 msgstr "馬里蘭州"
 
-#: model_variables.py:297
+#: model_variables.py:361
 msgid "Massachusetts"
 msgstr "麻州"
 
-#: model_variables.py:298
+#: model_variables.py:362
 msgid "Michigan"
 msgstr "密西根州"
 
-#: model_variables.py:299
+#: model_variables.py:363
 msgid "Minnesota"
 msgstr "明尼蘇達州"
 
-#: model_variables.py:300
+#: model_variables.py:364
 msgid "Mississippi"
 msgstr "密西西比州"
 
-#: model_variables.py:301
+#: model_variables.py:365
 msgid "Missouri"
 msgstr "密蘇里州"
 
-#: model_variables.py:302
+#: model_variables.py:366
 msgid "Montana"
 msgstr "蒙大拿州"
 
-#: model_variables.py:303
+#: model_variables.py:367
 msgid "Nebraska"
 msgstr "內布拉斯加州"
 
-#: model_variables.py:304
+#: model_variables.py:368
 msgid "Nevada"
 msgstr "內華達州"
 
-#: model_variables.py:305
+#: model_variables.py:369
 msgid "New Hampshire"
 msgstr "新罕布什爾州"
 
-#: model_variables.py:306
+#: model_variables.py:370
 msgid "New Jersey"
 msgstr "紐澤西州"
 
-#: model_variables.py:307
+#: model_variables.py:371
 msgid "New Mexico"
 msgstr "新墨西哥州"
 
-#: model_variables.py:308
+#: model_variables.py:372
 msgid "New York"
 msgstr "紐約州"
 
-#: model_variables.py:309
+#: model_variables.py:373
 msgid "North Carolina"
 msgstr "北卡羅萊納州"
 
-#: model_variables.py:310
+#: model_variables.py:374
 msgid "North Dakota"
 msgstr "北達科他州"
 
-#: model_variables.py:311
+#: model_variables.py:375
 msgid "Ohio"
 msgstr "俄亥俄州"
 
-#: model_variables.py:312
+#: model_variables.py:376
 msgid "Oklahoma"
 msgstr "奧克拉荷馬州"
 
-#: model_variables.py:313
+#: model_variables.py:377
 msgid "Oregon"
 msgstr "俄勒岡州"
 
-#: model_variables.py:314
+#: model_variables.py:378
 msgid "Pennsylvania"
 msgstr "賓州"
 
-#: model_variables.py:315
+#: model_variables.py:379
 msgid "Rhode Island"
 msgstr "羅得島州"
 
-#: model_variables.py:316
+#: model_variables.py:380
 msgid "South Carolina"
 msgstr "南卡羅萊納州"
 
-#: model_variables.py:317
+#: model_variables.py:381
 msgid "South Dakota"
 msgstr "南達科他州"
 
-#: model_variables.py:318
+#: model_variables.py:382
 msgid "Tennessee"
 msgstr "田納西州"
 
-#: model_variables.py:319
+#: model_variables.py:383
 msgid "Texas"
 msgstr "德州"
 
-#: model_variables.py:320
+#: model_variables.py:384
 msgid "Utah"
 msgstr "猶他州"
 
-#: model_variables.py:321
+#: model_variables.py:385
 msgid "Vermont"
 msgstr "佛蒙特州"
 
-#: model_variables.py:322
+#: model_variables.py:386
 msgid "Virginia"
 msgstr "維吉尼亞州"
 
-#: model_variables.py:323
+#: model_variables.py:387
 msgid "Washington"
 msgstr "華盛頓州"
 
-#: model_variables.py:324
+#: model_variables.py:388
 msgid "West Virginia"
 msgstr "西維吉尼亞州"
 
-#: model_variables.py:325
+#: model_variables.py:389
 msgid "Wisconsin"
 msgstr "威斯康辛州"
 
-#: model_variables.py:326
+#: model_variables.py:390
 msgid "Wyoming"
 msgstr "懷俄明州"
 
-#: model_variables.py:327
+#: model_variables.py:391
 msgid "American Samoa"
 msgstr "美屬薩摩亞"
 
-#: model_variables.py:328
+#: model_variables.py:392
 msgid "Guam"
 msgstr "關島"
 
-#: model_variables.py:329
+#: model_variables.py:393
 msgid "Northern Mariana Islands"
 msgstr "北馬利安納群島邦"
 
-#: model_variables.py:330
+#: model_variables.py:394
 msgid "Puerto Rico"
 msgstr "波多黎各"
 
-#: model_variables.py:331
+#: model_variables.py:395
 msgid "Virgin Islands"
 msgstr "維爾京群島"
 
-#: model_variables.py:332
+#: model_variables.py:396
 msgid "Armed Forces Africa"
 msgstr "非洲武裝部隊"
 
-#: model_variables.py:333
+#: model_variables.py:397
 msgid "Armed Forces Americas"
 msgstr "美國武裝部隊"
 
-#: model_variables.py:334
+#: model_variables.py:398
 msgid "Armed Forces Canada"
 msgstr "加拿大武裝部隊"
 
-#: model_variables.py:335
+#: model_variables.py:399
 msgid "Armed Forces Europe"
 msgstr "歐洲武裝部隊"
 
-#: model_variables.py:336
+#: model_variables.py:400
 msgid "Armed Forces Middle East"
 msgstr "中東武裝部隊"
 
-#: model_variables.py:337
+#: model_variables.py:401
 msgid "Armed Forces Pacific"
 msgstr "太平洋地區武裝部隊"
 
-#: model_variables.py:340
+#: model_variables.py:404
 msgid "Please provide description to continue"
 msgstr "請提供說明以繼續進行"
 
-#: model_variables.py:341
+#: model_variables.py:405
 msgid "Please select a primary reason to continue."
 msgstr "請選擇一項主要理由以繼續進行。"
 
-#: model_variables.py:344
+#: model_variables.py:408
 msgid "Please enter the name of the location where this took place."
 msgstr "請輸入此事件發生的地點名稱。"
 
-#: model_variables.py:345
+#: model_variables.py:409
 msgid "Please enter the city or town where this took place."
 msgstr "請輸入此事件發生的城市或城鎮。"
 
-#: model_variables.py:346
+#: model_variables.py:410
 msgid "Please select the state where this took place."
 msgstr "請選擇此事件發生的州。"
 
-#: model_variables.py:350
+#: model_variables.py:414
 msgid "Please select where this occurred"
 msgstr "請選擇此事件發生的地點"
 
-#: model_variables.py:351
+#: model_variables.py:415
 msgid "Please select the type of location"
 msgstr "請選擇地點類型"
 
-#: model_variables.py:363
+#: model_variables.py:427
 msgid "You must enter a month and year. Please use the format MM/DD/YYYY."
 msgstr "您必須輸入月份和年份。請使用月月／日日／年年年年的格式。"
 
-#: model_variables.py:366
+#: model_variables.py:430
 msgid "Please enter a month."
 msgstr "請輸入月份。"
 
-#: model_variables.py:367
+#: model_variables.py:431
 msgid "Please enter a valid month. Month must be between 1 and 12."
 msgstr "請輸入有效的月份。月份必須介於 1 至 12 之間。"
 
-#: model_variables.py:368
+#: model_variables.py:432
 msgid ""
 "Please enter a valid day of the month. Day must be between 1 and the last "
 "day of the month."
 msgstr "請輸入有效的日期。日期必須介於一個月的 1 號至一個月的最後一天。"
 
-#: model_variables.py:369
+#: model_variables.py:433
 msgid "Please enter a year."
 msgstr "請輸入年份。"
 
-#: model_variables.py:370
+#: model_variables.py:434
 msgid "Date can not be in the future."
 msgstr "日期不得是未來日期。"
 
-#: model_variables.py:371
+#: model_variables.py:435
 msgid "Please enter a year after 1900."
 msgstr "請輸入 1900 之後的年份。"
 
-#: model_variables.py:372
+#: model_variables.py:436
 msgid "Please enter a valid date. Use format MM/DD/YYYY."
 msgstr "請輸入有效的日期。請使用月月／日日／年年年年的格式。"
 
-#: model_variables.py:375
+#: model_variables.py:439
 msgid "Please select the type of election or voting activity."
 msgstr "請選擇選舉或投票活動的類型。"
 
-#: model_variables.py:415
+#: model_variables.py:479
 msgid ""
 "If you submit a phone number, please make sure to include between 7 and 15 "
 "digits. The characters \"+\", \")\", \"(\", \"-\", and \".\" are allowed. "
@@ -1110,12 +1110,12 @@ msgstr "涉及的人士姓名，包括目擊證人（如有）"
 msgid "Any supporting materials (please list and describe them)"
 msgstr "任何佐證資料（請列出並加以說明）"
 
-#: templates/base.html:33 templates/base.html:58
+#: templates/base.html:42 templates/base.html:67
 #: templates/forms/report_base.html:10 templates/forms/report_base.html:13
 msgid "Contact the Civil Rights Division | Department of Justice"
 msgstr "與民權科 | 司法部聯絡"
 
-#: templates/base.html:46
+#: templates/base.html:55
 msgid ""
 "Have you or someone you know experienced unlawful discrimination? The Civil "
 "Rights Division may be able to help. Civil rights laws can protect you from "
@@ -1127,16 +1127,16 @@ msgstr ""
 "於在各種場合遭受非法歧視、騷擾或虐待，如住房、職場、學校、投票、商店、醫療保"
 "健設施、公共場所等等。"
 
-#: templates/base.html:67
+#: templates/base.html:76
 msgid "Skip to main content"
 msgstr "跳到主要內容"
 
-#: templates/base.html:121 templates/forms/errors.html:13
+#: templates/base.html:130 templates/forms/errors.html:13
 #: templates/forms/report_maintenance.html:13 templates/landing.html:17
 msgid "U.S. Department of Justice"
 msgstr "美國司法部"
 
-#: templates/base.html:124 templates/forms/confirmation.html:21
+#: templates/base.html:133 templates/forms/confirmation.html:21
 #: templates/forms/errors.html:14 templates/forms/report_maintenance.html:14
 #: templates/landing.html:20
 msgid "Civil Rights Division"
@@ -1148,7 +1148,7 @@ msgstr "民權司"
 #: templates/forms/question_cards/police_location.html:4
 #: templates/forms/question_cards/single_form.html:16
 #: templates/forms/question_cards/single_question.html:13
-#: templates/forms/report_class.html:14 templates/forms/report_details.html:13
+#: templates/forms/report_class.html:14 templates/forms/report_details.html:12
 #: templates/forms/report_location.html:33
 #: templates/forms/report_location.html:39
 #: templates/forms/report_primary_complaint.html:11
@@ -1473,19 +1473,21 @@ msgstr[1] ""
 "                  發現 %(counter)s 項錯誤\n"
 "                "
 
-#: templates/forms/report_base.html:84
+#: templates/forms/report_base.html:85
+#: templates/forms/report_contact_info.html:40
 msgid "Submit"
 msgstr "提交"
 
-#: templates/forms/report_base.html:86
+#: templates/forms/report_base.html:87
+#: templates/forms/report_contact_info.html:42
 msgid "Next"
 msgstr "下一步"
 
-#: templates/forms/report_base.html:93 templates/forms/report_review.html:32
+#: templates/forms/report_base.html:95 templates/forms/report_review.html:33
 msgid "previous step"
 msgstr "上一步"
 
-#: templates/forms/report_base.html:96 templates/forms/report_review.html:35
+#: templates/forms/report_base.html:98 templates/forms/report_review.html:36
 #: templates/partials/redirect-modal.html:21
 msgid "Back"
 msgstr "返回"
@@ -1594,8 +1596,8 @@ msgstr "舉報侵權事件"
 msgid "Already submitted?"
 msgstr "已經提交？"
 
-#: templates/landing.html:58 templates/partials/footer.html:9 views.py:951
-#: views.py:1030 views.py:1049
+#: templates/landing.html:58 templates/partials/footer.html:9
+#: views_public.py:145 views_public.py:224 views_public.py:243
 msgid "Contact"
 msgstr "聯絡"
 
@@ -1619,7 +1621,7 @@ msgid ""
 "submit a report using our online form."
 msgstr "如果您認為自己或他人的民權受到侵犯，請使用我們的線上表格提交報告。"
 
-#: templates/landing.html:88
+#: templates/landing.html:88 templates/landing.html:326
 msgid "Start a report"
 msgstr "開始提交報告"
 
@@ -1841,10 +1843,6 @@ msgstr ""
 msgid "Have you or someone you know experienced a civil rights violation?"
 msgstr "您或您所認識的人是否曾遭遇民權侵權事件？"
 
-#: templates/landing.html:326
-msgid "Submit a report"
-msgstr "提交報告"
-
 #: templates/landing.html:331
 msgid ""
 "If you cannot access the online form, you can <a href=\"#phone-footer"
@@ -1956,6 +1954,30 @@ msgstr "美國政府官方網站"
 #: templates/partials/banner/usa_banner_header.html:13
 msgid "Here’s how you know"
 msgstr "以下為您說明辨識方式"
+
+#: templates/partials/contact-info-confirmation-modal.html:8
+msgid ""
+"You are continuing your complaint without providing email or phone "
+"information."
+msgstr "您在繼續填寫您的報告，但尚未提供電子郵件或電話信息。"
+
+#: templates/partials/contact-info-confirmation-modal.html:13
+msgid ""
+"You do not have to provide contact information, however, we will not be able "
+"to contact you for any status updates or potential follow up. Would you like "
+"to add your contact information now? If you prefer not to, you will go to "
+"Step 2."
+msgstr ""
+"您不一定要提供聯繫信息，但是，我們將無法與你聯繫，以提供任何狀態更新或進行後"
+"續跟進。您想現在添加聯繫信息嗎？如果不願意，您將進入第2步。"
+
+#: templates/partials/contact-info-confirmation-modal.html:16
+msgid "No, I don't want to provide it"
+msgstr "不，我不想提供聯繫方式"
+
+#: templates/partials/contact-info-confirmation-modal.html:17
+msgid "Yes, I'd like to add it"
+msgstr "好，我想添加聯繫方式"
 
 #: templates/partials/footer.html:47
 msgid "Availability of Language Assistance Services"
@@ -2385,23 +2407,75 @@ msgstr ""
 "82 Fed. Reg. 24147 (5-25-2017)。\n"
 "                "
 
-#: validators.py:101
+#: validators.py:106
 msgid "Enter a valid email address."
 msgstr "輸入一个有效的電子郵件地址"
 
-#: views.py:78
+#: views_public.py:146 views_public.py:225 views_public.py:226
+#: views_public.py:244 views_public.py:245 views_public.py:280
+msgid "Primary concern"
+msgstr "主要擔憂問題"
+
+#: views_public.py:147 views_public.py:227 views_public.py:228
+#: views_public.py:229 views_public.py:230 views_public.py:231
+#: views_public.py:232
+msgid "Location"
+msgstr "地點"
+
+#: views_public.py:148 views_public.py:233 views_public.py:252
+msgid "Personal characteristics"
+msgstr "個人特徵"
+
+#: views_public.py:149 views_public.py:234 views_public.py:253
+msgid "Date"
+msgstr "日期"
+
+#: views_public.py:150 views_public.py:235 views_public.py:254
+msgid "Personal description"
+msgstr "個人描述"
+
+#: views_public.py:151 views_public.py:236 views_public.py:285
+msgid "Review"
+msgstr "審查"
+
+#: views_public.py:246 views_public.py:247 views_public.py:248
+#: views_public.py:249 views_public.py:250 views_public.py:251
+msgid "Location details"
+msgstr "地點詳細資訊"
+
+#: views_public.py:255
+msgid "Review your report"
+msgstr "審查您的報告"
+
+#: views_public.py:271
+msgid "word remaining"
+msgstr "仍有剩餘字數"
+
+#: views_public.py:272
+msgid " words remaining"
+msgstr " 仍有剩餘字數"
+
+#: views_public.py:273
+msgid " word limit reached"
+msgstr " 已達字數限制"
+
+#: views_public.py:283
+msgid "Please select if any that apply to your situation (optional)"
+msgstr "請選擇任何適用於您情況的選項（選填）"
+
+#: views_public.py:359
 msgid "404 | Page not found"
 msgstr "404 | 找不到網頁"
 
-#: views.py:79
+#: views_public.py:360
 msgid "We can't find the page you are looking for"
 msgstr "我們找不到您要尋找的網頁"
 
-#: views.py:138
+#: views_public.py:419
 msgid "Your browser couldn't create a secure cookie"
 msgstr "您的瀏覽器無法建立安全 cookie"
 
-#: views.py:139
+#: views_public.py:420
 msgid ""
 "We use security cookies to protect your information from attackers. Make "
 "sure you allow cookies for this site. Having the page open for long periods "
@@ -2414,53 +2488,5 @@ msgstr ""
 "cookies，但您仍發生此問題，請嘗試使用新的瀏覽器分頁或視窗開啟此網頁。這將可讓"
 "您使用新的安全 cookie 且應能解決問題。"
 
-#: views.py:826 views.py:1077
-msgid "word remaining"
-msgstr "仍有剩餘字數"
-
-#: views.py:827 views.py:1078
-msgid " words remaining"
-msgstr " 仍有剩餘字數"
-
-#: views.py:828 views.py:1079
-msgid " word limit reached"
-msgstr " 已達字數限制"
-
-#: views.py:952 views.py:1031 views.py:1032 views.py:1050 views.py:1051
-#: views.py:1086
-msgid "Primary concern"
-msgstr "主要擔憂問題"
-
-#: views.py:953 views.py:1033 views.py:1034 views.py:1035 views.py:1036
-#: views.py:1037 views.py:1038
-msgid "Location"
-msgstr "地點"
-
-#: views.py:954 views.py:1039 views.py:1058
-msgid "Personal characteristics"
-msgstr "個人特徵"
-
-#: views.py:955 views.py:1040 views.py:1059
-msgid "Date"
-msgstr "日期"
-
-#: views.py:956 views.py:1041 views.py:1060
-msgid "Personal description"
-msgstr "個人描述"
-
-#: views.py:957 views.py:1042 views.py:1091
-msgid "Review"
-msgstr "審查"
-
-#: views.py:1052 views.py:1053 views.py:1054 views.py:1055 views.py:1056
-#: views.py:1057
-msgid "Location details"
-msgstr "地點詳細資訊"
-
-#: views.py:1061
-msgid "Review your report"
-msgstr "審查您的報告"
-
-#: views.py:1089
-msgid "Please select if any that apply to your situation (optional)"
-msgstr "請選擇任何適用於您情況的選項（選填）"
+#~ msgid "Submit a report"
+#~ msgstr "提交報告"

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -40,6 +40,7 @@
         {% include 'forms/complaint_view/index/filters/contact_email.html' %}
         {% include 'forms/complaint_view/index/filters/secondary_review.html' %}
         {% include 'forms/complaint_view/index/filters/report_language.html' %}
+        {% include 'forms/complaint_view/index/filters/prison_type_filter.html' %}
       </div>
     </div>
   </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/prison_type_filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/prison_type_filter.html
@@ -1,0 +1,11 @@
+{% extends "forms/complaint_view/index/filter.html" %}
+
+{% block controls %}prison_type{% endblock %}
+{% block label %}Prison Type{% endblock %}
+{% block id %}prison-type{% endblock %}
+
+{% block content %}
+  <div id="prison-type-filter" class="multicheckboxes-container">
+    {{ form.correctional_facility_type }}
+  </div>
+{% endblock %}

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -127,7 +127,8 @@
     page: '',
     per_page: '',
     no_status: '',
-    language: []
+    language: [],
+    correctional_facility_type: []
   };
   var filterDataModel = {};
 
@@ -295,6 +296,7 @@
     var contactEmailEl = dom.querySelector('input[name="contact_email"]');
     var referredEl = dom.getElementsByName('referred');
     var languageEl = dom.getElementsByName('language');
+    var correctionalFacilityTypeEl = dom.getElementsByName('correctional_facility_type');
     /**
      * Update the filter data model when the user clears (clicks on) a filter tag,
      * and perform a new search with the updated filters applied.
@@ -312,7 +314,8 @@
         'intake_format',
         'commercial_or_public_place',
         'reported_reason',
-        'language'
+        'language',
+        'correctional_facility_type'
       ];
       var filterIndex = multiSelectElements.indexOf(filterName);
       if (filterIndex !== -1) {
@@ -443,6 +446,10 @@
     checkBoxView({
       el: languageEl,
       name: 'language'
+    });
+    checkBoxView({
+      el: correctionalFacilityTypeEl,
+      name: 'correctional_facility_type'
     });
   }
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/994)

## What does this change?

Add Tagalog language to contact info nudge modal

## Screenshots (for front-end PR):

![image](https://user-images.githubusercontent.com/6232068/127216812-67e69063-5117-4fdb-ad7f-840e7f7999b9.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
