### PR TITLE
Add public_id to generated reports

### DIFF
--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand
 from cts_forms.tests.factories import ReportFactory
 from datetime import datetime
+from cts_forms.signals import salt
 
 
 class Command(BaseCommand):
@@ -18,5 +19,8 @@ class Command(BaseCommand):
             # report.contact_email = "test@test.test"
             report.status = 'open'
             report.create_date = datetime.now()
+            report.save()
+            salt_chars = salt()
+            report.public_id = f'{report.pk}-{salt_chars}'
             report.save()
         self.stdout.write(self.style.SUCCESS(f'Created {number_reports} reports'))


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?


The mock report generator was not adding a public ID to reports.  This PR will add the public_id to reports generated with the add_mock_reports management command.  

Note: the report must be saved twice.  Once to generate the report.pk, and the second time to take that id, and add the random 3 digit salt to it for report.public_id

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
