### PR TITLE
Fix "Edit this page" buttons on report review step

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_data.html
+++ b/crt_portal/cts_forms/templates/forms/report_data.html
@@ -46,20 +46,20 @@
   <div class="crt-portal-card__content crt-portal-card__content--lg margin-bottom-3">
     {# buttons to the right form page based on data present #}
 
-    <div class="button--review">
-    {% if report.election_details %}
+    <div class="button--review" data-testid="edit-location">
+    {% if primary_complaint_key == "voting" %}
       {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.2 step_value=2 %}
 
-    {% elif report.public_or_private_employer %}
+    {% elif primary_complaint_key == "workplace" %}
       {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.2 step_value=3 %}
 
-    {% elif report.inside_correctional_facility %}
+    {% elif primary_complaint_key == "police" %}
       {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.2 step_value=4 %}
 
-    {% elif report.commercial_or_public_place %}
+    {% elif primary_complaint_key == "commercial_or_public" %}
       {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.2 step_value=5 %}
 
-    {% elif report.public_or_private_school %}
+    {% elif primary_complaint_key == "education" %}
       {% include "forms/snippets/preview_button.html" with step_name=ordered_step_names.2 step_value=6 %}
 
     {% else %}

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -85,10 +85,10 @@ def test_report_complete_and_valid_submission(page):
     next_step()
     assert page.title() == "Step 3: Location - Contact the Civil Rights Division | Department of Justice"
 
-    # Fill input[name="3-location_name"]
+    # Fill input[name="2-location_name"]
     page.fill("input[name='2-location_name']", "Test store")
 
-    # Fill input[name="3-location_city_town"]
+    # Fill input[name="2-location_city_town"]
     page.fill("input[name='2-location_city_town']", "Testing")
 
     # Select Alabama
@@ -121,6 +121,17 @@ def test_report_complete_and_valid_submission(page):
     # Go to step 7
     next_step()
     assert page.title() == "Step 7: Review - Contact the Civil Rights Division | Department of Justice"
+
+    # Click on "Edit this page" for Location
+    with page.expect_navigation():
+        page.evaluate("document.querySelector('[data-testid=\"edit-location\"] button').click()")
+    assert page.title() == "Step 3: Location - Contact the Civil Rights Division | Department of Justice"
+
+    # Navigate back to review page
+    next_step()
+    next_step()
+    next_step()
+    next_step()
 
     # Complete submission
     next_step()

--- a/crt_portal/cts_forms/views_public.py
+++ b/crt_portal/cts_forms/views_public.py
@@ -311,6 +311,9 @@ class CRTReportWizard(SessionWizardView):
                 })
         elif current_step_name == _('Review'):
             form_data_dict = self.get_all_cleaned_data()
+            # remember primary complaint key (it's overwritten in the next step)
+            # this variable improves some conditional display logic in templates
+            primary_complaint_key = form_data_dict['primary_complaint']
             # unpack values in data for display
             form_data_dict['primary_complaint'] = data_decode(
                 form_data_dict, PRIMARY_COMPLAINT_DICT, 'primary_complaint'
@@ -340,7 +343,8 @@ class CRTReportWizard(SessionWizardView):
             context.update({
                 'protected_classes': form_data_dict.pop('protected_class'),
                 'report': Report(**form_data_dict),
-                'question': form.question_text
+                'question': form.question_text,
+                'primary_complaint_key': primary_complaint_key
             })
 
         return context


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1121)

## What does this change?

With the hate crime/human trafficking step removed from the complaint form, the "Edit this page" buttons were not linking to the correct steps. This fixes that issue.

In addition, it was discovered that if a user selects a primary concern that doesn't have additional location information (like housing, voting, or "something else"), the review page could not conditionally display the correct "Edit this page" button for the Location section. This resulted in unexpected behavior when a user clicks that button in these situations. This has also been fixed.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
