### PR TITLE
Updating the date in the print formatting.

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/form_letter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/form_letter.html
@@ -14,7 +14,7 @@
   <hr />
   <div class="subheader">
     <p><em>Washington, DC 20530</em></p>
-    <p>{% now "DATE_FORMAT" %}</p>
+    <p>{% now "F j, Y" %}</p>
   </div>
   <p id="form-letterhead--addressee">
     {{ data.contact_first_name }} {{ data.contact_last_name }}


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1045)

## What does this change?

The date was being abbreviated for printed letters being sent out.  This change updates that to include the entire Month (eg "September" instead of "Sept") 

## Screenshots (for front-end PR):

Before update: 
![image](https://user-images.githubusercontent.com/6232068/132913413-d4442f7e-107d-4206-8d9e-1b8b9b5074fd.png)


After update: 
![image](https://user-images.githubusercontent.com/6232068/132913340-0e4a4677-f700-45bb-81fc-c304277532e5.png)


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
