### PR TITLE
Viewing TMS email status also updates our own records

### DIFF
--- a/crt_portal/tms/admin.py
+++ b/crt_portal/tms/admin.py
@@ -14,7 +14,7 @@ class TMSEmailAdmin(ReadOnlyModelAdmin):
     ordering = ['-created_at']
 
     def tms_detail_url(self, obj):
-        return format_html('<a href="%s">View status</a>' % (reverse('tms:tms-admin-message', kwargs={"tms_id": obj.tms_id})))
+        return format_html('<a href="%s">View & update</a>' % (reverse('tms:tms-admin-message', kwargs={"tms_id": obj.tms_id})))
 
     tms_detail_url.short_description = 'TMS details'
 

--- a/crt_portal/tms/views.py
+++ b/crt_portal/tms/views.py
@@ -55,6 +55,16 @@ def _get_completed_at(request):
     return completed_datetime
 
 
+def _get_completed_at2(data):
+    """return a UTC datetime from inbound completed_at string, we're only expecting UTC
+    e.g: "2015-08-05T18:47:18Z"
+    Note this this is a different format than what gets posted to webhook
+    """
+    completed_at = data.get('completed_at', '')
+    completed_datetime = datetime.strptime(completed_at, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc)
+    return completed_datetime
+
+
 @method_decorator(csrf_exempt, name='dispatch')
 class WebhookView(View):
     """Handle inbound webhook requests from TMS"""
@@ -139,14 +149,30 @@ class AdminMessageView(LoginRequiredMixin, View):
         response = connection.get(target=self.WEBHOOK_ENDPOINT + '/' + str(tms_id))
         parsed = json.loads(response.content)
 
-        if parsed.status == 'completed':
-            if parsed.recipient_counts.failed > 0:
-                response2 = connection.get(target=parsed._links.failed)
-                parsed2 = json.loads(response2.content)
-            elif parsed.recipient_counts.sent > 0:
-                response2 = connection.get(target=parsed._links.sent)
-                parsed2 = json.loads(response2.content)
+        # if the email has been marked as "completed", it doesn't have the same data
+        # as the payload posted via the webhooks. We have to follow the links for the
+        # "failed" or "sent" state to receive status, completion date, and errors.
+        if parsed['status'] == 'completed':
+            if parsed['recipient_counts']['failed'] > 0:
+                response2 = connection.get(target=parsed['_links']['failed'])
+            elif parsed['recipient_counts']['sent'] > 0:
+                response2 = connection.get(target=parsed['_links']['sent'])
 
+            # Since we only send to one e-mail recipient at a time, we assume
+            # that the data only has one message in it. Just in case `parsed2`
+            # is output in the view so we can see exactly what the endpoint returns
+            parsed2 = json.loads(response2.content)
+            message = parsed[0]
+            email = TMSEmail.objects.get(tms_id=tms_id)
+            email.status = message['status']
+            email.completed_at = _get_completed_at2(message)
+            # Only failed messages have the error_message attribute, otherwise
+            # it does not exist
+            if email.failed:
+                email.error_message = message['error_message']
+            email.save()
+
+            # Displays both payloads
             return render(request, 'email.html', {'data': json.dumps(parsed, indent=2) + '\n' + json.dumps(parsed2, indent=2)})
         else:
             return render(request, 'email.html', {'data': json.dumps(parsed, indent=2)})


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1136)

## What does this change?

Follow up from https://github.com/usdoj-crt/crt-portal/pull/1040 with feedback from @ilodidoj:

- The "View status" link in the TMS table in the Django admin view has now updated to "View & update."
- Clicking this link will now display status, completion date and error message (if any) from sent and failed messages.
- Sent and failed messages will also now update our own record in the TMS model. This allows staff to manually update emails that have been stuck on a "New" status due to past webhook failures.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
