### PR TITLE
feat(location): change label to "organization name"

### DIFF
--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -1109,8 +1109,8 @@ msgstr ""
 "género o la discapacidad."
 
 #: question_text.py:30
-msgid "Location name"
-msgstr "Nombre del lugar"
+msgid "Organization name"
+msgstr "Nombre de la organización"
 
 #: question_text.py:31
 msgid "Street address 1"

--- a/crt_portal/cts_forms/locale/ko/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/ko/LC_MESSAGES/django.po
@@ -1048,8 +1048,8 @@ msgstr ""
 "가, 종교, 성별, 성적 지향, 성 정체성 또는 장애를 기반으로 해야 합니다."
 
 #: question_text.py:30
-msgid "Location name"
-msgstr "장소 이름"
+msgid "Organization name"
+msgstr "기관명"
 
 #: question_text.py:31
 msgid "Street address 1"

--- a/crt_portal/cts_forms/locale/tl/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/tl/LC_MESSAGES/django.po
@@ -1121,8 +1121,8 @@ msgstr ""
 "pagkakakilanlan ng kasarian, o kapansanan."
 
 #: question_text.py:30
-msgid "Location name"
-msgstr "Pangalan ng lugar"
+msgid "Organization name"
+msgstr "Pangalan ng organisasyon"
 
 #: question_text.py:31
 msgid "Street address 1"

--- a/crt_portal/cts_forms/locale/vi/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/vi/LC_MESSAGES/django.po
@@ -1097,8 +1097,8 @@ msgstr ""
 "khuyết tật."
 
 #: question_text.py:30
-msgid "Location name"
-msgstr "Tên địa điểm"
+msgid "Organization name"
+msgstr "Tên của tổ chức"
 
 #: question_text.py:31
 msgid "Street address 1"

--- a/crt_portal/cts_forms/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1009,8 +1009,8 @@ msgstr ""
 "性取向、性别认同或残疾的理由。"
 
 #: question_text.py:30
-msgid "Location name"
-msgstr "地点名称"
+msgid "Organization name"
+msgstr "机构名称"
 
 #: question_text.py:31
 msgid "Street address 1"

--- a/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
@@ -1020,8 +1020,8 @@ msgstr ""
 "或殘障等理由才可視為是仇恨犯罪。"
 
 #: question_text.py:30
-msgid "Location name"
-msgstr "地點名稱"
+msgid "Organization name"
+msgstr "機構名稱"
 
 #: question_text.py:31
 msgid "Street address 1"

--- a/crt_portal/cts_forms/question_text.py
+++ b/crt_portal/cts_forms/question_text.py
@@ -27,7 +27,7 @@ HATE_CRIME_HELP_TEXT = _('To be considered a hate crime, the physical harm or th
 # Location
 LOCATION_QUESTIONS = {
     'location_title': _('Where did this happen?'),
-    'location_name': _('Location name'),
+    'location_name': _('Organization name'),
     'location_address_line_1': _('Street address 1'),
     'location_address_line_2': _('Street address 2'),
     'location_city_town': _('City/town'),

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -146,7 +146,7 @@
         </td>
       </tr>
       <tr>
-        <th><label for="{{details_form.location_name.id_for_label}}">Location name</label></th>
+        <th><label for="{{details_form.location_name.id_for_label}}">Organization name</label></th>
         <td>
           <div class="details {% if details_form.errors %}display-none{% endif %}">
             <span>{{data.location_name|default:"—"}}</span>


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1094)

## What does this change?

The label "Location name" in step 3 of the report form, and in the intake report view, has been changed to "Organization name" in all languages.

## Screenshots (for front-end PR):

### "Location name" changed to "Organization name" in various places.

Step 3 of the report form:

<img width="582" alt="Screen Shot 2022-01-12 at 1 35 41 PM" src="https://user-images.githubusercontent.com/2553268/149206153-36e454b1-b01f-4912-88f6-f1c681bde859.png">

Review your report page:

<img width="680" alt="Screen Shot 2022-01-12 at 1 35 30 PM" src="https://user-images.githubusercontent.com/2553268/149206186-ab451127-9a38-43d4-aefd-edc7b3feffdd.png">

Confirmation of report page:
<img width="680" alt="Screen Shot 2022-01-12 at 1 36 10 PM" src="https://user-images.githubusercontent.com/2553268/149206225-d3d29c87-bc60-49a8-a92d-ae5f529aa144.png">

Intake specialist's report view:

<img width="620" alt="Screen Shot 2022-01-12 at 1 37 03 PM" src="https://user-images.githubusercontent.com/2553268/149206281-bfe7ad04-0a6d-4ebb-af0f-e8d6564408e3.png">

### In each language


<img width="589" alt="Screen Shot 2022-01-12 at 2 05 38 PM" src="https://user-images.githubusercontent.com/2553268/149206344-48e900e2-7fc2-4495-892f-6ec59cfc3ddd.png">
<img width="598" alt="Screen Shot 2022-01-12 at 2 06 01 PM" src="https://user-images.githubusercontent.com/2553268/149206345-2f810ff4-cf3b-442c-b449-a91daf2efe94.png">
<img width="595" alt="Screen Shot 2022-01-12 at 2 06 27 PM" src="https://user-images.githubusercontent.com/2553268/149206346-079e65ce-ceb7-4812-891f-fd120d2c49fc.png">
<img width="599" alt="Screen Shot 2022-01-12 at 2 06 48 PM" src="https://user-images.githubusercontent.com/2553268/149206347-f5452eb2-668f-4436-983a-0408bd36e332.png">
<img width="591" alt="Screen Shot 2022-01-12 at 2 07 12 PM" src="https://user-images.githubusercontent.com/2553268/149206348-ab91d9fc-6961-4b59-b003-b3f8d80f7c33.png">
<img width="593" alt="Screen Shot 2022-01-12 at 2 07 37 PM" src="https://user-images.githubusercontent.com/2553268/149206349-855b6c42-3c28-4319-8879-cd7cdd162c05.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
