### PR TITLE
fix(header): links no longer become bold on hover

### DIFF
--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -120,12 +120,6 @@ $arrow-height: 24px;
   a {
     color: color('white');
     text-decoration: none;
-
-    @include at-media('desktop') {
-      &:hover {
-        border-bottom: 1px solid color('white');
-      }
-    }
   }
 
   .crt-menu--section {
@@ -195,7 +189,7 @@ $arrow-height: 24px;
       padding: 0.5rem 0 !important;
 
       &:hover {
-        font-weight: bold !important;
+        border-bottom: 2px solid color('white');
       }
     }
   }
@@ -215,7 +209,6 @@ $arrow-height: 24px;
 
     a:hover {
       color: color('white');
-      border-bottom: 0;
     }
   }
 


### PR DESCRIPTION
## What does this change?

This is work that was originally done as part of https://github.com/usdoj-crt/crt-portal-management/issues/1108, which updated the styling for the header links. While focus state is no longer a concern, at the time I expressed that links becoming bold on hover is visually jarring. Layout elements should not "shift" in this way on a hover interaction.

The proposed change keeps text the same weight, but the underline is slightly thicker to compensate. (This is similar to current behavior on https://beta.ada.gov/, which keeps text the same weight, but the underline is even thicker.)

## Screenshots (for front-end PR):

![Oct-22-2021 15-58-19](https://user-images.githubusercontent.com/2553268/138516230-6c37df36-3555-4663-9617-028d7f3c8727.gif)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
