### PR TITLE
Bh/1025 or search

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -109,7 +109,10 @@ def report_filter(querydict):
             elif filter_options[field] == '__gte':
                 kwargs[field] = querydict.getlist(field)
             elif filter_options[field] == 'violation_summary':
-                combined_or_search = _combine_term_searches_with_or(filter_list)
+                combined_or_list = []
+                for vs_filter in filter_list:
+                    combined_or_list += vs_filter.split(" OR ")
+                combined_or_search = _combine_term_searches_with_or(combined_or_list)
                 qs = qs.filter(violation_summary_search_vector=combined_or_search)
     qs = qs.filter(**kwargs)
     return qs, filters

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -31,13 +31,13 @@ class ReportFilterTests(TestCase):
         r2.protected_class.add(gender)
 
         test_data['violation_summary'] = 'boat'
-        r3 = Report.objects.create(**test_data)
+        Report.objects.create(**test_data)
 
         test_data['violation_summary'] = 'hovercraft'
-        r4 = Report.objects.create(**test_data)
+        Report.objects.create(**test_data)
 
         test_data['violation_summary'] = 'boat with some other text in the search phrase and hovercraft'
-        r5 = Report.objects.create(**test_data)
+        Report.objects.create(**test_data)
 
     def test_no_filters(self):
         """Returns all reports when no filters provided"""

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -32,22 +32,24 @@ class ReportFilterTests(TestCase):
 
         test_data['violation_summary'] = 'boat'
         r3 = Report.objects.create(**test_data)
-        r3.protected_class.add(age)
 
         test_data['violation_summary'] = 'hovercraft'
         r4 = Report.objects.create(**test_data)
-        r4.protected_class.add(age)
-        r4.protected_class.add(gender)
 
         test_data['violation_summary'] = 'boat with some other text in the search phrase and hovercraft'
-        r4 = Report.objects.create(**test_data)
-        r4.protected_class.add(age)
-        r4.protected_class.add(gender)
+        r5 = Report.objects.create(**test_data)
 
     def test_no_filters(self):
         """Returns all reports when no filters provided"""
         reports, _ = report_filter(QueryDict(''))
         self.assertEquals(reports.count(), Report.objects.count())
+
+    def test_reported_reason(self):
+        reports, _ = report_filter(QueryDict('reported_reason=age'))
+        self.assertEquals(reports.count(), 2)
+
+        reports, _ = report_filter(QueryDict('reported_reason=gender&reported_reason=language'))
+        self.assertEquals(reports.count(), 1)
 
     def test_or_search_for_violation_summary(self):
         """
@@ -59,13 +61,11 @@ class ReportFilterTests(TestCase):
         reports, _ = report_filter(QueryDict('violation_summary=plane&violation_summary=truck'))
         self.assertEquals(reports.count(), 2)
 
-    def test_complex_and_or_search_for_violation_summary(self):
-        """
-        Returns query set responsive to a simple AND search and a simple OR search
-        """
+    def test_or_search(self):
         reports, _ = report_filter(QueryDict('violation_summary=boat%20OR%20hovercraft'))
         self.assertEquals(reports.count(), 3)
 
+    def test_and_search(self):
         # "boat AND hovercraft" is functionally the same as "boat hovercraft"
         reports, _ = report_filter(QueryDict('violation_summary=boat%20AND%20hovercraft'))
         self.assertEquals(reports.count(), 1)
@@ -73,15 +73,9 @@ class ReportFilterTests(TestCase):
         reports, _ = report_filter(QueryDict('violation_summary=boat%20hovercraft'))
         self.assertEquals(reports.count(), 1)
 
-        reports, _ = report_filter(QueryDict('violation_summary=boat%20OR%20hovercraft%20AND%20truck'))
-        self.assertEquals(reports.count(), 4)
-
-    def test_reported_reason(self):
-        reports, _ = report_filter(QueryDict('reported_reason=age'))
+    def test_or_and_search(self):
+        reports, _ = report_filter(QueryDict('violation_summary=boat%20AND%20hovercraft%20OR%20truck'))
         self.assertEquals(reports.count(), 2)
-
-        reports, _ = report_filter(QueryDict('reported_reason=gender&reported_reason=language'))
-        self.assertEquals(reports.count(), 1)
 
 
 class ReportLanguageFilterTests(TestCase):


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1025)

## What does this change?

Now it is possible to do an OR search within the personal description.  This is the first of several improvements to search that will be rolling out.  

To do an OR search use a capital OR to separate terms.  An AND search is used by default, so the search 

"search1 search2 OR search3" will return results that have "search1" and "search2" in it and anything with "search3" and is functionally equivalent to "search1 AND search2 OR search3".

Note the original way to do OR searches, changing the url with something like "violation_summary=search1&violation_summary=search2" still works.  

## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/6232068/130472930-c94e8377-b27d-4cd5-a3ff-d49c204dfde0.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
