### PR TITLE
feat(dashboard): simplify UI for assignee filter

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filter-controls.html
@@ -1,6 +1,6 @@
 {% load static %}
 <h2 class="intake-section-title">Team Management</h2>
-<div class="margin-bottom-2">Review the Activity Log of Intake Specialists by selecting their name(s) and dates in the filter options below.</div>
+<div class="margin-bottom-2">Review the activity log of intake specialists by selecting their name(s) and dates in the filter options below.</div>
 <form
   id="filters-form"
   method="GET"

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filters/assignee.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filters/assignee.html
@@ -1,13 +1,8 @@
-{% extends "forms/complaint_view/index/filter.html" %}
-
-{% block controls %}assigned_to{% endblock %}
-{% block label %}Intake specialist{% endblock %}
-{% block id %}assigned_to{% endblock %}
-{% block content %}
+<div class="crt-filter">
   <label for="id_assigned_to">
-    <span class="usa-sr-only">assignee</span>
+    <span class="usa-sr-only">Intake specialist</span>
   </label>
-  <div class="usa-combo-box" data-placeholder="Select one" data-default-value="">
+  <div class="usa-combo-box crt-combo-box-filter" data-placeholder="Intake specialist" data-default-value="{{ selected_actor_id }}">
     {{ form.assigned_to }}
   </div>
-{% endblock %}
+</div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter.html
@@ -10,7 +10,7 @@
   >
     <span class="label">{% block label %}{% endblock %}</span>
     <img src="{% static 'img/intake-icons/ic_select-down.svg' %}" alt="open filter dropdown" class="icon" />
-  </button>  
+  </button>
   <div class="content" hidden>
     {% block content %}{% endblock %}
   </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/assignee.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/assignee.html
@@ -7,7 +7,7 @@
   <label for="id_assigned_to">
     <span class="usa-sr-only">assignee</span>
   </label>
-  <div class="usa-combo-box" data-placeholder="Select one" data-default-value="{{ form.assigned_to.value }}">
+  <div class="usa-combo-box" data-placeholder="Select one" data-default-value="{{ selected_assignee_id }}">
     {{ form.assigned_to }}
   </div>
 {% endblock %}

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -36,7 +36,7 @@ from .forms import (
 )
 from .mail import crt_send_mail
 from .model_variables import HATE_CRIMES_TRAFFICKING_MODEL_CHOICES
-from .models import CommentAndSummary, Profile, Report, ReportAttachment, Trends, EmailReportCount
+from .models import CommentAndSummary, Profile, Report, ReportAttachment, Trends, EmailReportCount, User
 from .page_through import pagination
 from .sorts import report_sort
 
@@ -230,6 +230,13 @@ def index_view(request):
             "url": f'{report.id}?next={all_args_encoded}&index={paginated_offset + index}',
         })
 
+    selected_assignee = request.GET.get("assigned_to", "")
+    selected_assignee_object = User.objects.filter(username=selected_assignee).first()
+    if selected_assignee_object:
+        selected_assignee_id = selected_assignee_object.pk
+    else:
+        selected_assignee_id = ''
+
     final_data = {
         'form': Filters(request.GET),
         'profile_form': profile_form,
@@ -240,6 +247,7 @@ def index_view(request):
         'filter_state': filter_args,
         'filters': query_filters,
         'return_url_args': all_args_encoded,
+        'selected_assignee_id': selected_assignee_id,
     }
 
     return render(request, 'forms/complaint_view/index/index.html', final_data)
@@ -262,9 +270,17 @@ def dashboard_view(request):
     start_date = _format_date(request.GET.get("create_date_start", ""))
     end_date = _format_date(request.GET.get("create_date_end", ""))
 
+    selected_actor = request.GET.get("assigned_to", "")
+    selected_actor_object = User.objects.filter(username=selected_actor).first()
+    if selected_actor_object:
+        selected_actor_id = selected_actor_object.pk
+    else:
+        selected_actor_id = ''
+
     final_data = {
         'form': Filters(request.GET),
-        'selected_actor': request.GET.get("assigned_to", ""),
+        'selected_actor': selected_actor,
+        'selected_actor_id': selected_actor_id,
         'date_range_start': start_date,
         'date_range_end': end_date,
         'activity_count': len(reports_set),

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -340,6 +340,23 @@
   }
 }
 
+/* Matches styling of .crt-dropdown, but is not a .crt-dropdown */
+.crt-filter {
+  align-items: center;
+  background: color('white');
+  border-radius: 3px;
+  display: flex;
+  min-height: 2.5rem;
+  min-width: 6rem;
+  position: relative;
+  margin-right: 1rem;
+  margin-bottom: 2rem;
+
+  &:last-of-type {
+    margin-top: 0rem;
+  }
+}
+
 .crt-checkbox {
   @extend .crt-dropdown;
 
@@ -741,5 +758,30 @@ ul.messages {
       font-size: .80rem;
       line-height: 1.4;
     }
+  }
+}
+
+/* Match combo box input styling with other filters */
+.crt-combo-box-filter {
+  width: 15rem; /* Hard code width to fix situation where input would expand when an item is selected */
+
+  .usa-combo-box__input {
+    margin-top: 0;
+    border: 0;
+
+    &::placeholder {
+      color: color($theme-color-primary-darker);
+      opacity: 1; /* Firefox */
+    }
+
+    &::-ms-input-placeholder {
+      color: color($theme-color-primary-darker);
+    }
+  }
+
+  .usa-combo-box__list {
+    border: 0;
+    border-top: 1px solid color("base-lighter"); /* Match list item border color */
+    box-shadow: 0 15px 10px rgb(100 100 100 / 20%); /* Match .crt-dropdown .content */
   }
 }


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1156)

## What does this change?

We remove the "Intake specialist" two-step dropdown process and simplify it to one.

Previously:

<img width="865" alt="Screen Shot 2021-12-15 at 4 46 36 PM" src="https://user-images.githubusercontent.com/2553268/146270271-2183ca80-14d8-4a89-a6cf-0084e69da30b.png">

Currently: 

<img width="930" alt="Screen Shot 2021-12-15 at 4 40 44 PM" src="https://user-images.githubusercontent.com/2553268/146269879-9ce16da2-08e7-4452-95c3-f6d601080b5b.png">

<img width="927" alt="Screen Shot 2021-12-15 at 4 40 49 PM" src="https://user-images.githubusercontent.com/2553268/146269881-1588bfa4-88ff-463f-ad63-f8304bd826df.png">

Additionally, I fixed a bug that happens here, and also on the view-all filters page, where a selected assignee wouldn't populate the combo-box field at page load. This is because the `form.assigned_to.value` template value is the human-readable text label for the assignee, but we needed the primary key value. In order to provide the primary key value to the template so it knows which assignee is already selected, I had to get it in `views.py` and send it to the template from there. If anyone knows of an easier way to access this value, I'd love to hear it.

### Notes, caveats and known issues:

- The placeholder "label" can't be changed to read "Select one" when it's clicked into.
- I copy-edited the instruction text above the filters slightly to remove unnecessary capitalization.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
