### PR TITLE
1052: Allow different cases of an email to be used.

### DIFF
--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -18,7 +18,7 @@ def remove_disallowed_recipients(recipient_list):
         recipient_list = [
             to_address
             for to_address in recipient_list
-            if to_address in restricted_to
+            if to_address.lower() in restricted_to
         ]
     return recipient_list
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1052)

## What does this change?

Currently, email restriction lists are case sensitive.  This can be confusing for users.  This fix allows different cases of the same email to be treated equally when sending emails.

## Screenshots (for front-end PR):
*before*
<img width="607" alt="Screen Shot 2021-09-10 at 12 02 54 PM" src="https://user-images.githubusercontent.com/6232068/132883885-dd312fc9-0c30-4373-b50b-71f521f639a4.png">

*after*
<img width="616" alt="Screen Shot 2021-09-10 at 12 03 12 PM" src="https://user-images.githubusercontent.com/6232068/132883924-4f6fa576-5248-4b6c-8a91-dbed583a7f4b.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
