### PR TITLE
chore(ci): use latest zap image by disabling automatic framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,8 +161,8 @@ jobs:
       - run:
             name: Pull owasp zap docker image and run scan
             command: |
-              docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-weekly:w2021-09-20 zap-baseline.py \
-              -t https://crt-portal-django-dev.app.cloud.gov/report/ -c .circleci/zap.conf -z "-config rules.cookie.ignorelist=django_language"
+              docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-stable:latest zap-baseline.py \
+              -t https://crt-portal-django-dev.app.cloud.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
   owasp-scan-stage:
     machine:
       image: ubuntu-2004:202107-02
@@ -172,8 +172,8 @@ jobs:
       - run:
             name: Pull owasp zap docker image and run scan
             command: |
-              docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-weekly:w2021-09-20 zap-baseline.py \
-              -t https://crt-portal-django-stage.app.cloud.gov/report/ -c .circleci/zap.conf -z "-config rules.cookie.ignorelist=django_language"
+              docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-stable:latest zap-baseline.py \
+              -t https://crt-portal-django-stage.app.cloud.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
   owasp-scan-prod:
     machine:
       image: ubuntu-2004:202107-02
@@ -183,8 +183,8 @@ jobs:
       - run:
             name: Pull owasp zap docker image and run scan
             command: |
-              docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-weekly:w2021-09-20 zap-baseline.py \
-              -t https://civilrights.justice.gov/report/ -c .circleci/zap.conf -z "-config rules.cookie.ignorelist=django_language"
+              docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-stable:latest zap-baseline.py \
+              -t https://civilrights.justice.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
 # deployments
   deploy-dev:
     working_directory: ~/code


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1115)

## What does this change?

See the [linked issue comment](https://github.com/usdoj-crt/crt-portal-management/issues/1115#issuecomment-945987564) for more information.

I was able to test that this works by creating a branch named with the `release/*` pattern. Any branch named this way automatically triggers a zap test on CI. You can see the results here: https://app.circleci.com/pipelines/github/usdoj-crt/crt-portal/5010/workflows/002c2fe1-c97d-49aa-8295-990d977ad241/jobs/6895

We will still need to eventually investigate how to update our configuration to work with the automation framework since the legacy framework will eventually go away, but for now, this will allow us to continue using the most recent stable images instead of pinning to a specific older version.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
