### PR TITLE
feat(email): add webhook admin page

### DIFF
--- a/crt_portal/cts_forms/templates/email.html
+++ b/crt_portal/cts_forms/templates/email.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tms admin view</title>
+  <style>
+    .json {
+      white-space: pre;
+      font-family: "Courier New", monospace;
+      padding: 1em;
+      background-color: whitesmoke;
+      width: 90%;
+    }
+  </style>
+</head>
+<body>
+  <h1>tms admin view</h1>
+  <p class="json">{{ data }}</p>
+</body>
+</html>

--- a/crt_portal/tms/urls.py
+++ b/crt_portal/tms/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from .views import UnsubscribeView, WebhookView
+from .views import UnsubscribeView, WebhookView, AdminView
 
 app_name = 'tms'
 
 urlpatterns = [
     path('unsubscribe/<uuid:pk>/', UnsubscribeView.as_view(), name='email-unsubscribe'),
     path('webhook/', WebhookView.as_view(), name='tms-webhook'),
+    path('admin/', AdminView.as_view(), name='tms-admin'),
 ]


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1119)

## What does this change?

Adds a view-only page at `/email/admin` that displays the current status of webhooks set at TMS.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
