### PR TITLE
Update filter/table location labels for consistency

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -927,6 +927,7 @@ class Filters(ModelForm):
     )
     location_state = MultipleChoiceField(
         required=False,
+        label=_("Incident state"),
         choices=STATES_AND_TERRITORIES,
         widget=UsaCheckboxSelectMultiple(attrs={
             'name': 'location_state',
@@ -1057,8 +1058,8 @@ class Filters(ModelForm):
             'contact_first_name',
             'contact_last_name',
             'location_city_town',
-            'location_name',
             'location_state',
+            'location_name',
             'status',
             'assigned_to',
             'public_id',
@@ -1080,9 +1081,9 @@ class Filters(ModelForm):
             'assigned_section': 'View sections',
             'contact_first_name': 'Contact first name',
             'contact_last_name': 'Contact last name',
-            'location_city_town': 'Incident location city',
+            'location_city_town': 'Incident city',
+            'location_state': 'Incident state',
             'location_name': 'Incident location name',
-            'location_state': 'Incident location state',
             'assigned_to': 'Assignee',
             'public_id': 'Complaint ID',
             'primary_statute': 'Primary classification',
@@ -1118,8 +1119,8 @@ class Filters(ModelForm):
             'location_name': TextInput(attrs={
                 'class': 'usa-input',
                 'name': 'location_name',
-                'placeholder': 'Incident Location',
-                'aria-label': 'Incident Location'
+                'placeholder': 'Incident Location Name',
+                'aria-label': 'Incident Location Name'
             }),
             'public_id': TextInput(attrs={
                 'class': 'usa-input',

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -30,8 +30,8 @@
           {% render_sortable_heading 'Submitted' sort_state filter_state %}
           {% render_sortable_heading 'Contact Name' sort_state filter_state %}
           {% render_sortable_heading 'Contact Details' sort_state filter_state %}
-          {% render_sortable_heading 'Location Name' sort_state filter_state %}
           {% render_sortable_heading 'Incident Location' sort_state filter_state %}
+          {% render_sortable_heading 'Incident City/State' sort_state filter_state %}
           {% render_sortable_heading 'Incident Date' sort_state filter_state %}
         </tr>
       </thead>


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1036)

## What does this change?

Incident location and Incident city/state labels on the filter dropdowns, and on the table below, have been updated to be more consistent with each other. See linked issue for details.

## Screenshots (for front-end PR):

<img width="1356" alt="Screen Shot 2021-08-26 at 12 12 47 PM" src="https://user-images.githubusercontent.com/2553268/130998983-44899e76-f827-4117-9dbb-f709cef54c0c.png">
<img width="281" alt="Screen Shot 2021-08-26 at 12 12 54 PM" src="https://user-images.githubusercontent.com/2553268/130998975-1b580fdd-b160-4151-825a-3e359615fc14.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
