### PR TITLE
Docker: explicitly target linux/amd64 platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data/
   web:
+    platform: linux/amd64
     environment:
       - ENV=LOCAL
       - SECRET_KEY=${SECRET_KEY}


### PR DESCRIPTION
## What does this change?

By default, Docker builds and runs images on the machine's own platform. Nearly all of our environments, including our Macbooks and CircleCI, use the `linux/amd64` platform. (I'm making a reasonable assumption that this is also true for the cloud-deployed staging and production environments.)

Because we have always shared the same platform, it was not necessary to explicitly specify what we are targeting. However, I've run into a situation where it was necessary to explicitly specify the target when running this project on newer Apple M1 Silicon architecture. This is covered in the [known issues](https://docs.docker.com/desktop/mac/apple-silicon/) section on Docker's documentaiton.

While our team is not generally supporting the M1 devices for development, we do _have_ at least one of these devices. After testing this on Intel-chip Macbooks and on CircleCI, I believe it's safe to say that making this setting explicit is all gain and no loss:

- It makes it clear what our intended platform is.
- It is future-proof: in case our development MacBooks are replaced by newer M1 architecture.
- It ensures that anyone who happens to run or test code on non-`linux/amd64` devices are correctly targeting our common architecture, avoiding possible roadblocks.

## Checklist:

### Author

+ [ ] ~If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).~ n/a
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
