### PR TITLE
feat(autoresponse): default to sending an english autoresponse letter

### DIFF
--- a/crt_portal/cts_forms/views_public.py
+++ b/crt_portal/cts_forms/views_public.py
@@ -142,8 +142,9 @@ def show_location_form_condition(wizard):
 
 
 def send_autoresponse_mail(report):
-    # Guaranteed to find only one email template, or set to None
-    template = ResponseTemplate.objects.filter(title='CRT Auto response', language=report.language).first()
+    # Guaranteed to find only one email template, or set to None. If the letter template
+    # template in the report's language is not found, default to sending the English letter
+    template = ResponseTemplate.objects.filter(title='CRT Auto response', language=report.language).first() or ResponseTemplate.objects.filter(title='CRT Auto response', language='en').first()
 
     # Skip automated response if complainant doesn't provide an email
     # or if the auto response template doesn't exist


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1068)

## What does this change?

[Previously](https://github.com/usdoj-crt/crt-portal-management/issues/1057), an autoresponse email will not be sent if there's a letter template wasn't found in the submitted report's language. In response to team feedback, this change now always sends a letter (if it can) in English, if there's no letter in another language.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
