### PR TITLE
fix(styles): wrong hero image on mobile; extra bottom-border on footer in mobile

### DIFF
--- a/crt_portal/static/sass/custom/footer.scss
+++ b/crt_portal/static/sass/custom/footer.scss
@@ -106,6 +106,7 @@ footer {
 .usa-footer__nav {
   padding-left: 0;
   padding-right: 0;
+  border-bottom: 0; // Always remove bottom border, even on mobile
 }
 
 .usa-footer__secondary-section {

--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -238,6 +238,14 @@ $arrow-height: 24px;
   min-height: 800px;
   rel: preload;
 
+  @include at-media-max(desktop) {
+    background-image: url(../../img/landing-page-hero-tablet.jpg);
+    background-position: bottom;
+    min-height: 850px;
+    rel: preload;
+  }
+
+  // This must be placed _after_ the desktop media query for higher priority
   @include at-media-max(mobile-lg) {
     background-image: url(../../img/landing-page-hero-mobile.jpeg);
     background-size: cover; // avoid unsightly mobile gap
@@ -260,13 +268,6 @@ $arrow-height: 24px;
     a:visited {
       color: white;
     }
-  }
-
-  @include at-media-max(desktop) {
-    background-image: url(../../img/landing-page-hero-tablet.jpg);
-    background-position: bottom;
-    min-height: 850px;
-    rel: preload;
   }
 
   h1 {


### PR DESCRIPTION
## What does this change?

This is a hotfix to the 09-07-2021 release branch (currently on staging) that fixes a regression where the hero element of the landing page has the wrong background image on mobile devices. As a result, the hero text has improper contrast with the background, and is not legible. This warrants a hotfix before deploying to production.

The regression was caused by a change in the CSS build process of `uswds-gulp` (see https://github.com/uswds/uswds-gulp/commit/b714fd93fe917618ac666bbe50a6fdf1fff6b88d), which no longer forces media queries to be re-sorted. This altered the priority in which certain media queries applied styles to different devices, and the mobile view has improperly used the background for tablet devices. I did not initially expect this build process change to affect our stylesheets, but it turns out that it did. We fix this issue by changing the source order of the affected media query so that the build output has styles in the expected priority order.

This hotfix also fixes a smaller, less destructive regression that caused a small white border to appear on the bottom of the footer, also only on mobile devices.

This pull request was made to fix the immediate issue before deploying to production; it is not intended to guard against future regressions of a similar nature. However, we do have CI tests that will fail if text has improper contrast with its background. My next step to follow up from this is to see whether these tests can be augmented to cover mobile views.

## Screenshots (for front-end PR):

Regression (current develop branch)

<img width="427" alt="Screen Shot 2021-09-01 at 6 00 43 PM" src="https://user-images.githubusercontent.com/2553268/131752948-502c09ed-e0a4-4fef-a49f-efa3a087980f.png">

Expected (fix)

<img width="426" alt="Screen Shot 2021-09-01 at 6 05 43 PM" src="https://user-images.githubusercontent.com/2553268/131752956-06680cbf-fd7d-4847-9202-a31440fe9644.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
