### PR TITLE
Advanced search functionality (aka "search v2.0")

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -1,5 +1,6 @@
 # Class to handle filtering Reports by supplied query params,
 # provided they are valid filterable model properties.
+import re
 import urllib.parse
 from datetime import datetime
 
@@ -172,6 +173,10 @@ def _make_search_query(search_text):
         search_text = search_text.replace(' AND ', ' & ')
         search_text = search_text.replace(' OR ', ' | ')
         search_text = search_text.replace(' -', ' !')
+        # In between search tokens that don't have operators, insert &
+        # e.g. "foo -(bar | baz qux)" => "foo & !(bar | baz & qux)"
+        search_text = re.sub('([a-zA-Z)"]) ([a-zA-Z("!])', r'\1 & \2', search_text)
+        # Note: the only search type we don't handle here are exact phrase quotes.
         with connection.cursor() as cursor:
             try:
                 # This can still create syntax errors, so we ask the db to validate the

--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -128,8 +128,8 @@ def report_filter(querydict):
             elif filter_options[field] == '__gte':
                 kwargs[field] = querydict.getlist(field)
             elif filter_options[field] == 'violation_summary':
-                combined_or_search = _combine_term_searches_with_or(filter_list)
-                qs = qs.filter(violation_summary_search_vector=combined_or_search)
+                search_query = querydict.getlist(field)[0]
+                qs = qs.filter(violation_summary_search_vector=_make_search_query(search_query))
     qs = qs.filter(**kwargs)
     return qs, filters
 
@@ -162,15 +162,6 @@ def dashboard_filter(querydict):
     else:
         return filters, []
     return filters, filtered_actions
-
-
-def _combine_term_searches_with_or(terms):
-    """Create a CombinedSearchQuery of all received search terms"""
-    combined_search = _make_search_query(terms.pop())
-    for term in terms:
-        combined_search = combined_search | _make_search_query(term)
-
-    return combined_search
 
 
 def _make_search_query(search_text):

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -50,8 +50,9 @@
         </span>
       </span>
     </p>
-    <div class="intake-filters">
+    <div class="intake-filters search-filter-container">
       {% include 'forms/complaint_view/index/filters/violation_summary_filter.html' %} <!-- Personal description -->
+      <span id="search-notification"></span>
     </div>
 
     <div class="text-right">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -50,9 +50,13 @@
         </span>
       </span>
     </p>
-    <div class="intake-filters search-filter-container">
+    <div class="intake-filters">
       {% include 'forms/complaint_view/index/filters/violation_summary_filter.html' %} <!-- Personal description -->
-      <span id="search-notification"></span>
+    </div>
+    <div class="usa-alert usa-alert--error usa-alert--slim" id="search-notification">
+      <div class="usa-alert__body">
+        <em class="usa-alert__text"></em>
+      </div>
     </div>
 
     <div class="text-right">

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -64,12 +64,6 @@ class ReportFilterTests(TestCase):
         reports, _ = report_filter(QueryDict('violation_summary=plane'))
         self.assertEqual(reports.count(), 1)
 
-        # Undocumented feature: multiple search query params in URL becomes an OR
-        reports, _ = report_filter(QueryDict('violation_summary=plane&violation_summary=truck'))
-        self.assertEqual(reports.count(), 3)
-        for report in reports:
-            self.assertEqual('plane' in report.violation_summary or 'truck' in report.violation_summary, True)
-
     def test_or_search(self):
         reports, _ = report_filter(QueryDict('violation_summary=boat%20OR%20hovercraft'))
         self.assertEqual(reports.count(), 4)

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -127,6 +127,10 @@ class ReportFilterTests(TestCase):
         # with truck" is allowed
         self.assertEqual(reports.count(), 2)
 
+        # Should also assume AND
+        reports, _ = report_filter(QueryDict('violation_summary=boat%20-(fishing%20AND%20hovercraft)'))
+        self.assertEqual(reports.count(), 2)
+
     def test_exact_phrase_search(self):
         reports, _ = report_filter(QueryDict('violation_summary="fishing boat"'))
         self.assertEqual(reports.count(), 2)

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -455,16 +455,18 @@
 
   function validateTextSearch(el) {
     var buttonEl = document.getElementById('apply-filters-button');
-    var textEl = document.getElementById('search-notification');
+    var alertEl = document.getElementById('search-notification');
+    var textEl = alertEl.querySelector('.usa-alert__text');
     var value = el.value;
     if (value.includes('(') && value.includes(')') && value.includes('"')) {
       buttonEl.setAttribute('disabled', '');
-      textEl.textContent = 'Search query cannot contain both parentheses grouping and quoted text';
-      textEl.style.display = 'inline-block';
+      textEl.textContent =
+        '(Parentheses) and "quotation marks" cannot be used together in the same keyword search';
+      alertEl.style.display = 'inline-block';
     } else {
       buttonEl.removeAttribute('disabled');
       textEl.textContent = '';
-      textEl.style.display = 'none';
+      alertEl.style.display = 'none';
     }
   }
 

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -453,6 +453,31 @@
     });
   }
 
+  function validateTextSearch(el) {
+    var buttonEl = document.getElementById('apply-filters-button');
+    var textEl = document.getElementById('search-notification');
+    var value = el.value;
+    if (value.includes('(') && value.includes(')') && value.includes('"')) {
+      buttonEl.setAttribute('disabled', '');
+      textEl.textContent = 'Search query cannot contain both parentheses grouping and quoted text';
+      textEl.style.display = 'inline-block';
+    } else {
+      buttonEl.removeAttribute('disabled');
+      textEl.textContent = '';
+      textEl.style.display = 'none';
+    }
+  }
+
+  function initValidateTextSearch() {
+    var inputEl = document.getElementById('id_violation_summary');
+    // Validate immediately, in case field is pre-populated
+    validateTextSearch(inputEl);
+    // Then add an event listener to re-validate when input changes
+    inputEl.addEventListener('input', function(event) {
+      validateTextSearch(event.target);
+    });
+  }
+
   // Bootstrap the filter code's data persistence and
   // instantiate the controller that manages the UI components / views
   function init() {
@@ -468,6 +493,7 @@
     mutateFilterDataWithUpdates(filterDataModel, filterUpdates);
 
     filterController();
+    initValidateTextSearch();
   }
 
   window.addEventListener('DOMContentLoaded', init);

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -761,21 +761,10 @@ ul.messages {
   }
 }
 
-.search-filter-container {
-  width: 100%;
+#search-notification {
+  display: none;
+  margin-top: -1rem;
   margin-bottom: 2rem;
-  display: flex;
-  flex-direction: row;
-
-  .crt-textbox.summary_input {
-    margin-bottom: 0;
-  }
-
-  #search-notification {
-    display: inline-block;
-    font-style: italic;
-    color: red;
-  }
 }
 
 /* Match combo box input styling with other filters */

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -761,6 +761,23 @@ ul.messages {
   }
 }
 
+.search-filter-container {
+  width: 100%;
+  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: row;
+
+  .crt-textbox.summary_input {
+    margin-bottom: 0;
+  }
+
+  #search-notification {
+    display: inline-block;
+    font-style: italic;
+    color: red;
+  }
+}
+
 /* Match combo box input styling with other filters */
 .crt-combo-box-filter {
   width: 15rem; /* Hard code width to fix situation where input would expand when an item is selected */


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1173)

## What does this change?

Updates the "personal description" search filter to allow new search operators provided by PostgreSQL's "websearch" functionality, with caveats.

Here's what we can do in the search box:

- **Existing behavior:**
  - `AND` (default behavior). Searches for `mask vaccine` or `mask AND vaccine` return results containing both words.
  - `OR`. Searches for `mask OR vaccine` return results containing either word.
- **New behavior:**
  - Negation with `-` in front of a word. Searches for `mask -vaccine` return results containing "mask" but not "vaccine."
  - Adjacent word search with quotation marks. Searches for `"mask vaccine"` return results where the words must be in the same order. (See also caveats.)
  - Grouping with parentheses. Searches for `mask AND (vaccine OR shot)` allow changing the order of operations for search operators. This returns results containing both "mask" and "vaccine", along with results containing both "mask" and "shot". (See also caveats.)

### Caveats (for end users)

**Adjacent word search ignores "stop" words.** (Stop words are common English words such as "a" or "the", which include prepositions and articles.) I originally called this "exact phrase search" but that's not exactly correct because that would imply a search for "royale with cheese" must include those same three words in that order. In actuality, PostgreSQL will also return a result containing "royale and cheese" as valid. This behavior can create unexpected or useful results, depending on the use case.

**Grouping cannot be nested.** It's conceivable that someone might want to construct a query such as `mask AND (vaccine OR (shot AND pfizer))` but the query will be flatted into one set of parentheses. This is a limitation of the PostgreSQL search functionality.

**Adjacent word search and grouping cannot be used in the same query.** Someone might want to construct a query such as `mask AND (vaccine OR "covid shot")` but this will not work. ~~The search results drop the parentheses and will prioritize the adjacent word search.~~ (EDIT: Search results may be unexpected, it's not always obvious what will take priority.) This is also a limitation of PostgreSQL search functionality, where a workaround is theoretically possible but outside of the scope of this ticket.

### Technical notes

PostgreSQL's "websearch" functionality actually does not allow the grouping of search terms with parentheses, something that I did not catch until after we were able to put everything together after the Django and PostgreSQL updates. This misunderstanding occurred because the [Django documentation on SearchQuery](https://docs.djangoproject.com/en/3.2/ref/contrib/postgres/search/#searchquery) implied in their examples that the parentheses would be meaningful operators in websearch, however, [PostgreSQL only supports grouping in raw search queries, not websearch](https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES).

The current workaround to achieve our desired result is to do a simple string replacement on incoming search queries if a set of parentheses is detected. This converts incoming web search syntax into raw search syntax so that the results contain the grouping we want.

Because of this string replacement technique, I don't have a way to also handle adjacent word search (with quoted text). There are ways of doing this, such as parsing incoming queries into an abstract syntax tree and re-assembling a raw text search query, but I decided that given our original scope (to support grouping of queries) that it would not be feasible to pursue that strategy during this sprint.

Websearch is still useful for us, as other forms of text search (such as adjacent words) will be automatically parsed, and its ability to gracefully handle malformed search syntax. Raw search is very picky about syntax and won't hesitate to throw errors if the syntax isn't well-formed.

This means, in cases where we provide a raw search query that cannot be parsed, we continue to fall back on websearch functionality. This allows us to catch syntax errors. Even if the search results may not be what a user expects, it'll be better than throwing up an error page, and gives the user an opportunity to refine their query to something that might return better results.

### Deprecations

The undocumented workaround for creating an "OR" query by adding additional `?violation_summary=` parameters in a URL string has been removed, in favor of using the "OR" operator in the search query. Users who were depending on this previous functionality should be encouraged to revise bookmarks or links so that they are using the currently documented search functionality.

## Screenshots (for front-end PR):

n/a

## Checklist:

I would prefer if people try testing search queries on their own to try and break this, instead of running through a sequence of tests I know will work. But to get started, here's what I would try:

- [ ] Using the pro-form, create a series of reports with short personal descriptions:
    - "mask"
    - "mask vaccine"
    - "mask shot"
    - "mask vaccine shot"
    - "vaccine shot"
- [ ] Test query `mask AND (vaccine OR shot)` => 3 results.
- [ ] Test query `mask -shot` => 2 results.
- [ ] Test query `"vaccine shot"` => 2 results.
- [ ] Test query `mask -"vaccine shot"` => 3 results.
- [ ] Test query `mask -(vaccine OR shot)` => 1 result.


### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
