### PR TITLE
Fix pa11y tests

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_contact_info.html
+++ b/crt_portal/cts_forms/templates/forms/report_contact_info.html
@@ -29,7 +29,7 @@
 
 {% block submit-button %}
     <br />
-    <button class="usa-button button--continue report-step-1-continue">
+    <button class="usa-button button--continue" id="report-step-1-continue">
         {% trans 'Next' %}
     </button>
     <input hidden

--- a/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/crt_radio_area_option.html
@@ -25,7 +25,7 @@
             <div class="examples-title margin-top-2">
               {% trans "Examples:" %}
             </div>
-            <ul class="examples" role="presentation">
+            <ul class="examples">
               {% for example in examples %}
                 <li class="primary-issue-example-li" role="listitem">
                   {{ example|safe }}<span class="usa-sr-only">.</span>

--- a/crt_portal/static/js/contact_info_confirmation_modal.js
+++ b/crt_portal/static/js/contact_info_confirmation_modal.js
@@ -3,7 +3,7 @@
   var modal_el = document.getElementById('contact-info-confirmation--modal');
 
   function clickSubmit(stepOneSubmitButton) {
-    stepOneSubmitButton[0].addEventListener('click', event => {
+    stepOneSubmitButton.addEventListener('click', event => {
       var phone_el = document.getElementsByName('0-contact_phone')[0];
       var email_el = document.getElementsByName('0-contact_email')[0];
       var requiredFieldSelected =
@@ -33,8 +33,8 @@
   }
 
   if (root.CRT.stageNumber === 1) {
-    var stepOneSubmitButton = document.getElementsByClassName('report-step-1-continue');
-    if (stepOneSubmitButton.length) {
+    var stepOneSubmitButton = document.getElementById('report-step-1-continue');
+    if (stepOneSubmitButton) {
       var submitNextButton = document.getElementById('submit-next');
       var continue_modal_button = document.getElementById('external-link--continue');
       continue_modal_button.onclick = function(event) {

--- a/pa11y_scripts/.crt-view.json
+++ b/pa11y_scripts/.crt-view.json
@@ -1,19 +1,21 @@
 {
-    "urls": [
-        {
-          "useIncognitoBrowserContext": true,
-          "url": "http://127.0.0.1:8000/form/view/",
-          "actions": [
-            "wait for url to be http://127.0.0.1:8000/accounts/login/?next=/form/view/",
-            "set field #id_username to pa11y_tester",
-            "set field #id_password to imposing40Karl5monomial",
-            "click #login",
-            "wait for url to be http://127.0.0.1:8000/form/view/?status=new&status=open&no_status=false",
-            "wait for element #id_status to be visible",
-            "click element #submitted-sort",
-            "wait for url to be http://127.0.0.1:8000/form/view/?sort=create_date&status=new&status=open"
-          ],
-          "screenCapture": "pa11y-screenshots/crt-sort-view.png"
-        }
-    ]
+  "urls": [
+    {
+      "useIncognitoBrowserContext": true,
+      "url": "http://127.0.0.1:8000/form/view/",
+      "actions": [
+        "wait for url to be http://127.0.0.1:8000/accounts/login/?next=/form/view/",
+        "set field #id_username to pa11y_tester",
+        "set field #id_password to imposing40Karl5monomial",
+        "click element #login",
+        "wait for path to be /form/view/",
+        "wait for element #id_status to be visible",
+        "wait for element #submitted-sort to be visible",
+        "screen capture pa11y-screenshots/crt-sort-view-extra-wait.png",
+        "click element #submitted-sort",
+        "wait for url to be http://127.0.0.1:8000/form/view/?sort=-create_date&status=new&status=open"
+      ],
+      "screenCapture": "pa11y-screenshots/crt-sort-view.png"
+    }
+  ]
 }

--- a/pa11y_scripts/.p1-error.json
+++ b/pa11y_scripts/.p1-error.json
@@ -4,8 +4,8 @@
       "url": "http://127.0.0.1:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_0 to be visible",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
         "wait for element #page-errors to be visible"
       ],
       "screenCapture": "pa11y-screenshots/page1-error.png"

--- a/pa11y_scripts/.p2-error.json
+++ b/pa11y_scripts/.p2-error.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember to be visible",
         "click element #id_0-servicemember_0",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
         "wait for element #submit-next to be visible",
         "click element #submit-next",

--- a/pa11y_scripts/.p2-primary-issue.json
+++ b/pa11y_scripts/.p2-primary-issue.json
@@ -3,10 +3,11 @@
     {
       "url": "http://127.0.0.1:8000/report",
       "actions": [
-        "wait for element #submit-next to be visible",
         "click element #id_0-servicemember_0",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible"
       ],
       "screenCapture": "pa11y-screenshots/page2-primary-issue.png"

--- a/pa11y_scripts/.p3-hatecrime.json
+++ b/pa11y_scripts/.p3-hatecrime.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
         "click element #id_1-primary_complaint_0",
         "wait for element #submit-next to be visible",

--- a/pa11y_scripts/.p3-location-commercial.json
+++ b/pa11y_scripts/.p3-location-commercial.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember_0 to be visible",
         "click element #id_0-servicemember_0",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
         "click element #id_1-primary_complaint_5",
         "wait for element #submit-next to be visible",

--- a/pa11y_scripts/.p3-location-education.json
+++ b/pa11y_scripts/.p3-location-education.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember_0 to be visible",
         "click element #id_0-servicemember_0",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
         "click element #id_1-primary_complaint_2",
         "wait for element #submit-next to be visible",

--- a/pa11y_scripts/.p3-location-police.json
+++ b/pa11y_scripts/.p3-location-police.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember_0 to be visible",
         "click element #id_0-servicemember_0",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
         "click element #id_1-primary_complaint_4",
         "wait for element #submit-next to be visible",

--- a/pa11y_scripts/.p3-location-police.json
+++ b/pa11y_scripts/.p3-location-police.json
@@ -10,7 +10,7 @@
         "wait for element #external-link--continue to be visible",
         "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
-        "click element #id_1-primary_complaint_4",
+        "click element #id_1-primary_complaint_3",
         "wait for element #submit-next to be visible",
         "click element #submit-next",
         "wait for element #id_2-hate_crime_0 to be visible",

--- a/pa11y_scripts/.p3-location-workplace.json
+++ b/pa11y_scripts/.p3-location-workplace.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember_0 to be visible",
         "click element #id_0-servicemember_0",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint_0 to be visible",
         "click element #id_1-primary_complaint_0",
         "wait for element #submit-next to be visible",

--- a/pa11y_scripts/.p4-protected-class.json
+++ b/pa11y_scripts/.p4-protected-class.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
         "click element #id_1-primary_complaint_0",
         "wait for element #submit-next to be visible",

--- a/pa11y_scripts/.p5-date.json
+++ b/pa11y_scripts/.p5-date.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
         "click element #id_1-primary_complaint_0",
         "wait for element #submit-next to be visible",

--- a/pa11y_scripts/.p5-errors.json
+++ b/pa11y_scripts/.p5-errors.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
         "click element #id_1-primary_complaint_0",
         "wait for element #submit-next to be visible",

--- a/pa11y_scripts/.p5-errors.json
+++ b/pa11y_scripts/.p5-errors.json
@@ -37,6 +37,7 @@
         "click element #submit-next",
         "wait for element #page-errors to be visible",
         "set field #id_10-last_incident_year to 2021",
+        "set field #id_10-last_incident_month to 0",
         "wait for element #submit-next to be visible",
         "click element #submit-next",
         "wait for element #page-errors to be visible"

--- a/pa11y_scripts/.p6-details.json
+++ b/pa11y_scripts/.p6-details.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
         "click element #id_1-primary_complaint_0",
         "wait for element #submit-next to be visible",

--- a/pa11y_scripts/.p7-review.json
+++ b/pa11y_scripts/.p7-review.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
         "click element #id_1-primary_complaint_0",
         "wait for element #submit-next to be visible",

--- a/pa11y_scripts/.p8-confirmation.json
+++ b/pa11y_scripts/.p8-confirmation.json
@@ -5,8 +5,10 @@
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",
-        "wait for element #submit-next to be visible",
-        "click element #submit-next",
+        "wait for element #report-step-1-continue to be visible",
+        "click element #report-step-1-continue",
+        "wait for element #external-link--continue to be visible",
+        "click element #external-link--continue",
         "wait for element #id_1-primary_complaint to be visible",
         "click element #id_1-primary_complaint_0",
         "wait for element #submit-next to be visible",


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1028)

## What does this change?

Local pa11y tests run with `npm run test:a11y` are broken. We don't run them in CI right now, so the incentive to fix this has been low. (We may also want to replace using pa11y for E2E tests entirely, more on this in a second.)

The following changes to pa11y tests were made to make the test suite work:

- Interaction on the "next" button on step 1 needed to account for the new contact nudge modal.
- Update `3-police` test with new ID target
- Update `p5-error` test to properly fail with incorrect inputs
- Remove unnecessary `role="presentation"` attributes in accordance with pa11y report
- Update `crt-view` test with correct syntax and an extra screenshot which was apparently needed to give the `#submitted-sort` element sufficient time to exist

However, pa11y still remains a brittle test and not a good candidate for E2E texts. We currently do run Playwright on CI, although the tests there differ from tests written in pa11y. There will be a follow-up card soon to investigate replacing or migrating E2E tests full to Playwright or an equivalent E2E framework.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
