### PR TITLE
fix(tests): remove django toolbar in test environments

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -12,11 +12,15 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import json
 import os
+import sys
 
 import boto3
 import django.conf.locale
 from django.utils.log import DEFAULT_LOGGING
 from django.utils.translation import gettext_lazy as _
+
+# Are we in a test environment?
+TESTING = len(sys.argv) > 1 and sys.argv[1] == 'test'
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -464,6 +468,11 @@ elif environment == 'LOCAL':
 
 if environment == 'LOCAL':
     from .local_settings import *  # noqa: F401,F403
+
+# Don't activate the debug toolbar in a test environment; it can unexpectedly
+# output HTML content that will break test assertions
+if TESTING:
+    ENABLE_DEBUG_TOOLBAR = False
 
 # Django debug toolbar setup
 if ENABLE_DEBUG_TOOLBAR:


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1082)

## What does this change?

Removes the Django Debug Toolbar when the app is running under test. This removes the possibility of a type of bug (discovered in https://github.com/usdoj-crt/crt-portal/pull/987) that can result in unit tests behaving differently in CI versus local environments.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
