### PR TITLE
Add closed_date, unassign user, and close activity log entry to reports.

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1608,7 +1608,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
                 report.closeout_report()
                 self.report_closed = True
                 report.save()
-                activities.append({'user': user, 'report': report, 'verb': "Report closed and Assignee removed", 'description':  f"Date closed updated to {report.closed_date.strftime('%m/%d/%y %H:%M:%M %p')}"})
+                activities.append({'user': user, 'report': report, 'verb': "Report closed and Assignee removed", 'description': f"Date closed updated to {report.closed_date.strftime('%m/%d/%y %H:%M:%M %p')}"})
 
         for act in activities:
             add_activity(act['user'], act['verb'], act['description'], act['report'])

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1606,7 +1606,6 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
             if report.closed and not existing_reports_closed[index]:
                 index += 1
                 report.closeout_report()
-                self.report_closed = True
                 report.save()
                 activities.append({'user': user, 'report': report, 'verb': "Report closed and Assignee removed", 'description': f"Date closed updated to {report.closed_date.strftime('%m/%d/%y %H:%M:%M %p')}"})
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1601,13 +1601,11 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         for report in reports:
             existing_reports_closed.append(report.closed)
         updated_number = reports.update(**updated_data)
-        index = 0
-        for report in reports:
+        for index, report in enumerate(reports):
             if report.closed and not existing_reports_closed[index]:
                 report.closeout_report()
                 report.save()
                 activities.append({'user': user, 'report': report, 'verb': "Report closed and Assignee removed", 'description': f"Date closed updated to {report.closed_date.strftime('%m/%d/%y %H:%M:%M %p')}"})
-            index += 1
         for act in activities:
             add_activity(act['user'], act['verb'], act['description'], act['report'])
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1604,11 +1604,10 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         index = 0
         for report in reports:
             if report.closed and not existing_reports_closed[index]:
-                index += 1
                 report.closeout_report()
                 report.save()
                 activities.append({'user': user, 'report': report, 'verb': "Report closed and Assignee removed", 'description': f"Date closed updated to {report.closed_date.strftime('%m/%d/%y %H:%M:%M %p')}"})
-
+            index += 1
         for act in activities:
             add_activity(act['user'], act['verb'], act['description'], act['report'])
 

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -824,7 +824,7 @@ class BulkActionsTests(TestCase):
         first_report = Report.objects.get(id=self.reports[0].id)
         second_report = Report.objects.get(id=self.reports[1].id)
         self.post([first_report.id], confirm=False, status='closed', comment='Close Report')
-        response = self.post([first_report.id, second_report.id], assigned_to=self.user.id, comment='a comment')
+        self.post([first_report.id, second_report.id], assigned_to=self.user.id, comment='a comment')
         first_report_actions = str(first_report.target_actions.all())
         second_report_actions = str(second_report.target_actions.all())
         self.assertTrue('Report closed and Assignee removed' in first_report_actions)


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1075)

## What does this change?

Currently, some reports are not generating closed_dates when they are closed.  After some investigation, it seems as if the bulk action is the culprit.  This PR adds the logic currently found in the report detail view close action to bulk actions.

## Screenshots (for front-end PR):

## Checklist:

It turns out that batch processing was not adding a date to reports and updating the activity log. To test

Batch close 3 reports that are currently open and assigned to someone. Make sure that all three reports are closed, have an entry in the activity log, have a closed date, and are not assigned to anyone.
Batch close 2 open reports and 1 closed report. Make sure the 2 open reports were closed and the one already closed does not have an updated closed date.
Batch close 3 reports that are not assigned to anyone. Make sure that all three reports are closed, have an entry in the activity log, have a closed date, and are not assigned to anyone.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
