### PR TITLE
Add aria labels to language buttons

### DIFF
--- a/crt_portal/cts_forms/templates/partials/banner/usa_banner_language_selection.html
+++ b/crt_portal/cts_forms/templates/partials/banner/usa_banner_language_selection.html
@@ -11,7 +11,7 @@
       <form id="language_selection_form" action="{% url 'set_language' %}" method="post" class="usa-form">{% csrf_token %}
       <input id="language_input" name="language" type="hidden" />
         {% for language in languages %}
-          <button class="usa-banner__button language-selection__button {% if language.code == LANGUAGE_CODE %}language-selection__button-active{% endif %}" data-value="{{ language.code }}">
+          <button aria-label="{{ language.name }}"  class="usa-banner__button language-selection__button {% if language.code == LANGUAGE_CODE %}language-selection__button-active{% endif %}" data-value="{{ language.code }}">
             <span class="usa-banner__button-text">{{ language.name_local }}</span>
           </button>
         {% endfor %}


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1048)

## What does this change?

Aria labeling was not on the language buttons on the header of the site, so they were not accessible via screen readers.  This small PR fixes this.  

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
