### PR TITLE
Spike: add a link to govdelivery email status API within admin

### DIFF
--- a/crt_portal/tms/admin.py
+++ b/crt_portal/tms/admin.py
@@ -1,14 +1,22 @@
 from cts_forms.admin import ReadOnlyModelAdmin
 from django.contrib import admin
+from django.utils.html import format_html
+from django.urls import reverse
 
 from .models import TMSEmail
 
 
 class TMSEmailAdmin(ReadOnlyModelAdmin):
     search_fields = ['recipient', 'report__public_id', 'error_message']
-    list_display = ('tms_id', 'recipient', 'report', 'status', 'created_at', 'completed_at', 'purpose')
+    list_display = ('tms_id', 'tms_detail_url', 'recipient', 'report', 'status', 'created_at', 'completed_at', 'purpose')
     date_hierarchy = 'created_at'
     list_filter = ('status', 'created_at', 'purpose')
+    ordering = ['-created_at']
+
+    def tms_detail_url(self, obj):
+        return format_html('<a href="%s">View status</a>' % (reverse('tms:tms-admin-message', kwargs={"tms_id": obj.tms_id})))
+
+    tms_detail_url.short_description = 'TMS details'
 
 
 admin.site.register(TMSEmail, TMSEmailAdmin)

--- a/crt_portal/tms/urls.py
+++ b/crt_portal/tms/urls.py
@@ -1,11 +1,13 @@
 from django.urls import path
 
-from .views import UnsubscribeView, WebhookView, AdminView
+from .views import UnsubscribeView, WebhookView, AdminWebhookView, AdminMessageView
 
 app_name = 'tms'
 
 urlpatterns = [
     path('unsubscribe/<uuid:pk>/', UnsubscribeView.as_view(), name='email-unsubscribe'),
     path('webhook/', WebhookView.as_view(), name='tms-webhook'),
-    path('admin/', AdminView.as_view(), name='tms-admin'),
+    path('admin/', AdminWebhookView.as_view(), name='tms-admin-webhook'),
+    path('admin/webhooks/', AdminWebhookView.as_view(), name='tms-admin-webhook'),
+    path('admin/messages/<int:tms_id>/', AdminMessageView.as_view(), name='tms-admin-message'),
 ]

--- a/crt_portal/tms/views.py
+++ b/crt_portal/tms/views.py
@@ -100,7 +100,7 @@ class WebhookView(View):
             return HttpResponse(status=400)
 
 
-class AdminView(LoginRequiredMixin, View):
+class AdminWebhookView(LoginRequiredMixin, View):
     """View webhook settings at TMS"""
 
     http_method_names = ['get']
@@ -111,6 +111,25 @@ class AdminView(LoginRequiredMixin, View):
         try:
             connection = TMSClient()
             response = connection.get(target=self.WEBHOOK_ENDPOINT)
+            parsed = json.loads(response.content)
+            return render(request, 'email.html', {'data': json.dumps(parsed, indent=2)})
+        except AttributeError:
+            return render(request, 'email.html', {'data': 'no tms settings here'})
+
+
+class AdminMessageView(LoginRequiredMixin, View):
+    """View message status at TMS"""
+
+    http_method_names = ['get']
+    WEBHOOK_ENDPOINT = "/messages/email"
+
+    @method_decorator(staff_member_required)
+    def get(self, request, tms_id):
+        if not tms_id:
+            return render(request, 'email.html', {'data': 'need an email id'})
+        try:
+            connection = TMSClient()
+            response = connection.get(target=self.WEBHOOK_ENDPOINT + '/' + tms_id)
             parsed = json.loads(response.content)
             return render(request, 'email.html', {'data': json.dumps(parsed, indent=2)})
         except AttributeError:

--- a/crt_portal/tms/views.py
+++ b/crt_portal/tms/views.py
@@ -7,6 +7,7 @@ from urllib.parse import unquote
 from cts_forms.models import DoNotEmail
 from cts_forms.signals import get_client_ip
 from django.conf import settings
+from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import DisallowedHost
 from django.http import HttpResponse
@@ -105,6 +106,7 @@ class AdminView(LoginRequiredMixin, View):
     http_method_names = ['get']
     WEBHOOK_ENDPOINT = "/webhooks"
 
+    @method_decorator(staff_member_required)
     def get(self, request):
         try:
             connection = TMSClient()

--- a/crt_portal/tms/views.py
+++ b/crt_portal/tms/views.py
@@ -129,7 +129,7 @@ class AdminMessageView(LoginRequiredMixin, View):
             return render(request, 'email.html', {'data': 'need an email id'})
         try:
             connection = TMSClient()
-            response = connection.get(target=self.WEBHOOK_ENDPOINT + '/' + tms_id)
+            response = connection.get(target=self.WEBHOOK_ENDPOINT + '/' + str(tms_id))
             parsed = json.loads(response.content)
             return render(request, 'email.html', {'data': json.dumps(parsed, indent=2)})
         except AttributeError:


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1136)

## What does this change?

Adds a link to govdelivery email status API within admin. This will only work on servers with a TMS email connection (e.g. dev, not locally).

This gives CRT portal staff an easy path to examine the status of emails on the GovDelivery side, since not every email in our system has received a webhook response. This was true of all emails sent before webhoook integration, as well as all emails during the October 2021-ish period where an SSL certificate configuration change caused webhook responses not to be sent.

Furthermore, since webhooks can fail to send or be received (e.g. due to temporary outages) it is always possible for emails to be stuck in a "New" state. Therefore, adding a method to check the status of an email on demand via the GovDelivery API allows staff to always have some way of checking information.

As a follow-up, the next step will be to also update our email records locally when the data is retrieved.

## Screenshots (for front-end PR):

Admin view (email recipients obscured):
<img width="547" alt="Screen Shot 2021-11-16 at 3 22 53 PM" src="https://user-images.githubusercontent.com/2553268/142060460-7d3c0fff-3382-4b72-8138-4807544969d5.png">

Very bare-bones, MVP API response view (emails obscured):
![Screenshot 2021-11-16 at 15-23-33 tms admin view](https://user-images.githubusercontent.com/2553268/142060254-436f7e71-e338-42df-b2db-6584864ccb9b.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
