### PR TITLE
Include ARIA hint to read one instance of "911" as digits

### DIFF
--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -1762,8 +1762,12 @@ msgid "or learn more about <a href=\"#your-rights\">your rights</a>"
 msgstr "o aprenda más sobre <a href=\"#your-rights\">sus derechos</a>"
 
 #: templates/landing.html:102
-msgid "If you are in danger, contact <a href=\"tel:911\">911</a>"
-msgstr "Si usted se encuentra en peligro, llame al <a href=\"tel:911\">911</a>"
+msgid ""
+"If you are in danger, contact <a href=\"tel:911\" aria-label=\"9 1 1\">911</"
+"a>"
+msgstr ""
+"Si usted se encuentra en peligro, llame al <a href=\"tel:911\" aria-label="
+"\"9 1 1\">911</a>"
 
 #: templates/landing.html:113
 msgid ""

--- a/crt_portal/cts_forms/locale/ko/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/ko/LC_MESSAGES/django.po
@@ -1679,8 +1679,12 @@ msgid "or learn more about <a href=\"#your-rights\">your rights</a>"
 msgstr "또는 <a href=\"#your-rights\">귀하의 권리</a>에 대해 더 알아보세요"
 
 #: templates/landing.html:102
-msgid "If you are in danger, contact <a href=\"tel:911\">911</a>"
-msgstr "위험에 처해 있다면 <a href=\"tel:911\">911</a>로 연락하세요"
+msgid ""
+"If you are in danger, contact <a href=\"tel:911\" aria-label=\"9 1 1\">911</"
+"a>"
+msgstr ""
+"위험에 처해 있다면 <a href=\"tel:911\" aria-label=\"9 1 1\">911</a>로 연락하"
+"세요"
 
 #: templates/landing.html:113
 msgid ""

--- a/crt_portal/cts_forms/locale/tl/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/tl/LC_MESSAGES/django.po
@@ -1784,9 +1784,12 @@ msgstr ""
 "mga karapatan</a>"
 
 #: templates/landing.html:102
-msgid "If you are in danger, contact <a href=\"tel:911\">911</a>"
+msgid ""
+"If you are in danger, contact <a href=\"tel:911\" aria-label=\"9 1 1\">911</"
+"a>"
 msgstr ""
-"Kung ikaw ay nasa panganib, makipag-ugnay sa <a href=\"tel:911\">911</a>"
+"Kung ikaw ay nasa panganib, makipag-ugnay sa <a href=\"tel:911\" aria-label="
+"\"9 1 1\">911</a>"
 
 #: templates/landing.html:113
 msgid ""

--- a/crt_portal/cts_forms/locale/vi/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/vi/LC_MESSAGES/django.po
@@ -1750,8 +1750,12 @@ msgstr ""
 "hoặc tìm hiểu thêm về các <a href=\"#your-rights\">quyền của quý vị</a>"
 
 #: templates/landing.html:102
-msgid "If you are in danger, contact <a href=\"tel:911\">911</a>"
-msgstr "Nếu quý vị đang gặp nguy hiểm, hãy gọi <a href=\"tel:911\">911</a>"
+msgid ""
+"If you are in danger, contact <a href=\"tel:911\" aria-label=\"9 1 1\">911</"
+"a>"
+msgstr ""
+"Nếu quý vị đang gặp nguy hiểm, hãy gọi <a href=\"tel:911\" aria-label=\"9 1 "
+"1\">911</a>"
 
 #: templates/landing.html:113
 msgid ""

--- a/crt_portal/cts_forms/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1615,8 +1615,10 @@ msgid "or learn more about <a href=\"#your-rights\">your rights</a>"
 msgstr "或了解更多<a href=\"#your-rights\">你的权利</a>"
 
 #: templates/landing.html:102
-msgid "If you are in danger, contact <a href=\"tel:911\">911</a>"
-msgstr "如果你身处危险，请拨打<a href=\"tel:911\">911</a>"
+msgid ""
+"If you are in danger, contact <a href=\"tel:911\" aria-label=\"9 1 1\">911</"
+"a>"
+msgstr "如果你身处危险，请拨打<a href=\"tel:911\" aria-label=\"9 1 1\">911</a>"
 
 #: templates/landing.html:113
 msgid ""

--- a/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
@@ -1630,8 +1630,11 @@ msgid "or learn more about <a href=\"#your-rights\">your rights</a>"
 msgstr "或進一步瞭解<a href=\"#your-rights\">您的權利</a>"
 
 #: templates/landing.html:102
-msgid "If you are in danger, contact <a href=\"tel:911\">911</a>"
-msgstr "如果您處境危險，請聯絡 <a href=\"tel:911\">911</a>"
+msgid ""
+"If you are in danger, contact <a href=\"tel:911\" aria-label=\"9 1 1\">911</"
+"a>"
+msgstr ""
+"如果您處境危險，請聯絡 <a href=\"tel:911\" aria-label=\"9 1 1\">911</a>"
 
 #: templates/landing.html:113
 msgid ""

--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -99,7 +99,7 @@
         <div class="tablet:grid-offset-2 tablet:grid-col-8">
           <img src="{% static "img/ic_phone-circle.svg" %}" alt="phone" class="icon">
           <p class="h3__display crt-landing--emergency_header">
-            {% trans 'If you are in danger, contact <a href="tel:911">911</a>' %}
+            {% trans 'If you are in danger, contact <a href="tel:911" aria-label="9 1 1">911</a>' %}
           </p>
         </div>
         <div class="tablet:grid-offset-2 tablet:grid-col-8">


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1080)

## What does this change?

Adds an `aria-label` attribute to one instance of `<a href="tel:911">911</a>` that was being read as "nine hundred and eleven" in the NVDA screen reader. The attribute hint should inform NVDA to read this element as "nine one one".

Note that NVDA won't read it as digits if it's reading the element _by itself_, it needs to read the entire sentence to pick up the hint.

Because this changes inline HTML for the sentence, locale files must also be updated accordingly.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
