### PR TITLE
fix(landing): proper hover states on example dropdown

### DIFF
--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -442,10 +442,11 @@ $arrow-height: 24px;
   }
 
   .crt-landing--large_select {
-    @include u-radius('md');
+    @include u-radius-top('lg');
     @include u-shadow(3);
     margin-top: 2.5rem;
     padding: 0;
+    background-color: color('white');
 
     @include at-media-max(mobile-lg) {
       margin-top: 2rem;
@@ -456,12 +457,12 @@ $arrow-height: 24px;
     }
 
     button {
+      @include u-radius('lg');
       @include text--heading__medium();
       padding: 1rem 1.5rem !important;
       font-weight: normal;
       color: color('white');
       min-height: 5rem;
-      border-radius: 4px;
 
       // caret adjustments -- in many cases overriding the USWDS defaults
       background-repeat: no-repeat !important;
@@ -479,6 +480,7 @@ $arrow-height: 24px;
       }
 
       &[aria-expanded='true'] {
+        @include u-radius-bottom(0);
         background-image: url(../../img/angle-arrow-up-white.svg) !important;
       }
 
@@ -496,6 +498,7 @@ $arrow-height: 24px;
   #crt-landing--examples {
     padding: 0;
     background: color('white');
+    @include u-radius-bottom('lg');
     @include u-shadow(3);
 
     width: calc(100% - 2rem);
@@ -507,14 +510,18 @@ $arrow-height: 24px;
     margin-top: 0;
 
     li {
-      margin: 0.5rem 0;
-      padding: 0.5rem 1.5rem;
       font-weight: normal;
       line-height: 1.5;
       cursor: pointer;
+      margin: 0;
 
       &:hover {
         color: color($theme-color-primary-darker);
+        background-color: color($theme-color-primary-lighter) !important;
+      }
+
+      &:last-of-type {
+        @include u-radius-bottom('lg');
       }
     }
 
@@ -523,10 +530,13 @@ $arrow-height: 24px;
       font-weight: normal;
       line-height: 1.5;
       text-decoration: none;
+      display: block;
+      padding: 1rem 1.5rem;
+      width: 100%;
+      height: 100%;
 
       &:hover {
         color: color($theme-color-primary-darker);
-        background: color($theme-color-primary-lighter) !important;
       }
     }
   }


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/900)

## What does this change?

Fixes the hover experience for example dropdown on the landing page.

There's also some tweaks in there to really nail down the detailing on element radii.

## Screenshots (for front-end PR):

<img width="584" alt="Screen Shot 2021-10-01 at 3 15 44 PM" src="https://user-images.githubusercontent.com/2553268/135676328-6e60f26c-ab6a-4b5e-a19c-da6f6d082e7d.png">

**Even works better on mobile!**

Previous experience:

<img width="451" alt="Screen Shot 2021-10-01 at 3 21 48 PM" src="https://user-images.githubusercontent.com/2553268/135676329-adf3bc81-12ad-4be9-b7b2-3ecac7172d95.png">

Proposed experience:

<img width="457" alt="Screen Shot 2021-10-01 at 3 22 27 PM" src="https://user-images.githubusercontent.com/2553268/135676330-1a236650-95c3-42e5-ae76-2d8941c51efb.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
