### PR TITLE
Add relative positioning to form/view status checkbox.

### DIFF
--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -120,6 +120,9 @@
         + .usa-button {
           margin-left: 2rem;
         }
+        .usa-checkbox {
+          position: relative;
+        }
       }
     }
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1078)

## What does this change?

There was some css stylings that were causing strange checkbox behavior on form/view in the status checkbox.  This css change takes care of it.  



## Screenshots (for front-end PR):

This is the location of the Closed checkbox before the change.  Note it is over the Open box, leading to the incorrect checkbox being clicked.  
![image](https://user-images.githubusercontent.com/6232068/134574634-c69829e0-e515-4946-b02a-0d47dfa92a07.png)

Here it is after the change.
![image](https://user-images.githubusercontent.com/6232068/134574950-6a231fe6-2bb5-40e9-8cb4-0f5e82ad1148.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
