### PR TITLE
chore(ci): update circleci config to use current images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
-# Python CircleCI 2.0 configuration file
+# Python CircleCI 2.1 configuration file
 # Circle docs https://circleci.com/docs/2.0/language-python/
 # Set deployment variables in CircleCI as environment variables
+
+version: 2.1
 
 # Snippet for installing CloudFoundry CLI version 7
 install-cf7: &install-cf7
@@ -29,14 +31,13 @@ install-python-dev-dependencies: &install-python-dev-dependencies
       pipenv install --dev
       pipenv run python -m playwright install
 
-version: 2
 jobs:
   build_and_test: # runs not using Workflows must have a `build` job as entry point
     # directory where steps are run
     working_directory: ~/code
     docker:
-      # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
-      - image: circleci/python:3.9.7-node-browsers
+      # CircleCI Python images available at: https://hub.docker.com/r/cimg/python/
+      - image: cimg/python:3.9.7-browsers
         environment: # environment variables for primary container
           PIPENV_VENV_IN_PROJECT: true
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
@@ -51,9 +52,9 @@ jobs:
       # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
-            - node-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
-            - node-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
-            - node-{{ .Environment.CACHE_VERSION }}-
+            - node-v4-{{ .Branch }}-{{ checksum "package-lock.json" }}
+            - node-v4-{{ .Branch }}-
+            - node-v4-
       - run:
           name: Install gettext
           command: sudo apt-get update && sudo apt-get install -yqq gettext
@@ -66,12 +67,12 @@ jobs:
       - save_cache:
           paths:
             - /home/circleci/code/node_modules/
-          key: node-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          key: node-v4-{{ .Branch }}-{{ checksum "package-lock.json" }}
       - restore_cache:
           keys:
-            - pip-packages-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-            - pip-packages-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
-            - pip-packages-{{ .Environment.CACHE_VERSION }}-
+            - pip-packages-v4-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+            - pip-packages-v4-{{ .Branch }}-
+            - pip-packages-v4-
       - *install-python-dev-dependencies
       - run:
           name: Migrate the database
@@ -79,7 +80,7 @@ jobs:
       - save_cache:
           paths:
             - /home/circleci/code/.venv # this path depends on where pipenv creates a virtualenv
-          key: pip-packages-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: pip-packages-v4-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Run prettier code formatting check
           command: npm run lint:check
@@ -129,8 +130,8 @@ jobs:
     description: Runs E2E tests against dev
     working_directory: ~/code
     docker:
-      # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
-      - image: circleci/python:3.9.7-node-browsers
+      # CircleCI Python images available at: https://hub.docker.com/r/cimg/python/
+      - image: cimg/python:3.9.7-browsers
         environment: # environment variables for primary container
           PIPENV_VENV_IN_PROJECT: true
     steps:
@@ -144,8 +145,8 @@ jobs:
     description: Runs E2E tests against stage
     working_directory: ~/code
     docker:
-      # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
-      - image: circleci/python:3.9.7-node-browsers
+      # CircleCI Python images available at: https://hub.docker.com/r/cimg/python/
+      - image: cimg/python:3.9.7-browsers
         environment: # environment variables for primary container
           PIPENV_VENV_IN_PROJECT: true
     steps:
@@ -205,14 +206,12 @@ jobs:
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
-
-
     steps:
       - checkout
       # removing as we deal with caching problem
       # - restore_cache:
       # # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-      #     key: deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
+      #     key: deps-v4-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
       - run:
           name: Node install
           command: |
@@ -235,7 +234,7 @@ jobs:
             rm cf7.deb
             cf7 api https://api.fr.cloud.gov
       # - save_cache: # cache Python and Node dependencies using checksum of Pipfile and package.json as the cache-key
-      #     key: deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
+      #     key: deps-v4-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
       #     paths:
       #       - ".venv"
       #       - "/usr/local/bin"
@@ -268,7 +267,7 @@ jobs:
       - checkout
       - restore_cache:
       # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-          key: deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
+          key: deps-v4-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
       - run:
           name: Node install
           command: |
@@ -291,7 +290,7 @@ jobs:
             rm cf7.deb
             cf7 api https://api.fr.cloud.gov
       - save_cache: # cache Python and Node dependencies using checksum of Pipfile and package.json as the cache-key
-          key: deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
+          key: deps-v4-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
           paths:
             - ".venv"
             - "/usr/local/bin"
@@ -309,7 +308,7 @@ jobs:
   deploy-prod:
     working_directory: ~/code
     docker:
-      # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
+      # CircleCI Python images available at: https://hub.docker.com/r/cimg/python/
       - image: python:3.9.7
         environment: # environment variables for primary container
           PIPENV_VENV_IN_PROJECT: true
@@ -325,7 +324,7 @@ jobs:
       - checkout
       - restore_cache:
       # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-          key: deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
+          key: deps-v4-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
       - run:
           name: Node install
           command: |
@@ -348,7 +347,7 @@ jobs:
             rm cf7.deb
             cf7 api https://api.fr.cloud.gov
       - save_cache: # cache Python and Node dependencies using checksum of Pipfile and package.json as the cache-key
-          key: deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
+          key: deps-v4-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
           paths:
             - ".venv"
             - "/usr/local/bin"
@@ -433,7 +432,6 @@ jobs:
           command: cf run-task crt-portal-django  -c "python crt_portal/manage.py clearsessions" --name clear-sessions
 
 workflows:
-  version: 2
   build-test-deploy:
     jobs:
       - build_and_test


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1153)

## What does this change?

This updates our CircleCI configuration to migrate to "next-generation" build images, as described here: https://circleci.com/docs/2.0/next-gen-migration-guide/

- Legacy `circleci/python:3.9.7-node-browsers` images have been updated to `cimg/python:3.9.7-browsers`
- Configuration has been updated to specify version 2.1 in case we use orbs. However, we currently don't need it.
- Because the new images have a different Python environment than the legacy images, previously cached Python dependencies broke the CI job. Starting with this update, we follow the pattern in CircleCI's [Caching Dependencies documentation](https://circleci.com/docs/2.0/caching/#clearing-cache) to hard-code version numbers in cache keys rather than using project-wide environment variables.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
