### PR TITLE
Unassign from report actions (first pass)

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1214,15 +1214,18 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
     assigned_to = ModelChoiceField(
         queryset=User.objects.filter(is_active=True).order_by('username'),
         # crt view only
-        label="Assigned to",
-        required=False
+        label='Assigned to',
+        required=False,
+        widget=Select(attrs={
+            'class': 'usa-input usa-select',
+        })
     )
     referred = BooleanField(
+        label='Secondary review',
         required=False,
-        label='Secondary Review',
         widget=CheckboxInput(attrs={
             'class': 'usa-checkbox__input',
-            'aria-label': 'Secondary Review',
+            'aria-label': 'Secondary review',
         })
     )
 
@@ -1272,7 +1275,6 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
             choices=_add_empty_choice(DISTRICT_CHOICES, default_string=''),
             required=False
         )
-        self.fields['assigned_to'].widget.label = 'Assigned to'
 
     def get_actions(self):
         """

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -150,10 +150,12 @@ PROTECTED_MODEL_CHOICES = tuple(
 PROTECTED_CLASS_ERROR = _('Please make a selection to continue. If none of these apply to your situation, please select “None of these apply to me” or "Other reason"and explain.')
 
 # CRT views only
+NEW_STATUS = 'new'
+OPEN_STATUS = 'open'
 CLOSED_STATUS = 'closed'
 STATUS_CHOICES = (
-    ('new', 'New'),
-    ('open', 'Open'),
+    (NEW_STATUS, 'New'),
+    (OPEN_STATUS, 'Open'),
     (CLOSED_STATUS, 'Closed'),
 )
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/assignee.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/assignee.html
@@ -7,7 +7,7 @@
   <label for="id_assigned_to">
     <span class="usa-sr-only">assignee</span>
   </label>
-  <div class="usa-combo-box" data-placeholder="Select one" data-default-value="">
+  <div class="usa-combo-box" data-placeholder="Select one" data-default-value="{{ form.assigned_to.value }}">
     {{ form.assigned_to }}
   </div>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -44,7 +44,7 @@
       <label for="id_assigned_to" class="intake-label">
         {{ actions.fields.assigned_to.label }}
       </label>
-      <div class="usa-combo-box" data-default-value="{{ actions.assigned_to.value }}">
+      <div class="usa-combo-box" data-placeholder="(nobody)" data-default-value="{{ actions.assigned_to.value }}">
         {{ actions.assigned_to }}
       </div>
     </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -44,7 +44,9 @@
       <label for="id_assigned_to" class="intake-label">
         {{ actions.fields.assigned_to.label }}
       </label>
-      {{ actions.assigned_to }}
+      <div class="usa-combo-box" data-default-value="{{ actions.assigned_to.value }}">
+        {{ actions.assigned_to }}
+      </div>
     </div>
     <div class="margin-bottom-2 crt-checkbox">
       <label class="intake-label">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -97,12 +97,4 @@
 <script src="{% static 'js/print_report.min.js' %}"></script>
 <script src="{% static 'js/routing_guide.min.js' %}"></script>
 <script src="{% static 'js/attachments.min.js' %}"></script>
-<script type="text/javascript" src="{% static 'vendor/aria-autocomplete-1.2.3.min.js' %}"></script>
-<script nonce="{{request.csp_nonce}}">
- var select = document.getElementById('id_assigned_to');
- AriaAutocomplete(select, {
-   minLength: 0,
-   maxResults: 5
- });
-</script>
 {%endblock%}

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -532,8 +532,15 @@ form#cts-forms-profile {
       }
     }
 
-    select {
+    select,
+    .usa-combo-box {
       flex-basis: 60%; // label flex-basis is 40% for total of 100%
+    }
+
+    select,
+    .usa-combo-box input,
+    .crt-checkbox__label {
+      margin-top: 0; // Fixes vertical spacing issues
     }
   }
 


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/739)

## What does this change?

We replace the old autocomplete widget in the "assign to" action with the new [combo box](https://designsystem.digital.gov/components/combo-box/) component from USWDS. There is some rationale about this move in [this previous task where the report filters can now filter for unassigned reports](https://github.com/usdoj-crt/crt-portal/pull/1027).

The new component has a "clear this value" button in its UI that the previous autocomplete widget did not have. The "clear this value" button only appears when the combo box value has a selected value. For a user to unassign a report, they only need to clear this value; this was [previously verified to be manually achievable by pressing backspace or deleting the contents of the input box](https://github.com/usdoj-crt/crt-portal-management/issues/739). However, this interaction was unclear to end users, hence there was an ask for a way to unassign the report in the UI. With a "clear this value" button, this need can be addressed using UI we already have. (See screenshots section below for a brief animation of this behavior.)

The alternative proposal (not implemented here) is to include a "unassign" option in the dropdown itself. This was how we implemented the unassign filter for https://github.com/usdoj-crt/crt-portal-management/issues/1116 (#1027), and I briefly explored doing the same in this case. However, the solution was less simple:

- Clicking the dropdown to select "unassign" required multiple clicks as opposed to clicking on the "clear this" X once. (If we determine later that users still struggle to understand the X, and prefer selecting something from a dropdown, then the multiple clicks may still be justified.)
- We have the "clear this" UI for free.
- Implementing a special option for "unassign" requires more work (for future note, though, don't re-implement the same widget used in the filter, since the filter needs to distinguish between "empty" and "unassigned," for this UI, "empty" == "unassign".)

Furthermore, I added tests in this PR and fixed a small issue that prevented the entire report action test suite from running in the past.

## Screenshots (for front-end PR):

![Nov-08-2021 12-44-42](https://user-images.githubusercontent.com/2553268/140791847-2d0e1bb3-ca4b-4ecd-a406-00922f5d8b8c.gif)

## Checklist:


### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
