### PR TITLE
Remove Yarn installation from run scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,10 +213,8 @@ jobs:
           command: |
             echo "deb https://deb.nodesource.com/node_12.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
             wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-            echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
-            wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
             apt-get update && \
-            apt-get install -yqq nodejs yarn && \
+            apt-get install -yqq nodejs && \
             npm i -g npm@^6 && \
             rm -rf /var/lib/apt/lists/*
             npm ci --production
@@ -270,10 +268,8 @@ jobs:
           command: |
             echo "deb https://deb.nodesource.com/node_12.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
             wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-            echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
-            wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
             apt-get update && \
-            apt-get install -yqq nodejs yarn && \
+            apt-get install -yqq nodejs && \
             npm i -g npm@^6 && \
             rm -rf /var/lib/apt/lists/*
             npm ci --production
@@ -328,10 +324,8 @@ jobs:
           command: |
             echo "deb https://deb.nodesource.com/node_12.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
             wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-            echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
-            wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
             apt-get update && \
-            apt-get install -yqq nodejs yarn && \
+            apt-get install -yqq nodejs && \
             npm i -g npm@^6 && \
             rm -rf /var/lib/apt/lists/*
             npm ci --production

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,8 @@ RUN \
 RUN \
   echo "deb https://deb.nodesource.com/node_12.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
-  wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   apt-get update && \
-  apt-get install -yqq nodejs yarn && \
+  apt-get install -yqq nodejs && \
   pip install -U pip && pip install pipenv && \
   npm i -g npm@^6 && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1065)

## What does this change?

Removes Yarn from install scripts, which saves us a little bit of install time during deployment. We don't use it.

## Screenshots (for front-end PR):

n/a 

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
