### PR TITLE
fix(header): links should have underline on focus state

### DIFF
--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -120,12 +120,6 @@ $arrow-height: 24px;
   a {
     color: color('white');
     text-decoration: none;
-
-    @include at-media('desktop') {
-      &:hover {
-        border-bottom: 1px solid color('white');
-      }
-    }
   }
 
   .crt-menu--section {
@@ -194,8 +188,9 @@ $arrow-height: 24px;
       margin-bottom: 0.5rem;
       padding: 0.5rem 0 !important;
 
-      &:hover {
-        font-weight: bold !important;
+      &:hover,
+      &:focus {
+        border-bottom: 1px solid color('white');
       }
     }
   }
@@ -215,7 +210,6 @@ $arrow-height: 24px;
 
     a:hover {
       color: color('white');
-      border-bottom: 0;
     }
   }
 


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1108)

## What does this change?

Header links have an underline when hovered, but not when focused (the state when keyboards navigate to a link). This adds the underline on focus, and also removes the bold state, which would cause the navigation layout to jump around interacting with it.

## Screenshots (for front-end PR):

<img width="1182" alt="Screen Shot 2021-10-13 at 4 54 36 PM" src="https://user-images.githubusercontent.com/2553268/137211653-8870502d-7490-48e5-aa65-661a988b5518.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
