### PR TITLE
Remove CSS from Pro Form Page Errors

### DIFF
--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -424,10 +424,3 @@ select.usa-input--error {
     }
   }
 }
-
-//Since #page-errors is in a parent report_base.html, and we don't want it in the pro form, we reference it via the #id_pro_form_view-current_step sibling.
-#id_pro_form_view-current_step ~ .crt-portal-card {
-  #page-errors {
-    display: none;
-  }
-}


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1174)

## What does this change?

When adding server side validation to the pro form, some page error html was breaking styling. In the interests of time, I wrote some brittle css to remove the html, and created a PR to go back and pay down the technical debt later.  

Going back to work on it, the CSS does not seem to be doing anything.  I cannot get that problematic unneeded html to display.  

(in pro_template.html. Notice the display-none that is already there)
```
      <section id="page-errors" class="display-none page-errors margin-bottom-2" role="alert" aria-live="assertive">
      {{ num_page_errors }} error{{ num_page_errors|pluralize }}: {{ page_errors_desc }}
      </section>
```

It's a bit of a mystery, but my current thinking is that updates to the USWDS fixed it. Either way, the bad css is doing nothing. 

I removed the bad css, and tested the code.   All tests pass, and everything seems to be working.  Let me know if you all see anything.  

## Screenshots (for front-end PR):

## Checklist:

+ [x] Go to the pro form, and create a validation error (easiest way is to click submit without filling in anything.  Make sure you do not see page errors at the top of the page.  

### **This:**
![image](https://user-images.githubusercontent.com/6232068/150869636-85675304-67e8-4f77-9d84-d52359c11a6d.png)

### **Not this:**
![image](https://user-images.githubusercontent.com/6232068/150869688-343d9d33-5c6b-4a66-b700-b147bcb32477.png)

+ [x] Go to the Report page, and on each page, create a validation error (easiest way is to click submit without filling in anything).  Make sure you do see page errors at the top of the page.  

### **You should see page level errors like this on every section of the report:**
![image](https://user-images.githubusercontent.com/6232068/150869950-41d35907-dc12-413a-8fb2-9e05459295c5.png)



### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
