### PR TITLE
Add filter for unassigned reports

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -111,7 +111,10 @@ def report_filter(querydict):
                 kwargs['protected_class__value__in'] = reasons
             elif filter_options[field] == 'foreign_key':
                 # assumes assigned_to but could add logic for other foreign keys in the future
-                kwargs['assigned_to__username__in'] = querydict.getlist(field)
+                if querydict.getlist(field)[0] == '(unassigned)':
+                    kwargs['assigned_to__isnull'] = True
+                else:
+                    kwargs['assigned_to__username__in'] = querydict.getlist(field)
             elif filter_options[field] == 'eq':
                 kwargs[field] = querydict.getlist(field)[0]
             elif filter_options[field] == '__gte':

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -929,6 +929,25 @@ def reported_reason_proform():
 
 
 class Filters(ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        ModelForm.__init__(self, *args, **kwargs)
+        # Putting this field in __init__ allows the User QuerySet to be evaluated
+        # (otherwise it breaks when this module is read during a migration)
+        self.fields['assigned_to'] = ChoiceField(
+            required=False,
+            choices=[
+                ('', ''),  # Default choice: empty
+                ('-1', '(unassigned)'),  # Custom choice: unassigned report.
+                # Appends a queryset of active users, converted to a list of tuples
+            ] + list(User.objects.filter(is_active=True).values_list('pk', 'username').order_by('username')),
+            label=_("Assigned to"),  # This is overriden in templates as "Assigned"
+            widget=Select(attrs={
+                'name': 'assigned_to',
+                'class': 'usa-input usa-select',
+            })
+        )
+
     status = MultipleChoiceField(
         initial=(('new', 'New'), ('open', 'Open')),
         required=False,
@@ -964,19 +983,6 @@ class Filters(ModelForm):
                 'aria-label': 'Complaint Summary'
             },
         ),
-    )
-    assigned_to = ChoiceField(
-        required=False,
-        choices=[
-            ('', ''),  # Default choice: empty
-            ('-1', '(unassigned)'),  # Custom choice: unassigned report.
-            # Appends a queryset of active users, converted to a list of tuples
-        ] + list(User.objects.filter(is_active=True).values_list('username', 'username').order_by('username')),
-        label=_("Assigned to"),  # This is overriden in templates as "Assigned"
-        widget=Select(attrs={
-            'name': 'assigned_to',
-            'class': 'usa-input usa-select',
-        })
     )
     create_date_start = DateField(
         required=False,

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -965,14 +965,17 @@ class Filters(ModelForm):
             },
         ),
     )
-    assigned_to = ModelChoiceField(
+    assigned_to = ChoiceField(
         required=False,
-        queryset=User.objects.filter(is_active=True).order_by('username'),
+        choices=[
+            ('', ''),  # Default choice: empty
+            ('-1', '(unassigned)'),  # Custom choice: unassigned report.
+            # Appends a queryset of active users, converted to a list of tuples
+        ] + list(User.objects.filter(is_active=True).values_list('username', 'username').order_by('username')),
         label=_("Assigned to"),  # This is overriden in templates as "Assigned"
-        to_field_name='username',
         widget=Select(attrs={
             'name': 'assigned_to',
-            'class': 'usa-input'
+            'class': 'usa-input usa-select',
         })
     )
     create_date_start = DateField(

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_actions.html
@@ -61,9 +61,6 @@
           <label for="id_assigned_to" class="intake-label">
             {{ bulk_actions_form.assigned_to.label }}
           </label>
-          <label for="id_assigned_to-select">
-            <span class="usa-sr-only">assignee</span>
-          </label>
           {{ bulk_actions_form.assigned_to }}
         </div>
         <div class="margin-bottom-2 crt-textarea">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/assignee.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/assignee.html
@@ -4,11 +4,10 @@
 {% block label %}Assignee{% endblock %}
 {% block id %}assigned_to{% endblock %}
 {% block content %}
-   <label for="id_assigned_to">
+  <label for="id_assigned_to">
     <span class="usa-sr-only">assignee</span>
-   </label>
-   <label for="id_assigned_to-select">
-    <span class="usa-sr-only">assignee</span>
-   </label>
-   {{ form.assigned_to }}
+  </label>
+  <div class="usa-combo-box" data-placeholder="Select one" data-default-value="">
+    {{ form.assigned_to }}
+  </div>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -38,12 +38,4 @@
 <script src="{% static 'js/complaint_quick_view.min.js' %}"></script>
 <script src="{% static 'js/complaint_view_filters.min.js' %}"></script>
 <script src="{% static 'js/complaint_actions.min.js' %}"></script>
-<script type="text/javascript" src="{% static 'vendor/aria-autocomplete-1.2.3.min.js' %}"></script>
-<script nonce="{{request.csp_nonce}}">
- var select = document.getElementById('id_assigned_to');
- AriaAutocomplete(select, {
-   minLength: 0,
-   maxResults: 5
- });
-</script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -44,9 +44,6 @@
       <label for="id_assigned_to" class="intake-label">
         {{ actions.fields.assigned_to.label }}
       </label>
-      <label for="id_assigned_to-select">
-        <span class="usa-sr-only">assignee</span>
-      </label>
       {{ actions.assigned_to }}
     </div>
     <div class="margin-bottom-2 crt-checkbox">

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -7,7 +7,7 @@ import urllib.parse
 
 from django.contrib.auth.models import User
 from django.http import QueryDict
-from django.test import SimpleTestCase, TestCase
+from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 from django.utils.html import escape
@@ -978,8 +978,32 @@ class FiltersFormTests(TestCase):
         for row in response.context['data_dict']:
             self.assertTrue(row['report'].referred)
 
+    def test_assigned_report_filter(self):
+        ReportFactory.create_batch(3, assigned_to=self.user)
 
-class SimpleFilterFormTests(SimpleTestCase):
+        base_url = reverse('crt_forms:crt-forms-index')
+        url = f'{base_url}?assigned_to=DELETE_USER'
+
+        response = self.client.get(url, {})
+        self.assertEquals(response.status_code, 200)
+
+        self.assertEquals(len(response.context['data_dict']), 3)
+
+        for row in response.context['data_dict']:
+            self.assertEqual(row['report'].assigned_to, self.user)
+
+    def test_unassigned_report_filter(self):
+        base_url = reverse('crt_forms:crt-forms-index')
+        url = f'{base_url}?assigned_to=(unassigned)'
+
+        response = self.client.get(url, {})
+        self.assertEquals(response.status_code, 200)
+
+        for row in response.context['data_dict']:
+            self.assertEqual(row['report'].assigned_to, None)
+
+
+class SimpleFilterFormTests(TestCase):
 
     def test_get_sections_returns_only_valid_choices(self):
         """

--- a/crt_portal/static/sass/custom/combo-box.scss
+++ b/crt_portal/static/sass/custom/combo-box.scss
@@ -1,0 +1,28 @@
+.usa-combo-box input {
+  border-radius: 3px;
+}
+
+.usa-combo-box__list {
+  border-radius: 3px;
+}
+
+.usa-combo-box__toggle-list {
+  background-image: url(../../img/intake-icons/ic_chevron-down.svg), linear-gradient(transparent, transparent);;
+  background-size: 15px;
+  background-position: center center;
+
+  /* Override a very aggressive button width from .intake-content */
+  width: auto !important;
+}
+
+/* Override a very aggressive li margin from .usa-form */
+.usa-combo-box__list-option {
+  margin-top: 0 !important;
+}
+
+.usa-combo-box__clear-input {
+  background-image: url(../../img/close-blue-60-alt.svg), linear-gradient(transparent, transparent);
+
+  /* Override a very aggressive button width from .intake-content */
+  width: auto !important;
+}

--- a/crt_portal/static/sass/styles.scss
+++ b/crt_portal/static/sass/styles.scss
@@ -35,6 +35,7 @@
 @import "custom/alerts";
 @import "custom/banner";
 @import "custom/buttons";
+@import "custom/combo-box";
 @import "custom/footer";
 @import "custom/form";
 @import "custom/header";


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1116)

## What does this change?

Adds an "(unassigned)" option to the Assignee filter. The "(unassigned)" option is visible at the top of the list and can be reached via typeahead. If "(unassigned)" is selected, and the "Apply filters" button is clicked, reports without assignees will be shown in the resulting table.

Furthermore, I took the opportunity to replace the underlying third-party autocomplete component with the USWDS [combo box component](https://designsystem.digital.gov/components/combo-box/), which was first introduced in [v2.7.0](https://github.com/uswds/uswds/releases/tag/v2.7.0). Note that this only occurs here in the Assignee filter and not elsewhere that the assignee dropdown occurs; this can be resolved in follow up tickets, such as the one that addresses https://github.com/usdoj-crt/crt-portal-management/issues/739. The eventual, preferred outcome is to fully replace the third-party autocomplete library. Using the USWDS's built-in component is advantageous for a number of reasons:

1. It unifies the appearance of the typeahead dropdown with the rest of the rest of the app's UI.
2. It reduces the loading time needed, which currently makes an additional request for the third-party component.
3. We use a component that is developed in accordance with federal web accessibility guidance.

## Screenshots (for front-end PR):

<img width="565" alt="Screen Shot 2021-11-03 at 10 14 31 AM" src="https://user-images.githubusercontent.com/2553268/140141275-ba8c9326-3f0f-4c9a-81f1-49278e447ce3.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
