### PR TITLE
fix(intake): remove extraneous screen reader tag

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/header.html
@@ -12,7 +12,6 @@
     <span class="backend-blue">{{ data.create_date|date:'g:i a F j, Y' }}</span>
   </span>
   {% if data.intake_format %}
-    <span class="usa-sr-only">from {{ data.intake_format }}</span>
     <span class="usa-tooltip" data-position="right" data-classes="margin-left-1 display-inline" title="from {{ data.intake_format }}">
     {% if data.intake_format == 'web' %}
       <img src="{% static "img/intake-icons/ic_web.svg" %}" class="text-tbottom" alt="" role="presentation">


### PR DESCRIPTION

## What does this change?

From screen reader testing with Terri today: when the intake format tooltip is being read correctly (in Jaws 18, but there seems to be other issues with Jaws 2020 and NVDA, we will need to follow up with that separately) it will read the intake format twice. This is because of an extraneous `.sr-only` tag. We can remove that and let the USWDS tooltip component handle the screen reader text.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
