### PR TITLE
fix: date pickers should not pick up uswds js

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/date.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/date.html
@@ -4,13 +4,18 @@
 {% block id %}date{% endblock %}
 
 {% block content %}
-<div class="usa-date-range-picker">
-  <label class="margin-bottom-1" for="date_range_filter"><b>Submission date</b></label>
-  <div class="usa-date-picker">
-    <label for="id_{{form.create_date_start.name}}" class="usa-label"
-      for="{{form.create_date_start.name}}">From:</label>
+<div class="date-range-picker">
+  <label class="margin-bottom-1">
+    <b>Submission date</b>
+  </label>
+  <div class="date-picker">
+    <label for="id_{{form.create_date_start.name}}" class="usa-label">
+      From:
+    </label>
     {{ form.create_date_start }}
-    <label for="id_{{form.create_date_end.name}}" class="usa-label" for="{{form.create_date_end.name}}">To:</label>
+    <label for="id_{{form.create_date_end.name}}" class="usa-label">
+      To:
+    </label>
     {{ form.create_date_end }}
   </div>
 </div>


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1085)

## What does this change?

USWDS date picker functionality was conflicting with existing date picker functionality on `/form/view/`. This change restores the original date picker functionality.

## Screenshots (for front-end PR):

<img width="337" alt="Screen Shot 2021-09-28 at 12 17 09 PM" src="https://user-images.githubusercontent.com/2553268/135126007-721249fb-6d45-47d1-b89c-0cc7ed8c61f7.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
