### PR TITLE
fix(header): long agency name text breaks with readable line height

### DIFF
--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -125,7 +125,7 @@
                    alt=""
                    height="64" />
             </div>
-            <div class="grid-col-auto">
+            <div class="grid-col-auto display-flex flex-column flex-justify-center">
               <p class="usa-footer__logo-subheading">
                 {% trans "U.S. Department of Justice" %}
               </p>

--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -12,7 +12,7 @@
             <div class="grid-col-auto">
               <img src="{% static 'img/doj-logo-footer.png' %}" alt="" />
             </div>
-            <div class="grid-col-auto">
+            <div class="grid-col-auto display-flex flex-column flex-justify-center">
               <p class="crt-landing--logo_subheading">
                 {% trans "U.S. Department of Justice" %}
               </p>

--- a/crt_portal/static/sass/custom/footer.scss
+++ b/crt_portal/static/sass/custom/footer.scss
@@ -35,12 +35,22 @@ footer {
 .usa-footer__logo-section {
   margin-top: 1.25rem;
   margin-bottom: 2.5rem;
+
+  img {
+    max-width: initial;
+  }
+
+  /* Prevent agency heading from wrapping to below the logo */
+  .grid-row {
+    flex-wrap: nowrap;
+  }
 }
 
 .usa-footer__logo-heading {
   @include text--heading__large();
   @include u-font-family('serif');
   font-weight: bold;
+  margin: 0;
 }
 
 .usa-footer__logo-subheading {

--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -124,6 +124,7 @@ $arrow-height: 24px;
 
   .crt-menu--section {
     margin-top: 0.1rem;
+    margin-left: 1rem;
     padding-right: 0;
 
     .language-selection {
@@ -196,9 +197,12 @@ $arrow-height: 24px;
 
   .crt-landing--logo_section {
     img {
-      height: 60px;
-      @include at-media-max(mobile-lg) {
-        height: 45px;
+      height: 45px;
+      width: 45px;
+      max-width: initial;
+      @include at-media(mobile-lg) {
+        height: 60px;
+        width: 60px;
       }
     }
 
@@ -210,27 +214,31 @@ $arrow-height: 24px;
     a:hover {
       color: color('white');
     }
+
+    /* Prevent agency heading from wrapping to below the logo */
+    .grid-row {
+      flex-wrap: nowrap;
+    }
   }
 
   .crt-landing--logo_subheading {
     @extend .usa-footer__logo-subheading;
     font-size: $theme-text-font-size-xs;
-    line-height: 2.25;
-    margin-top: 0.25rem;
-    @include at-media-max(mobile-lg) {
-      @include text--body-copy__xsmall();
+    line-height: 1.2;
+
+    @include at-media(mobile-lg) {
+      line-height: 1.3;
     }
   }
 
   .crt-landing--logo_heading {
     @extend .usa-footer__logo-heading;
-    font-size: $theme-heading-font-size-md;
-    line-height: 0.5;
-    margin-bottom: 1rem;
-    margin-top: .2rem;
-    @include at-media-max(mobile-lg) {
-      font-size: $theme-heading-font-size-md-mobile;
-      margin-top: 0.5rem;
+    font-size: $theme-heading-font-size-md-mobile;
+    line-height: 1.2;
+
+    @include at-media(mobile-lg) {
+      font-size: $theme-heading-font-size-md;
+      line-height: 1.3;
     }
   }
 }


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1127)

## What does this change?

This PR adjusts the styling of the header logo/agency name so that long text is still readable when it breaks to a new line. This is primarily only visible on the Tagalog translation.

A few other improvements:

- Agency name no longer wraps to below the logo image. (This change has been ported to the footer, as well.)
- Provide buffer on the menu button on mobile so that it doesn't crowd logo text.
- Styles are reconfigured to be mobile-first.

## Screenshots (for front-end PR):

![Screenshot 2021-10-27 at 12-09-00 Makipag-ugnay sa Dibisyon sa mga Karapatang Sibil Kagawaran ng Katarungan](https://user-images.githubusercontent.com/2553268/139142691-412c9fe3-8af4-4a12-91bc-bd445774b0ba.png)


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
