### PR TITLE
fix(form/view): autoresponder activity missing in print view

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/activities.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/activities.html
@@ -9,6 +9,9 @@
     {% for action in activity %}
       {% include 'forms/complaint_view/show/activity_stream_item.html' with activity=action %}
     {% endfor %}
+    {% if autoresponse_email %}
+      {% include 'forms/complaint_view/show/activity_stream_autoresponse.html' %}
+    {% endif %}
     {% include 'forms/complaint_view/show/activity_stream_created.html' %}
   </ul>
 


### PR DESCRIPTION
## What does this change?

In https://github.com/usdoj-crt/crt-portal/pull/980 we added a feature to display autoresponse email activity in the front-end view of the activity stream.

This activity was missing in the print view, since I didn't realize at the time that the print view was controlled by a different template. This PR adds the same autoresponse activity to the print view of the activity log.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
