### PR TITLE
Update to relative links to fix local env.

### DIFF
--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -233,14 +233,14 @@
   &.sort-up {
     &:after {
       @include sortable-cell-icon();
-      background: url('/static/img/sort-up.svg');
+      background: url('../../img/sort-up.svg');
     }
   }
 
   &.sort-down {
     &:after {
       @include sortable-cell-icon();
-      background: url('/static/img/sort-down.svg');
+      background: url('../../img/sort-down.svg');
     }
   }
 }


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1086)

## What does this change?

'sort-up.svg' and 'sort-down.svg' were not showing up in our local environment.  This change will fix that, and brings the background svg in line with the rest of the project.  

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
