### PR TITLE
Added test and allow mixed case in settings.RESTRICT_EMAIL_RECIPIENTS_TO

### DIFF
--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -18,7 +18,7 @@ def remove_disallowed_recipients(recipient_list):
         recipient_list = [
             to_address
             for to_address in recipient_list
-            if to_address.lower() in restricted_to
+            if to_address.lower() in [email.lower() for email in restricted_to]
         ]
     return recipient_list
 

--- a/crt_portal/cts_forms/tests/test_mail.py
+++ b/crt_portal/cts_forms/tests/test_mail.py
@@ -23,3 +23,11 @@ class CrtSendMailTests(SimpleTestCase):
         """
         recipients = ['to1@example.com', 'to2@test.com']
         self.assertEquals(remove_disallowed_recipients(recipients), recipients)
+
+    @override_settings(RESTRICT_EMAIL_RECIPIENTS_TO=['mixedCASE@example.com'])
+    def test_case_remove_disallowed_recipients(self):
+        """
+        Test to make sure the correct restricted emails are used, regardless of case.
+        """
+        recipients = ['MiXedCAsE@example.com']
+        self.assertEquals(remove_disallowed_recipients(recipients), ['MiXedCAsE@example.com'])


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1052)

## What does this change?

This is a continuation of 1052.  I wanted to add some tests.  in adding the tests, I discovered a potential problem down the road if someone enters a non lowercase email on circleci.  This change to mail.py fixes it.  

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
