### PR TITLE
Refresh the email count after adding mock reports.

### DIFF
--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 from cts_forms.tests.factories import ReportFactory
 from datetime import datetime
 from cts_forms.signals import salt
+from cts_forms.models import EmailReportCount
 
 
 class Command(BaseCommand):
@@ -23,4 +24,5 @@ class Command(BaseCommand):
             salt_chars = salt()
             report.public_id = f'{report.pk}-{salt_chars}'
             report.save()
+        EmailReportCount.refresh_view()
         self.stdout.write(self.style.SUCCESS(f'Created {number_reports} reports'))


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1163)

## What does this change?

After adding mock reports in our local environments, the email count is incorrect because we are not running the update as we do when a new report is created on production, staging, or dev.

This PR automatically updates the email count when you create mock reports, saving the step of having to do it manually.

Note there is no way to test this anywhere but a local environment.

Also, since it is not run on prod, staging, or dev, its impact is low.

## Screenshots (for front-end PR):

Before: 
![image](https://user-images.githubusercontent.com/6232068/146788579-64b660f0-efb1-49e8-b54c-b64bfa48dd79.png)

After:
![image](https://user-images.githubusercontent.com/6232068/146788646-a19fe4d9-6f5f-4c60-acf0-8e32a0ed6076.png)


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
