### PR TITLE
Add index for default sort on index page.

### DIFF
--- a/crt_portal/cts_forms/migrations/0137_create_create_date_id_index.py
+++ b/crt_portal/cts_forms/migrations/0137_create_create_date_id_index.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+from django.db import connection
+
+def create_create_date_id_index(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute("""
+        CREATE INDEX IF NOT EXISTS cts_forms_id_create_date_idx
+            ON public.cts_forms_report USING btree
+            (create_date ASC NULLS LAST, id ASC NULLS LAST)
+        """)
+
+def revert_create_date_id_index(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            DROP INDEX cts_forms_id_create_date_idx
+        """)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cts_forms', '0136_auto_20220106_1621'),
+    ]
+    operations = [
+        migrations.RunPython(create_create_date_id_index, revert_create_date_id_index)
+    ]
+


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1184)

Even after enhancements to the related emails query, there was still room for improvement. This PR adds an index for create_date and id to the database, which is the default sort that happens.  

NOTE if you do a sort from the index table, it will still be slow because the alternate sorts are not indexed.  We will see how this improvement works in production, and if it offers improvement, we can consider adding other indexes.  

Before: search takes 344ms
<img width="1559" alt="2" src="https://user-images.githubusercontent.com/6232068/150009891-95d2346a-7c4c-4e60-b342-fb5cab56fa5e.png">

After search takes 2.7ms (> 100x faster!)
<img width="1569" alt="3" src="https://user-images.githubusercontent.com/6232068/150009980-fe27d07d-d599-42af-bc5b-1a81a80d1706.png">


## Checklist:

+ [x] Run 

```
docker-compose run web python /code/crt_portal/manage.py makemigrations
docker-compose run web python /code/crt_portal/manage.py migrate
```

+ [ ] Do some default searches on the index page (EG, load the page).  Make sure it is faster.  
+ [ ] Search for a given email address.  Make sure it works.  
+ [ ] Click the sort options on the table.  Make sure they function, and are not slower than they used to be (eyeballing it).
+ [ ] Open several detail reports, make sure report counts are right and that the pages are not running slower than normal.
+ [ ] Open several detail reports, make sure report counts are right and that the pages are not running slower than normal.
+ [ ] Revert the change by running  
```docker-compose run web python /code/crt_portal/manage.py migrate cts_forms 0136_auto_20220106_1621``` 
Make sure that everything works as expected.
+ [ ] rerun 

``` docker-compose run web python /code/crt_portal/manage.py makemigrations
docker-compose run web python /code/crt_portal/manage.py migrate
```

Make sure it is fast again.


### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
