### PR TITLE
Fix TMS message API bugs

### DIFF
--- a/crt_portal/tms/views.py
+++ b/crt_portal/tms/views.py
@@ -152,7 +152,7 @@ class AdminMessageView(LoginRequiredMixin, View):
         # if the email has been marked as "completed", it doesn't have the same data
         # as the payload posted via the webhooks. We have to follow the links for the
         # "failed" or "sent" state to receive status, completion date, and errors.
-        if parsed['status'] == 'completed':
+        if parsed.get('status', '') == 'completed':
             response2 = None
             if parsed['recipient_counts']['failed'] > 0:
                 response2 = connection.get(target=parsed['_links']['failed'])

--- a/crt_portal/tms/views.py
+++ b/crt_portal/tms/views.py
@@ -162,7 +162,7 @@ class AdminMessageView(LoginRequiredMixin, View):
             # that the data only has one message in it. Just in case `parsed2`
             # is output in the view so we can see exactly what the endpoint returns
             parsed2 = json.loads(response2.content)
-            message = parsed[0]
+            message = parsed2[0]
             email = TMSEmail.objects.get(tms_id=tms_id)
             email.status = message['status']
             email.completed_at = _get_completed_at2(message)


### PR DESCRIPTION
Follow up to https://github.com/usdoj-crt/crt-portal/pull/1045.

## What does this change?

In dev environment, we noticed some issues with certain types of responses. These have been fixed.

- Fix a typo in code preventing follow up message status data from being read
- Fix an issue where we did not handle completed emails that were not sent or failed
- Handle a situation where the status API could return an error

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
