### PR TITLE
fix(styles): regression causing red button text in modals

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/attachments.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/attachments.html
@@ -26,7 +26,7 @@
           <form id="complaint-view-remove-attachment-{{ attachment.pk }}" class="usa-form" method="post"
           action="{% url 'crt_forms:remove-report-attachment' attachment_id=attachment.pk %}">
             {% csrf_token %}
-            <button data-attachment-id="{{ attachment.pk }}" data-attachment-filename="{{ attachment.filename }}" class="usa-button light-button remove-attachment-button"> <img src="{% static "img/trash-2.svg" %}" class="icon" alt="remove attachment"></button>
+            <button data-attachment-id="{{ attachment.pk }}" data-attachment-filename="{{ attachment.filename }}" class="usa-button usa-button--outline remove-attachment-button"> <img src="{% static "img/trash-2.svg" %}" class="icon" alt="remove attachment"></button>
           </form>
         </td>
       </tr>

--- a/crt_portal/cts_forms/templates/forms/snippets/preview_button.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/preview_button.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% if not hide_edit_button %}
-  <button name="wizard_goto_step" type="submit" aria-label="edit {{ step_name }} step" value="{{ step_value }}" class="usa-button usa-button--outline light-button float-right padding-left-105 padding-right-105 padding-top-1 padding-bottom-1 text-normal">
+  <button name="wizard_goto_step" type="submit" aria-label="edit {{ step_name }} step" value="{{ step_value }}" class="usa-button usa-button--outline float-right padding-left-105 padding-right-105 padding-top-1 padding-bottom-1 text-normal">
     {% trans 'Edit this page' %}
   </button>
 {% endif %}

--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -227,7 +227,7 @@
                   {% endfor %}
                 </div>
                 <div hidden id="crt-landing--humantrafficking">
-                  <a class="usa-button usa-button--outline light-button" aria-label="{% trans "Were you forced to work against your will?" %} {% trans "Get help from the National Human Trafficking Hotline" %}" href=" https://humantraffickinghotline.org/">{% trans "Get help from the National Human Trafficking Hotline" %}
+                  <a class="usa-button usa-button--outline" aria-label="{% trans "Were you forced to work against your will?" %} {% trans "Get help from the National Human Trafficking Hotline" %}" href=" https://humantraffickinghotline.org/">{% trans "Get help from the National Human Trafficking Hotline" %}
                     <img src="{% static 'img/external_link.svg'%}" alt="external link" class="icon" />
                   </a>
                 </div>

--- a/crt_portal/cts_forms/templates/partials/attachment-removal-confirmation-modal.html
+++ b/crt_portal/cts_forms/templates/partials/attachment-removal-confirmation-modal.html
@@ -17,7 +17,7 @@
         <div class="modal-footer">
           <ul class="usa-button-group">
             <li class="usa-button-group__item">
-              <a id="attachment-removal--no" href="#" class="usa-button button--cancel usa-button--outline light-button">No</a>
+              <a id="attachment-removal--no" href="#" class="usa-button usa-button--outline">No</a>
             </li>
             <li class="usa-button-group__item">
               <a id="attachment-removal--yes" href="#" class="usa-button button--continue">Yes</a>

--- a/crt_portal/cts_forms/templates/partials/contact-info-confirmation-modal.html
+++ b/crt_portal/cts_forms/templates/partials/contact-info-confirmation-modal.html
@@ -15,7 +15,7 @@
         <div class="modal-footer">
           <ul class="usa-button-group">
             <li class="usa-button-group__item">
-              <a id="external-link--continue" href="#" class="usa-button usa-button--outline button--cancel light-button">{% trans "No, I don't want to provide it" %}</a>
+              <a id="external-link--continue" href="#" class="usa-button usa-button--outline">{% trans "No, I don't want to provide it" %}</a>
             </li>
             <li class="usa-button-group__item">
               <a id="external-link--cancel" href="#" class="usa-button button--continue">{% trans "Yes, I'd like to add it" %}</a>

--- a/crt_portal/cts_forms/templates/partials/redirect-modal.html
+++ b/crt_portal/cts_forms/templates/partials/redirect-modal.html
@@ -20,7 +20,7 @@
         <div class="modal-footer">
           <ul class="usa-button-group">
             <li class="usa-button-group__item">
-              <a id="external-link--cancel" href="#" class="usa-button usa-button--outline button--cancel light-button">{% trans "Back" %}</a>
+              <a id="external-link--cancel" href="#" class="usa-button usa-button--outline">{% trans "Back" %}</a>
             </li>
             <li class="usa-button-group__item">
               <a id="external-link--continue" href="#" class="usa-button button--continue">{% trans "Continue" %}</a>

--- a/crt_portal/static/sass/custom/buttons.scss
+++ b/crt_portal/static/sass/custom/buttons.scss
@@ -3,6 +3,17 @@ button,
   background-color: color($theme-color-primary-darker);
 }
 
+.usa-button--outline,
+.usa-button--outline:visited {
+  background-color: transparent;
+  color: color($theme-color-primary-darker);
+
+  &:hover {
+    background-color: transparent !important;
+    color: color($theme-link-hover-color) !important;
+  }
+}
+
 /* Override above style to make sure unstyled buttons don't pick up background-color */
 .usa-button--unstyled {
   background-color: transparent !important;
@@ -57,7 +68,7 @@ button,
   }
 }
 
-.button--continue, button#login {
+.button--continue {
   color: color('white') !important;
 }
 

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -152,20 +152,13 @@ form#cts-forms-profile {
     box-shadow: 0 0 0 2px color($theme-color-primary-darker), inset 0 0 0 2px color('white');
   }
   .usa-button {
+    // TODO: remove this level of specificity, which can override alternate button styles
     &:hover {
       background-color: color($theme-link-hover-color);
     }
 
     @media (min-width: 30em) {
       margin-top: 0;
-    }
-  }
-
-  .light-button {
-    color: color($theme-color-primary-darker);
-    background-color: transparent;
-    &:hover {
-      background-color: color('white');
     }
   }
 

--- a/crt_portal/static/sass/custom/typography.scss
+++ b/crt_portal/static/sass/custom/typography.scss
@@ -71,9 +71,10 @@ li {
 a,
 a:visited {
   color: color($theme-link-color);
-  &:hover {
-    color: color($theme-link-hover-color);
-  }
+}
+
+a:hover {
+  color: color($theme-link-hover-color);
 }
 
 .text__reverse {

--- a/crt_portal/templates/registration/login.html
+++ b/crt_portal/templates/registration/login.html
@@ -8,7 +8,7 @@
       <form label="log in form" method="post">
         {% csrf_token %}
         {{ form.as_p }}
-        <button label="login" type="submit" id="login">Login</button>
+        <button label="login" type="submit" id="login" class="usa-button">Login</button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1118)

## What does this change?

The red button in modals (see linked issue above) was caused by a change in HTML structure (commit https://github.com/usdoj-crt/crt-portal/commit/382d53e985afb23475c3169db21ffa355abfd9b5) that moved modals outside of the form element, in an effort to standardize where modals are loaded in the templates, as well as to prevent some overly-specific form styling from clashing with modal styles. Form styling was used to override the red color, which is provided by us on the `.button--cancel` selector. (In other words, the red color was not provided by the USWDS.)

It seems that the intent is to use the red color on cancel buttons where intake specialists can manually edit a report:

<img width="611" alt="Screen Shot 2021-10-20 at 6 41 15 PM" src="https://user-images.githubusercontent.com/2553268/138499840-d2b58114-3405-4075-ab4d-f65536771c21.png">

To fix this, we should be able to just remove `.button--cancel` from the modals. However, given the cascading and interlaced nature of CSS, there are a lot of interdependencies that mean no solution is "simple." The simplest solution would be to write one more CSS override, but this just compounds the problem in the long term. The proper solution involves taking inventory of the different types of buttons we use and creating a proper library from them, but this would create a much bigger intervention than is strictly required to fix the original bug. My goal here is to provide enough-but-necessary step toward CSS that gets us a bug fix _and_ makes it easier to refactor things in the future.

With that in mind, here are a rundown of changes:

- Remove the `.button--cancel` class from modals, but leave them on the intake editing side.
- Remove the `.light-button` class from our stylesheets, in favor of relying on the framework-supplied `.usa-button--outline` class to achieve the same effect.
- Untangle a CSS specificity issue with the `a:hover:visited` selector that caused some button styling to be overridden unexpectedly
- (bonus, tiny, easy change): Remove the need for custom CSS to be applied to the login button in dev/local environments.

## Screenshots (for front-end PR):

I didn't take a screenshot, but imagine a modal without red buttons on it.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
