### PR TITLE
Bh/remove inline js 1001

### DIFF
--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -147,6 +147,7 @@
     <script src="{% static 'js/focus_alert.js' %}"></script>
     <script src="{% static 'js/clear_error_class.js' %}"></script>
     <script src="{% static 'js/banner_language_selection.js' %}"></script>
+    <script src="{% static 'js/disable_submit_button.js' %}"></script>
     {% block page_js %}{% endblock %}
 
     {% block analytics %}

--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -147,7 +147,6 @@
     <script src="{% static 'js/focus_alert.js' %}"></script>
     <script src="{% static 'js/clear_error_class.js' %}"></script>
     <script src="{% static 'js/banner_language_selection.js' %}"></script>
-    <script src="{% static 'js/disable_submit_button.js' %}"></script>
     {% block page_js %}{% endblock %}
 
     {% block analytics %}

--- a/crt_portal/cts_forms/templates/forms/pro_template.html
+++ b/crt_portal/cts_forms/templates/forms/pro_template.html
@@ -114,6 +114,7 @@
     };
   })(window)
 </script>
+<script src="{% static 'js/disable_submit_button.js' %}"></script>
 <script src="{% static 'js/pro_form_show_hide.js' %}"></script>
 <script src="{% static 'js/autofill_current_date.js' %}"></script>
 <script src="{% static 'js/word_count.js' %}"></script>

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -32,7 +32,6 @@
                 class="usa-form"
                 action=""
                 method="post"
-                onsubmit="document.getElementById('submit-next').disabled = true;"
                 {% if form_autocomplete_off %}autocomplete="off"{% endif %}
                 {% if form_novalidate %}novalidate{% endif %}
           >

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -113,6 +113,7 @@
 {% endblock footer_extra %}
 
 {% block page_js %}
+<script src="{% static 'js/disable_submit_button.js' %}"></script>
 <script nonce="{{request.csp_nonce}}">
   (function(root) {
     root.CRT = root.CRT || {};

--- a/crt_portal/static/js/disable_submit_button.js
+++ b/crt_portal/static/js/disable_submit_button.js
@@ -1,0 +1,6 @@
+(function(root) {
+  document.getElementById('report-form').addEventListener('submit', disableSubmitButton);
+  function disableSubmitButton() {
+    document.getElementById('submit-next').disabled = true;
+  }
+})(window);

--- a/crt_portal/static/js/disable_submit_button.js
+++ b/crt_portal/static/js/disable_submit_button.js
@@ -2,7 +2,7 @@
   document.getElementById('report-form').addEventListener('submit', disableSubmitButton);
   function disableSubmitButton() {
     const submitNextButton = document.getElementById('submit-next');
-    const submitButton = document.getElementById('submit-next');
+    const submitButton = document.getElementById('submit');
     if (submitNextButton) submitNextButton.disabled = true;
     if (submitButton) submitButton.disabled = true;
   }

--- a/crt_portal/static/js/disable_submit_button.js
+++ b/crt_portal/static/js/disable_submit_button.js
@@ -2,8 +2,10 @@
   document.getElementById('report-form').addEventListener('submit', disableSubmitButton);
   function disableSubmitButton() {
     const submitNextButton = document.getElementById('submit-next');
+    const submitNextTopButton = document.getElementById('submit-next-top');
     const submitButton = document.getElementById('submit');
     if (submitNextButton) submitNextButton.disabled = true;
+    if (submitNextTopButton) submitNextTopButton.disabled = true;
     if (submitButton) submitButton.disabled = true;
   }
 })(window);

--- a/crt_portal/static/js/disable_submit_button.js
+++ b/crt_portal/static/js/disable_submit_button.js
@@ -1,6 +1,9 @@
 (function(root) {
   document.getElementById('report-form').addEventListener('submit', disableSubmitButton);
   function disableSubmitButton() {
-    document.getElementById('submit-next').disabled = true;
+    const submitNextButton = document.getElementById('submit-next');
+    const submitButton = document.getElementById('submit-next');
+    if (submitNextButton) submitNextButton.disabled = true;
+    if (submitButton) submitButton.disabled = true;
   }
 })(window);


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1001)

## What does this change?

I recently added some javascript to our site to disable a submit button after it was clicked.  I used an inline event to do the disable, which is a security no no.  This PR addresses that issue, which will allow the code to run.

## Screenshots (for front-end PR):

![image](https://user-images.githubusercontent.com/6232068/127379517-11742a84-a0ef-41b3-8328-bc6dee519dec.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
