### PR TITLE
feat(factory): add a random intake_format to mock reports

### DIFF
--- a/crt_portal/cts_forms/tests/factories.py
+++ b/crt_portal/cts_forms/tests/factories.py
@@ -1,6 +1,7 @@
 from cts_forms.model_variables import (PRIMARY_COMPLAINT_CHOICES,
                                        SECTION_CHOICES, SERVICEMEMBER_CHOICES,
-                                       STATES_AND_TERRITORIES, STATUS_CHOICES)
+                                       STATES_AND_TERRITORIES, STATUS_CHOICES,
+                                       INTAKE_FORMAT_CHOICES)
 from cts_forms.models import Report
 from factory import Faker
 from factory.django import DjangoModelFactory
@@ -39,3 +40,5 @@ class ReportFactory(DjangoModelFactory):
     servicemember = FuzzyChoice(SERVICEMEMBER_CHOICES, getter=lambda c: c[0])
     status = FuzzyChoice(STATUS_CHOICES, getter=lambda c: c[0])
     assigned_section = FuzzyChoice(SECTION_CHOICES, getter=lambda c: c[0])
+
+    intake_format = FuzzyChoice(INTAKE_FORMAT_CHOICES, getter=lambda c: c[0])


### PR DESCRIPTION
## What does this change?

Small tech task improvement to add the `intake_format` property to mock reports. This enables the intake format icon to appear correctly when viewing reports created in this way.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
