### PR TITLE
feat(admin): add judicial districts read-only table

### DIFF
--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -8,7 +8,8 @@ from django.db.models import Prefetch
 from django.http import StreamingHttpResponse
 
 from .models import (CommentAndSummary, HateCrimesandTrafficking, Profile,
-                     ProtectedClass, Report, ResponseTemplate, DoNotEmail)
+                     ProtectedClass, Report, ResponseTemplate, DoNotEmail,
+                     JudicialDistrict)
 from .signals import get_client_ip
 
 logger = logging.getLogger(__name__)
@@ -156,6 +157,12 @@ class ActionAdmin(ReadOnlyModelAdmin):
     actions = [export_actions_as_csv]
 
 
+class JudicialDistrictAdmin(ReadOnlyModelAdmin):
+    list_display = ['zipcode', 'city', 'county', 'state', 'district']
+    list_filter = ['district']
+    search_fields = ['zipcode', 'city', 'county', 'state', 'district']
+
+
 admin.site.register(CommentAndSummary)
 admin.site.register(Report, ReportAdmin)
 admin.site.register(ProtectedClass)
@@ -163,7 +170,7 @@ admin.site.register(HateCrimesandTrafficking)
 admin.site.register(ResponseTemplate)
 admin.site.register(Profile)
 admin.site.register(DoNotEmail)
-
+admin.site.register(JudicialDistrict, JudicialDistrictAdmin)
 
 # Activity stream already registers an Admin for Action, we want to replace it
 admin.site.unregister(Action)


### PR DESCRIPTION
## What does this change?

This came about during a review/debug session with @ilodidoj and @billyhunt today. The app loads a lookup table of city/state to judicial districts during the database migration process, which can sometimes not be present under certain conditions. This lookup table has not been exposed in the admin view previously, but by adding it, it can help with debugging:

- To verify if the judicial district table has been loaded locally or in any given app instance
- To see why certain combinations of city/state don't automatically assign to a judicial district, e.g. "New York City, NY" will not assign a district, but "New York, NY" will.

## Screenshots (for front-end PR):

<img width="1330" alt="Screen Shot 2021-11-29 at 4 05 03 PM" src="https://user-images.githubusercontent.com/2553268/143943361-981ac531-2db7-4f3b-9c8a-4a090e5be40a.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
