### PR TITLE
Contextual form letter date

### DIFF
--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -417,7 +417,7 @@ class ResponseActionTests(TestCase):
         # Ignore crt_reciept_date it is not valid
         self.report.create_date = datetime(2020, 12, 31, 23, 0, 0)
         self.report.crt_reciept_day = None
-        self.report.intake_format = 'web'
+        self.report.intake_format = 'fax'
         self.report.save()
         response = self.client.post(
             reverse(

--- a/crt_portal/cts_forms/tests/test_data.py
+++ b/crt_portal/cts_forms/tests/test_data.py
@@ -13,7 +13,8 @@ SAMPLE_REPORT = {
     'language': 'en',
     'crt_reciept_day': 1,
     'crt_reciept_month': 12,
-    'crt_reciept_year': 2000
+    'crt_reciept_year': 2000,
+    'intake_format': 'web'
 }
 
 SAMPLE_RESPONSE_TEMPLATE = {


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1159)

## What does this change?

For reports not submitted via the web, the response letters currently have inaccurate dates.  For example, if a person submits a civil rights complaint via letter, the date used should be the date the letter was received, not the date the report was created.  This PR will use the crt_reciept_date instead of create date if 

1. crt_reciept_date exists
2. the input_format is not "web"



## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.

## Testing Instructions
+ [x] On a report with an intake_type of "web" (created through the normal report process), add a crt_reciept_date.  Check the form letters and make sure the create date is used, NOT the crt_reciept_date
+ [x] On a report with an intake_type of "web" (created through the normal report process), make sure there is no crt_reciept_date.  Check the form letters and make sure the create date is used, NOT the crt_reciept_date
+ [x] On a report with an intake_type of something other than "web" (created through the pro form), add a crt_reciept_date.  Check the form letters and make sure the crt_reciept_date is used.
+ [x] On a report with an intake_type of something other than "web" (created through the pro form), add an invalid crt_reciept_date (for example, leave the month blank).  Check the form letters and make sure the create_date is used.
