### PR TITLE
Add custom label on location_name in proform.

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -937,6 +937,7 @@ class ProForm(
         self.fields['crt_reciept_month'].required = True
         self.fields['crt_reciept_year'].label = DATE_QUESTIONS['last_incident_year']
         self.fields['crt_reciept_year'].required = True
+        self.fields['location_name'].label = LOCATION_QUESTIONS['location_name']
         if 'violation_summary' in self.fields:
             self.fields['violation_summary'].widget.attrs['class'] = 'usa-textarea word-count-500'
             self.label_suffix = ''


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1196)

## What does this change?

This is a continuation of card #1094 changing a label name of a field on the pro form.  

## Screenshots (for front-end PR):

## Checklist:

+ [x] Go to the proform, make sure the "Incident location" section looks like this (has "Organization name" as the first field label.  
<img width="705" alt="image" src="https://user-images.githubusercontent.com/6232068/153257808-74e8cdbe-3856-40a0-b535-86d35ed82e2a.png">


### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
