### PR TITLE
fix: when closing a report, don't check against cached status

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -15,7 +15,8 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
-from .model_variables import (COMMERCIAL_OR_PUBLIC_ERROR,
+from .model_variables import (CLOSED_STATUS,
+                              COMMERCIAL_OR_PUBLIC_ERROR,
                               COMMERCIAL_OR_PUBLIC_PLACE_CHOICES,
                               COMMERCIAL_OR_PUBLIC_PLACE_HELP_TEXT,
                               CONTACT_PHONE_INVALID_MESSAGE,
@@ -1346,7 +1347,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
         If this report was referred, set the section.
         """
         report = super().save(commit=False)
-        if report.closed:
+        if report.status == CLOSED_STATUS:
             report.closeout_report()
             self.report_closed = True
         if report.referred:


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1075)

## What does this change?

Potential fix for a bug where reports that are closed do not update its "closed date" property.

We think the issue is with a stale cached value. When [the `report.closed` property is checked](https://github.com/usdoj-crt/crt-portal/blob/4bdcbb4a4c05eb6b983a09d15210422d94150a2a/crt_portal/cts_forms/forms.py#L1349), it is not always true when it should be. This is because it's a [computed property that is cached](https://github.com/usdoj-crt/crt-portal/blob/develop/crt_portal/cts_forms/models.py#L356-L358).

The quick-fix is to stop checking against the cached property in this method.

Since we can't consistently cause a closed report to fail to update its closed date, we may need to run this for a while to ensure that we've solved the problem and that it doesn't create unnecessary performance bottlenecks.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
