### PR TITLE
feat(styles): word-break utility class for text content

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
@@ -4,18 +4,17 @@
 
 <div class="crt-portal-card crt-description-card">
   <div class="crt-portal-card__content">
-    <h3 class="complaint-card-heading text-uppercase">Personal Description</h3>
-    <p>{{ description|linebreaks }}</p>
+    <h3 class="complaint-card-heading text-uppercase">Personal description</h3>
+    <div class="word-break">
+      {{ description|linebreaks }}
+    </div>
   </div>
   <div class="crt-portal-card__content">
-    <h3 class="complaint-card-heading text-uppercase">Report Language</h3>
+    <h3 class="complaint-card-heading text-uppercase">Report language</h3>
     <p>
-
       {% for language in languages %}
         {% if language.code == data.language %}This report submitted in: {{ language.name }}{% endif %}
       {% endfor %}
-
     </p>
-
   </div>
 </div>

--- a/crt_portal/static/sass/custom/utils.scss
+++ b/crt_portal/static/sass/custom/utils.scss
@@ -1,3 +1,11 @@
 .align-center {
   text-align: center;
 }
+
+// This utility class should be used on elements that may have extremely
+// long words that cause text to overflow outside of containers.
+.word-break {
+  word-wrap: break-word; // IE11 support
+  overflow-wrap: break-word;
+  hyphens: auto;
+}


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1097)

## What does this change?

Adds a new `.word-break` utility class that allows text content to break (with hyphens!) if it contains extremely long words or content.

While word breaking is [well-supported](https://caniuse.com/?search=overflow-wrap) across browsers, [hyphen support is a little less complete](https://caniuse.com/?search=hyphens).

This PR applies the utility class to the UI noted in the original issue, and it can be applied to other elements on an as-needed basis.

## Screenshots (for front-end PR):

<img width="483" alt="Screen Shot 2021-10-04 at 4 49 06 PM" src="https://user-images.githubusercontent.com/2553268/135922872-b7455c04-d183-4293-a8ce-8db270faf3f5.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
