### PR TITLE
Require receipt date and intake type fields on proform

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -588,6 +588,7 @@ def date_cleaner(self, cleaned_data):
 
     return cleaned_data
 
+
 def crt_date_cleaner(self, cleaned_data):
     """This should give the most specific error message, if the date doesn't render for reasons other than what we are checking for, it will give the generic error."""
     try:

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -623,10 +623,8 @@ def crt_date_cleaner(self, cleaned_data):
 
     except ValueError:
         # a bit of a catch-all for all the ways people could make invalid dates
-        self.add_error('last_incident_year', ValidationError(
-            DATE_ERRORS['not_valid'],
-            params={'value': f'{month}/{day}/{year}'},
-        ))
+        return cleaned_data
+
     except KeyError:
         # these required errors will be caught by the built in error validation
         return cleaned_data

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -591,44 +591,37 @@ def date_cleaner(self, cleaned_data):
 
 def crt_date_cleaner(self, cleaned_data):
     """This should give the most specific error message, if the date doesn't render for reasons other than what we are checking for, it will give the generic error."""
-    try:
-        # If these are required they will be caught by the key error
-        day = cleaned_data.get('crt_reciept_day')
-        year = cleaned_data.get('crt_reciept_year')
-        month = cleaned_data.get('crt_reciept_month')
-        # custom messages
-        if not month:
-            self.add_error('crt_recript_month', ValidationError(DATE_ERRORS['month_required']))
-        elif month > 12 or month < 1:
+    if 'crt_reciept_month' in cleaned_data:
+        month = cleaned_data['crt_reciept_month']
+        if month > 12 or month < 1:
             self.add_error('crt_reciept_month', ValidationError(
                 DATE_ERRORS['month_invalid'],
             ))
-        if not day:
-            self.add_error('crt_recript_day', ValidationError(DATE_ERRORS['day_required']))
-        elif day > 31 or day < 1:
+    else:
+        self.add_error('crt_reciept_month', ValidationError(DATE_ERRORS['month_required']))
+
+    if 'crt_reciept_day' in cleaned_data:
+        day = cleaned_data['crt_reciept_day']
+        if day > 31 or day < 1:
             self.add_error('crt_reciept_day', ValidationError(
                 DATE_ERRORS['day_invalid'],
             ))
-        if not year:
-            self.add_error('crt_recript_year', ValidationError(DATE_ERRORS['year_required']))
+    else:
+        self.add_error('crt_reciept_day', ValidationError(DATE_ERRORS['day_required']))
+
+    if 'crt_reciept_year' in cleaned_data:
+        year = cleaned_data['crt_reciept_year']
+        if year < 2000:
+            self.add_error('crt_reciept_year', ValidationError(
+                DATE_ERRORS['crt_no_past'],
+            ))
         elif datetime(year, month, day) > datetime.now():
             self.add_error('crt_reciept_year', ValidationError(
                 DATE_ERRORS['no_future'],
                 params={'value': datetime(year, month, day).strftime('%x')},
             ))
-        elif datetime(year, month, day) < datetime(1999, 12, 31):
-            self.add_error('crt_reciept_year', ValidationError(
-                DATE_ERRORS['crt_no_past'],
-                params={'value': datetime(year, month, day).strftime('%x')},
-            ))
-
-    except ValueError:
-        # a bit of a catch-all for all the ways people could make invalid dates
-        return cleaned_data
-
-    except KeyError:
-        # these required errors will be caught by the built in error validation
-        return cleaned_data
+    else:
+        self.add_error('crt_reciept_year', ValidationError(DATE_ERRORS['year_required']))
 
     return cleaned_data
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -615,9 +615,9 @@ def crt_date_cleaner(self, cleaned_data):
                 DATE_ERRORS['no_future'],
                 params={'value': datetime(year, month, day).strftime('%x')},
             ))
-        elif datetime(year, month, day) < datetime(1899, 12, 31):
+        elif datetime(year, month, day) < datetime(1999, 12, 31):
             self.add_error('crt_reciept_year', ValidationError(
-                DATE_ERRORS['no_past'],
+                DATE_ERRORS['crt_no_past'],
                 params={'value': datetime(year, month, day).strftime('%x')},
             ))
 

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -405,6 +405,7 @@ STATES_AND_TERRITORIES = (
 
 VIOLATION_SUMMARY_ERROR = _('Please provide description to continue')
 PRIMARY_COMPLAINT_ERROR = _('Please select a primary reason to continue.')
+INTAKE_FORMAT_ERROR = _('Please select an intake format')
 
 WHERE_ERRORS = (
     ('location_name', _('Please enter the name of the location where this took place.')),
@@ -431,6 +432,7 @@ INCIDENT_DATE_HELPTEXT = _('You must enter a month and year. Please use the form
 DATE_ERRORS = {
     'month_required': _('Please enter a month.'),
     'month_invalid': _('Please enter a valid month. Month must be between 1 and 12.'),
+    'day_required': _('Please enter a day.'),
     'day_invalid': _('Please enter a valid day of the month. Day must be between 1 and the last day of the month.'),
     'year_required': _('Please enter a year.'),
     'no_future': _('Date can not be in the future.'),

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -437,6 +437,7 @@ DATE_ERRORS = {
     'year_required': _('Please enter a year.'),
     'no_future': _('Date can not be in the future.'),
     'no_past': _('Please enter a year after 1900.'),
+    'crt_no_past': _('Please enter a year after 2000.'),
     'not_valid': _('Please enter a valid date. Use format MM/DD/YYYY.'),
 }
 

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -437,7 +437,7 @@ DATE_ERRORS = {
     'year_required': _('Please enter a year.'),
     'no_future': _('Date can not be in the future.'),
     'no_past': _('Please enter a year after 1900.'),
-    'crt_no_past': _('Please enter a year after 2000.'),
+    'crt_no_past': _('Please enter a year after 1999.'),
     'not_valid': _('Please enter a valid date. Use format MM/DD/YYYY.'),
 }
 

--- a/crt_portal/cts_forms/templates/forms/pro_template.html
+++ b/crt_portal/cts_forms/templates/forms/pro_template.html
@@ -18,12 +18,12 @@
 
     <h2 class="h1" id="intake">Intake</h2>
     <div class="margin-top-3 display-flex flex-align-end">
-      {% include "forms/question_cards/date.html" with question='CRT receipt date' month=form.crt_reciept_month day=form.crt_reciept_day year=form.crt_reciept_year required=False %}
+      {% include "forms/question_cards/date.html" with question='CRT receipt date' month=form.crt_reciept_month day=form.crt_reciept_day year=form.crt_reciept_year required=True proform_required=True %}
       <button id="today-receipt-btn" name="today-receipt-date" label="autofill receipt date"
         class="usa-button usa-button--unstyled autofill_today_btn margin-left-2" type="button">Today</button>
     </div>
     <div class="margin-top-4">
-      {% include "forms/question_cards/single_question.html" with field=form.intake_format %}
+      {% include "forms/question_cards/single_question.html" with field=form.intake_format required=True proform_required=True %}
     </div>
   </div>
 </div>
@@ -40,7 +40,7 @@
   <div class="crt-portal-card__content crt-portal-card__content--lg">
     <h2 class="h1" id="primary-concern">Primary concern</h2>
     <div class="margin-top-3">
-      {% include "forms/question_cards/single_question.html" with field=form.primary_complaint required=True %}
+      {% include "forms/question_cards/single_question.html" with field=form.primary_complaint required=True proform_required=True %}
 
       {# Optional questions: #}
 

--- a/crt_portal/cts_forms/templates/forms/question_cards/single_question.html
+++ b/crt_portal/cts_forms/templates/forms/question_cards/single_question.html
@@ -10,7 +10,7 @@
   {% if field.label %}
   <h3 class="question--header margin-top-0">
     <label for="{{ field.id_for_label }}" class="{{label_class}} margin-bottom-0">
-      {{ field.label }}{% if required or field.field.required %}<span class="field-required">{% trans "required" %}</span>{% endif %}
+      {{ field.label }}{% if required or field.field.required or proform_required %}<span class="field-required">{% trans "required" %}</span>{% endif %}
     </label>
   </h3>
   {% endif %} {% if field.help_text %}

--- a/crt_portal/cts_forms/templates/forms/snippets/date_components.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/date_components.html
@@ -7,7 +7,7 @@
   </div>
   <div class="usa-form-group usa-form-group--day">
     <label class="usa-label" for="{{ day.id_for_label}}">
-      {{ day.label }}
+      {{ day.label }}{% if proform_required %}<span class="text-secondary-dark">*</span>{% endif %}
     </label>
     {{ day|withInputError }}
   </div>

--- a/crt_portal/cts_forms/tests/test_intake_forms.py
+++ b/crt_portal/cts_forms/tests/test_intake_forms.py
@@ -712,7 +712,7 @@ class ProFormTest(TestCase):
         bad_year_data["crt_reciept_year"] = 1899
         form = ProForm(data=bad_year_data)
         errors = str(form.errors)
-        self.assertTrue("Please enter a year after 1900." in errors)
+        self.assertTrue("Please enter a year after 1999." in errors)
         self.assertFalse(form.is_valid())
         bad_year_data["crt_reciept_year"] = 3000
         form = ProForm(data=bad_year_data)

--- a/crt_portal/cts_forms/tests/test_intake_forms.py
+++ b/crt_portal/cts_forms/tests/test_intake_forms.py
@@ -675,11 +675,53 @@ class ProFormTest(TestCase):
 
     def test_required_fields(self):
         form = ProForm(data={})
+        errors = str(form.errors)
+        self.assertTrue("Please select an intake format" in errors)
+        self.assertTrue("Please select a primary reason to continue." in errors)
+        self.assertTrue("crt_reciept_day" in errors)
+        self.assertTrue("crt_reciept_month" in errors)
+        self.assertTrue("crt_reciept_year" in errors)
         self.assertFalse(form.is_valid())
-        self.assertEquals(
-            form.errors,
-            {'primary_complaint': ['Please select a primary reason to continue.']}
-        )
+
+    def test_month_validation(self):
+        bad_month_data = self.data
+        bad_month_data["crt_reciept_month"] = 13
+        form = ProForm(data=bad_month_data)
+        errors = str(form.errors)
+        self.assertTrue("Please enter a valid month. Month must be between 1 and 12." in errors)
+        self.assertFalse(form.is_valid())
+
+    def test_day_validation(self):
+        bad_day_data = self.data
+        bad_day_data["crt_reciept_day"] = 32
+        form = ProForm(data=bad_day_data)
+        errors = str(form.errors)
+        self.assertTrue("Please enter a valid day of the month. Day must be between 1 and the last day of the month." in errors)
+        self.assertFalse(form.is_valid())
+
+    def test_month_validation(self):
+        bad_month_data = self.data
+        bad_month_data["crt_reciept_month"] = 13
+        form = ProForm(data=bad_month_data)
+        errors = str(form.errors)
+        self.assertTrue("Please enter a valid month. Month must be between 1 and 12." in errors)
+        self.assertFalse(form.is_valid())
+
+    def test_year_validation(self):
+        bad_year_data = self.data
+        bad_year_data["crt_reciept_year"] = 1899
+        form = ProForm(data=bad_year_data)
+        errors = str(form.errors)
+        self.assertTrue("Please enter a year after 1900." in errors)
+        self.assertFalse(form.is_valid())
+        bad_year_data["crt_reciept_year"] = 3000
+        form = ProForm(data=bad_year_data)
+        errors = str(form.errors)
+        print(errors)
+        self.assertTrue("Date can not be in the future." in errors)
+        self.assertFalse(form.is_valid())
+
+
 
     def test_full_example(self):
         form = ProForm(data=self.data)

--- a/crt_portal/cts_forms/tests/test_intake_forms.py
+++ b/crt_portal/cts_forms/tests/test_intake_forms.py
@@ -699,14 +699,6 @@ class ProFormTest(TestCase):
         self.assertTrue("Please enter a valid day of the month. Day must be between 1 and the last day of the month." in errors)
         self.assertFalse(form.is_valid())
 
-    def test_month_validation(self):
-        bad_month_data = self.data
-        bad_month_data["crt_reciept_month"] = 13
-        form = ProForm(data=bad_month_data)
-        errors = str(form.errors)
-        self.assertTrue("Please enter a valid month. Month must be between 1 and 12." in errors)
-        self.assertFalse(form.is_valid())
-
     def test_year_validation(self):
         bad_year_data = self.data
         bad_year_data["crt_reciept_year"] = 1899
@@ -720,8 +712,6 @@ class ProFormTest(TestCase):
         print(errors)
         self.assertTrue("Date can not be in the future." in errors)
         self.assertFalse(form.is_valid())
-
-
 
     def test_full_example(self):
         form = ProForm(data=self.data)

--- a/crt_portal/cts_forms/tests/test_intake_forms.py
+++ b/crt_portal/cts_forms/tests/test_intake_forms.py
@@ -709,7 +709,6 @@ class ProFormTest(TestCase):
         bad_year_data["crt_reciept_year"] = 3000
         form = ProForm(data=bad_year_data)
         errors = str(form.errors)
-        print(errors)
         self.assertTrue("Date can not be in the future." in errors)
         self.assertFalse(form.is_valid())
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -513,7 +513,6 @@ class ShowView(LoginRequiredMixin, View):
 
 class ActionsView(LoginRequiredMixin, FormView):
     """ CRT view to update report data"""
-
     def get(self, request):
         return_url_args = request.GET.get('next', '')
         return_url_args = urllib.parse.unquote(return_url_args)
@@ -688,6 +687,7 @@ class RemoveReportAttachmentView(LoginRequiredMixin, View):
     http_method_names = ['post']
 
     def post(self, request, attachment_id):
+
         attachment = get_object_or_404(ReportAttachment, pk=attachment_id)
 
         logger.info(f'User {request.user} removing attachment with id {attachment_id}')
@@ -751,7 +751,6 @@ class SaveCommentView(LoginRequiredMixin, FormView):
 
 class ProFormView(LoginRequiredMixin, SessionWizardView):
     """This is the one-page internal form for CRT staff to input complaints"""
-
     def get_template_names(self):
         return 'forms/pro_template.html'
 
@@ -760,6 +759,7 @@ class ProFormView(LoginRequiredMixin, SessionWizardView):
 
         field_errors = list(map(lambda field: field.errors, context['form']))
         page_errors = [error for field in field_errors for error in field]
+
         # internal use only
         ordered_step_names = [
             'Intake',

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -439,7 +439,8 @@ class ShowView(LoginRequiredMixin, View):
         contact_form = ContactEditForm(instance=report)
         details_form = ReportEditForm(instance=report)
         filter_output = setup_filter_parameters(report, request.GET)
-        autoresponse_email = TMSEmail.objects.filter(report=report.id, purpose=TMSEmail.AUTO_EMAIL).order_by('created_at').first()
+        autoresponse_email = TMSEmail.objects.filter(report=report.id, purpose=TMSEmail.AUTO_EMAIL).order_by(
+            'created_at').first()
         output.update({
             'contact_form': contact_form,
             'details_form': details_form,
@@ -512,6 +513,7 @@ class ShowView(LoginRequiredMixin, View):
 
 class ActionsView(LoginRequiredMixin, FormView):
     """ CRT view to update report data"""
+
     def get(self, request):
         return_url_args = request.GET.get('next', '')
         return_url_args = urllib.parse.unquote(return_url_args)
@@ -686,7 +688,6 @@ class RemoveReportAttachmentView(LoginRequiredMixin, View):
     http_method_names = ['post']
 
     def post(self, request, attachment_id):
-
         attachment = get_object_or_404(ReportAttachment, pk=attachment_id)
 
         logger.info(f'User {request.user} removing attachment with id {attachment_id}')
@@ -750,6 +751,7 @@ class SaveCommentView(LoginRequiredMixin, FormView):
 
 class ProFormView(LoginRequiredMixin, SessionWizardView):
     """This is the one-page internal form for CRT staff to input complaints"""
+
     def get_template_names(self):
         return 'forms/pro_template.html'
 
@@ -758,7 +760,6 @@ class ProFormView(LoginRequiredMixin, SessionWizardView):
 
         field_errors = list(map(lambda field: field.errors, context['form']))
         page_errors = [error for field in field_errors for error in field]
-
         # internal use only
         ordered_step_names = [
             'Intake',
@@ -783,6 +784,7 @@ class ProFormView(LoginRequiredMixin, SessionWizardView):
             'ordered_step_names': ordered_step_names,
             'stage_link': True,
             'submit_button': True,
+            'form_novalidate': True,
         })
 
         return context

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -424,3 +424,10 @@ select.usa-input--error {
     }
   }
 }
+
+//Since #page-errors is in a parent report_base.html, and we don't want it in the pro form, we reference it via the #id_pro_form_view-current_step sibling.
+#id_pro_form_view-current_step ~ .crt-portal-card {
+  #page-errors {
+    display: none;
+  }
+}


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1158)

## What does this change?

* Require date and intake type fields on proform
* Add error messaging
* Add date form validation

In order to correctly reflect the date on return letters, we are going to use the default crt_receipt_date on letters that CRT receives from any method other than the web form.  To improve data, we are going to require crt_receipt_date and intake_type on the pro form moving forward, and do some data validation on those forms.  

## Screenshots (for front-end PR):

![image](https://user-images.githubusercontent.com/6232068/147601969-3010ef1b-1851-4728-b9d8-ebb214184a3d.png)
![image](https://user-images.githubusercontent.com/6232068/147601985-8132e9ee-08e7-48eb-9ecf-04ac4f5dd14e.png)
![image](https://user-images.githubusercontent.com/6232068/147602084-993199e1-5162-45e0-89be-5fe3874213c6.png)
![image](https://user-images.githubusercontent.com/6232068/147602321-80fa2c24-cad6-4c65-857e-50287d7fe5df.png)
![image](https://user-images.githubusercontent.com/6232068/147602344-ea265691-8ea9-433b-a1b2-0793d24c0118.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
