### PR TITLE
fix(pagination): page pills overflow at large page numbers

### DIFF
--- a/crt_portal/static/sass/custom/pagination.scss
+++ b/crt_portal/static/sass/custom/pagination.scss
@@ -18,14 +18,14 @@ $button-size: 1.5rem;
   li {
     height: 2rem;
     margin: 0 2px;
-    width: 2rem;
+    min-width: 2rem;
 
     a,
     div,
     span.ellipsis {
       border-radius: 5px;
       display: block;
-      width: $button-size;
+      padding: 0 0.25rem;
       height: $button-size;
       line-height: $button-size;
       text-align: center;


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1081)

## What does this change?

Adjusts CSS for pagination pills to display large page numbers correctly.

## Screenshots (for front-end PR):

<img width="1081" alt="Screen Shot 2021-09-22 at 6 03 44 PM" src="https://user-images.githubusercontent.com/2553268/134584342-71b375d0-be70-4c68-957a-bb3111ea2ce3.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
