### PR TITLE
Follow up improvements to unassigned reports action

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -119,7 +119,7 @@ def report_filter(querydict):
                 kwargs['protected_class__value__in'] = reasons
             elif filter_options[field] == 'foreign_key':
                 # assumes assigned_to but could add logic for other foreign keys in the future
-                if querydict.getlist(field)[0] == '(unassigned)':
+                if querydict.getlist(field)[0] == '(none)':
                     kwargs['assigned_to__isnull'] = True
                 else:
                     kwargs['assigned_to__username__in'] = querydict.getlist(field)

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -938,7 +938,7 @@ class Filters(ModelForm):
             required=False,
             choices=[
                 ('', ''),  # Default choice: empty
-                ('-1', '(unassigned)'),  # Custom choice: unassigned report.
+                ('-1', '(none)'),  # Custom choice: unassigned report.
                 # Appends a queryset of active users, converted to a list of tuples
             ] + list(User.objects.filter(is_active=True).values_list('pk', 'username').order_by('username')),
             label=_("Assigned to"),  # This is overriden in templates as "Assigned"

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -44,7 +44,7 @@
       <label for="id_assigned_to" class="intake-label">
         {{ actions.fields.assigned_to.label }}
       </label>
-      <div class="usa-combo-box" data-placeholder="(nobody)" data-default-value="{{ actions.assigned_to.value }}">
+      <div class="usa-combo-box" data-placeholder="(none)" data-default-value="{{ actions.assigned_to.value }}">
         {{ actions.assigned_to }}
       </div>
     </div>

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -1036,7 +1036,7 @@ class FiltersFormTests(TestCase):
 
     def test_unassigned_report_filter(self):
         base_url = reverse('crt_forms:crt-forms-index')
-        url = f'{base_url}?assigned_to=(unassigned)'
+        url = f'{base_url}?assigned_to=(none)'
 
         response = self.client.get(url, {})
         self.assertEquals(response.status_code, 200)

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -542,6 +542,11 @@ form#cts-forms-profile {
     .crt-checkbox__label {
       margin-top: 0; // Fixes vertical spacing issues
     }
+
+    // Force combo box inputs to use bold text to match other UI
+    .usa-combo-box input {
+      font-weight: bold;
+    }
   }
 
   .crt-textarea {

--- a/crt_portal/static/sass/custom/modal.scss
+++ b/crt_portal/static/sass/custom/modal.scss
@@ -20,7 +20,7 @@ body.is-modal {
   top: 0;
   width: 100%;
   height: 100%;
-  z-index: 10;
+  z-index: 10000;
   overflow-y: auto; // a11y: allow scroll for zoomed in modal
 
   @media print {


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1140)

## What does this change?

- In the "assign to" dropdown on the report view, the text "(nobody)" has been updated to "(none)" to match the text output in the activity log.
- The combo box UI now uses bold text to match other inputs in the actions widget.
- A fix to the modal (superceding #1136) to ensure that its z-index is higher than UI elements from USWDS.
- The "assigned to" filter on the view-all page has updated "(unassigned)" to "(none)" for consistency.

## Screenshots (for front-end PR):

<img width="467" alt="Screen Shot 2021-11-12 at 3 29 32 PM" src="https://user-images.githubusercontent.com/2553268/141530749-d3dae6a3-42d5-4b8e-ad80-6c2762d0ed0b.png">

<img width="311" alt="Screen Shot 2021-11-12 at 3 30 01 PM" src="https://user-images.githubusercontent.com/2553268/141530757-954dbc15-fdfd-4c81-ad72-d2ea277547c1.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
