### PR TITLE
Add check for object truthiness in filter

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -156,7 +156,7 @@ def dashboard_filter(querydict):
                     continue
     actions = Action.objects.filter(**kwargs)
     for action in actions:
-        if selected_actor == action.actor.username:
+        if hasattr(action.actor, 'username') and selected_actor == action.actor.username:
             selected_actions.append(action)
     return filters, selected_actions
 


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

We are currently getting a 500 error when going to the dashboard because of some activity logs that do not have an actor with a username in them.  Although there does not seem to be a way to do this, we think there might be some bad data in the dev database.  This change allows us to ignore this bad data. 

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
