### PR TITLE
Update to Postgres 11 in local and CI/CD environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,12 @@ jobs:
         environment: # environment variables for primary container
           PIPENV_VENV_IN_PROJECT: true
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
-      # CircleCI PostgreSQL images available at: https://hub.docker.com/r/circleci/postgres/
-      - image: postgres:10.1-alpine
+      # CircleCI PostgreSQL images available at: https://hub.docker.com/_/postgres
+      - image: postgres:11.14-alpine
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
+          POSTGRES_PASSWORD: password
     steps:
       - checkout
       # Removing chache for now, we either need to build our image or move the cache location
@@ -201,11 +202,12 @@ jobs:
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
           CF_MANIFEST: manifest_dev.yaml
           CF_SPACE: dev
-      # CircleCI PostgreSQL images available at: https://hub.docker.com/r/circleci/postgres/
-      - image: postgres:10.1-alpine
+      # CircleCI PostgreSQL images available at: https://hub.docker.com/_/postgres
+      - image: postgres:11.14-alpine
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
+          POSTGRES_PASSWORD: password
     steps:
       - checkout
       # removing as we deal with caching problem
@@ -258,11 +260,12 @@ jobs:
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
           CF_MANIFEST: manifest_staging.yaml
           CF_SPACE: staging
-      # CircleCI PostgreSQL images available at: https://hub.docker.com/r/circleci/postgres/
-      - image: postgres:10.1-alpine
+      # CircleCI PostgreSQL images available at: https://hub.docker.com/_/postgres
+      - image: postgres:11.14-alpine
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
+          POSTGRES_PASSWORD: password
     steps:
       - checkout
       - restore_cache:
@@ -315,11 +318,12 @@ jobs:
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
           CF_MANIFEST: manifest_prod.yaml
           CF_SPACE: prod
-      # CircleCI PostgreSQL images available at: https://hub.docker.com/r/circleci/postgres/
-      - image: postgres:10.1-alpine
+      # CircleCI PostgreSQL images available at: https://hub.docker.com/_/postgres
+      - image: postgres:11.14-alpine
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
+          POSTGRES_PASSWORD: password
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ Clone the project locally:
 
     git clone git@github.com:usdoj-crt/crt-portal.git
 
-In the top level directory create a .env file in the top of your directory and set `SECRET_KEY` to a long, random string.
+In the top level directory create a .env file in the top of your directory and add the following environment variables. Set `SECRET_KEY` to a long, random string and `POSTGRES_PASSWORD` to any string you like.
 
-    SECRET_KEY=''
+    SECRET_KEY=this_is_a_long_random_string
+    POSTGRES_PASSWORD=rando_pw
 
 To build the project
     You will need to build the project for the first time and when there are package updates to apply.

--- a/crt_portal/crt_portal/local_settings.py
+++ b/crt_portal/crt_portal/local_settings.py
@@ -7,6 +7,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'postgres',
         'USER': 'postgres',
+        'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
         'HOST': 'db',  # set in docker-compose.yml
         'PORT': 5432  # default postgres port
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,19 @@ version: "3.7"
 
 services:
   db:
-    image: postgres:10.1-alpine
+    image: postgres:11.14-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    ports:
+      - 5432:5432
   web:
     platform: linux/amd64
     environment:
       - ENV=LOCAL
       - SECRET_KEY=${SECRET_KEY}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - TMS_AUTH_TOKEN=${TMS_AUTH_TOKEN}
       - TMS_WEBHOOK_ALLOWED_CIDR_NETS=${TMS_WEBHOOK_ALLOWED_CIDR_NETS}
       - RESTRICT_EMAIL_RECIPIENTS_TO=${RESTRICT_EMAIL_RECIPIENTS_TO}


### PR DESCRIPTION
Part of issue https://github.com/usdoj-crt/crt-portal-management/issues/1172.

## What does this change?

We have recently confirmed that staging and production instances of our portal runs Postgres v11. This updates local Docker images and CI/CD images to Postgres v11 so that we're running the same database versions as our cloud environments.

### Manual update notes.

- While previous Postgres versions allowed databases to be set up and accessed without a password, Postgres v11+ **requires** that a database password be set. We can force-override this requirement, but Postgres will output dangerous-sounding security warnings. I'd rather not have Postgres raise an alarm when we're not at risk, so instead, we'll go ahead and specify the `POSTGRES_PASSWORD` with any string. You can add this to the `.env` file in the root of your project repository. (See also the updated README.)
- The `docker-compose.yml` configuration reuses the `postgres_data` volume which will have previously been on Postgres 10. You have two options:
  - Delete the `postgres_data` volume and run `docker-compose up --build` to re-initialize the volume with Postgres 11. You will need to recreate your data, including the superuser and records.
  - Upgrade the `postgres_data` volume. [postgres dbs do not automatically upgrade. let me know if we need instructions on how to do this.]
  - A third option (for testing) is to momentarily use a new volume other than `postgres_data`.

**This change does not affect the dev, staging, or production instances.**

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
