### PR TITLE
fix(form_letter): removeChild error after print action

### DIFF
--- a/crt_portal/static/js/form_letter.js
+++ b/crt_portal/static/js/form_letter.js
@@ -130,7 +130,7 @@
     letterhead.removeAttribute('hidden');
     document.body.appendChild(letterhead);
     window.print();
-    letterhead.removeChild(el);
+    el.remove();
     document.body.removeChild(letterhead);
     root.CRT.closeModal(modal);
   };


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1039)

## What does this change?

Fixes a "Failed to execute 'removeChild' on 'Node' error in console after canceling a print action on the "Contact Complainant" form letter. https://github.com/usdoj-crt/crt-portal-management/issues/1039

The issue was caused because the `removeChild` method was called on the wrong parent element. One technique for correcting the bug would have been to call the method on the right parent element. However, there's a newer JavaScript method which is easier to use and less error-prone: `el.remove()`, which allows us to remove an element from the page without needing to know or access its parent element.

The `.remove()` syntax [is supported in a majority of all browsers](https://caniuse.com/childnode-remove), but not in Internet Explorer. Since the CRT team uses Edge on Windows, this functionality should behave as expected.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
