### PR TITLE
fix(combo-box): patch for z-index conflict

### DIFF
--- a/crt_portal/static/sass/custom/combo-box.scss
+++ b/crt_portal/static/sass/custom/combo-box.scss
@@ -1,3 +1,9 @@
+.usa-combo-box {
+  // Create a new stacking context to hold generated combo box elements
+  // that have its own z-index
+  z-index: 1;
+}
+
 .usa-combo-box input {
   border-radius: 3px;
 }


### PR DESCRIPTION
## What does this change?

Bug fix (reported by @billyhunt) for an issue with the combo box component where its child UI elements can appear on top of other site UI, e.g. in this case where the "Assigned to" select UI shows above the "Contact complainant" modal.

<img width="497" alt="Screen Shot 2021-11-10 at 11 42 07 AM" src="https://user-images.githubusercontent.com/2553268/141155346-b6ac1137-2fc9-4bca-8875-1e05bec3e0a7.png">

The fix is to apply a z-index to the parent `.usa--combo-box` element which creates a local "stacking context" that keeps the child elements from leaking into the global stacking context.

## Screenshots (for front-end PR):

Should look like this, post-fix.

<img width="481" alt="Screen Shot 2021-11-10 at 11 42 14 AM" src="https://user-images.githubusercontent.com/2553268/141155541-dedab2c6-adc2-4adb-8dc6-87b970574c70.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
