### PR TITLE
fix(forms): improve a11y on date input fields

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -578,7 +578,11 @@ def date_cleaner(self, cleaned_data):
         year = cleaned_data['last_incident_year']
         month = cleaned_data['last_incident_month']
         # custom messages
-        if day > 31 or day < 1:
+        if month > 12 or month < 1:
+            self.add_error('last_incident_month', ValidationError(
+                DATE_ERRORS['month_invalid'],
+            ))
+        elif day > 31 or day < 1:
             self.add_error('last_incident_day', ValidationError(
                 DATE_ERRORS['day_invalid'],
             ))
@@ -617,18 +621,27 @@ class When(ModelForm):
             'last_incident_month': TextInput(attrs={
                 'class': 'usa-input usa-input--small',
                 'required': True,
-                'type': 'number',
+                'type': 'text',
+                'maxlength': 2,
+                'pattern': '[0-9]*',
+                'inputmode': 'numeric',
                 'label': DATE_QUESTIONS['last_incident_month']
             }),
             'last_incident_day': TextInput(attrs={
                 'class': 'usa-input usa-input--small',
-                'type': 'number',
-                'min': 0
+                'type': 'text',
+                'maxlength': 2,
+                'pattern': '[0-9]*',
+                'inputmode': 'numeric',
             }),
             'last_incident_year': TextInput(attrs={
                 'class': 'usa-input usa-input--medium',
                 'required': True,
-                'type': 'number',
+                'type': 'text',
+                'minlength': 4,
+                'maxlength': 4,
+                'pattern': '[0-9]*',
+                'inputmode': 'numeric',
             }),
         }
 
@@ -637,12 +650,17 @@ class When(ModelForm):
 
         self.fields['last_incident_month'].label = DATE_QUESTIONS['last_incident_month']
         self.fields['last_incident_month'].error_messages = {
+            'invalid': DATE_ERRORS['month_invalid'],
             'required': DATE_ERRORS['month_required'],
         }
         self.fields['last_incident_month'].required = True
         self.fields['last_incident_day'].label = DATE_QUESTIONS['last_incident_day']
+        self.fields['last_incident_day'].error_messages = {
+            'invalid': DATE_ERRORS['day_invalid'],
+        }
         self.fields['last_incident_year'].label = DATE_QUESTIONS['last_incident_year']
         self.fields['last_incident_year'].error_messages = {
+            'invalid': DATE_ERRORS['no_past'],
             'required': DATE_ERRORS['year_required'],
         }
         self.fields['last_incident_year'].required = True
@@ -736,36 +754,53 @@ class ProForm(
             {
                 'last_incident_month': TextInput(attrs={
                     'class': 'usa-input usa-input--small',
-                    'type': 'number',
+                    'type': 'text',
+                    'maxlength': 2,
+                    'pattern': '[0-9]*',
+                    'inputmode': 'numeric',
                     'required': False,
                 }),
                 'last_incident_day': TextInput(attrs={
                     'class': 'usa-input usa-input--small',
-                    'type': 'number',
-                    'min': 0,
+                    'type': 'text',
+                    'maxlength': 2,
+                    'pattern': '[0-9]*',
+                    'inputmode': 'numeric',
                     'required': False,
                 }),
                 'last_incident_year': TextInput(attrs={
                     'class': 'usa-input usa-input--medium',
-                    'type': 'number',
+                    'type': 'text',
+                    'minlength': 4,
+                    'maxlength': 4,
+                    'pattern': '[0-9]*',
                     'required': False,
                 }),
             },
             {
                 'crt_reciept_month': TextInput(attrs={
                     'class': 'usa-input usa-input--small',
-                    'type': 'number',
+                    'type': 'text',
+                    'maxlength': 2,
+                    'pattern': '[0-9]*',
+                    'inputmode': 'numeric',
                     'required': False,
                 }),
                 'crt_reciept_day': TextInput(attrs={
                     'class': 'usa-input usa-input--small',
-                    'type': 'number',
-                    'min': 0,
+                    'type': 'text',
+                    'maxlength': 2,
+                    'pattern': '[0-9]*',
+                    'inputmode': 'numeric',
                     'required': False,
                 }),
                 'crt_reciept_year': TextInput(attrs={
                     'class': 'usa-input usa-input--medium',
-                    'type': 'number',
+                    'type': 'text',
+                    'minlength': 4,
+                    'maxlength': 4,
+                    'pattern': '[0-9]*',
+                    'inputmode': 'numeric',
                     'required': False,
                 }),
             },


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1029)

## What does this change?

Date input fields are now rendered as text fields, rather than number fields, because screen readers have trouble navigating number fields successfully. For more information, see here: https://github.com/usdoj-crt/crt-portal-management/issues/1029

Because input fields now accept text, additional error-handling logic on the back-end side was added in case users submit non-numeric data. I attempted to re-use existing error messages so new translations should be required, unless we don't think the existing messages are clear enough.

## Screenshots (for front-end PR):

New error handling:

<img width="826" alt="Screen Shot 2021-08-23 at 3 56 49 PM" src="https://user-images.githubusercontent.com/2553268/130511159-070e0a09-9a52-415c-9a80-95b56393b62a.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
