### PR TITLE
'Next' button tab fix

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_contact_info.html
+++ b/crt_portal/cts_forms/templates/forms/report_contact_info.html
@@ -30,9 +30,9 @@
 
 {%  block submit-button %}
     <br />
-    <a class="usa-button button--continue report-step-1-continue">
+    <button class="usa-button button--continue report-step-1-continue">
         {% trans 'Next' %}
-    </a>
+    </button>
     <input hidden
            id="submit-next"
            type="submit"


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

Update to allow tabs to work on first page of contact.  

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
