### PR TITLE
Il/pol outgoing response language 1195

### DIFF
--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -212,6 +212,7 @@ SECTION_CHOICES_TL = (
     ('FCS', 'Pederal na Koordinasyon at Pagsunod'),
     ('HCE', 'Pabahay at Pagpapatupad ng Sibil'),
     ('IER', 'Imigrasyon at Mga Karapatan ng Empleyado'),
+    ('POL', 'Patakaran'),    # Added to support SVI related report
     ('SPL', 'Espesyal na Paglilitis'),
     ('VOT', 'Pagboto'),
 )

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -176,6 +176,7 @@ SECTION_CHOICES = (
 )
 # for form letter translations only. Note that these choices
 # technically differ from section choices since they have "de" (of).
+#  Spanish
 SECTION_CHOICES_ES = (
     ('ADM', 'Administrativa'),
     ('APP', 'de Apelación'),
@@ -190,6 +191,8 @@ SECTION_CHOICES_ES = (
     ('SPL', 'de Litigios Especiales'),
     ('VOT', 'de Votación'),
 )
+
+#  Korean
 SECTION_CHOICES_KO = (
     ('ADM', '행정'),
     ('CRM', '형사'),
@@ -199,10 +202,12 @@ SECTION_CHOICES_KO = (
     ('FCS', '연방 조정 및 규정준수'),
     ('HCE', '주택 및 민법 시행'),
     ('IER', '이민 및 직원 권리'),
+    ('POL', '정책 섹션'),    # Added to support SVI related report form letters
     ('SPL', '특별 소송'),
     ('VOT', '투표'),
 )
 
+#  Tagalog
 SECTION_CHOICES_TL = (
     ('ADM', 'Pang-Administratibo'),
     ('CRM', 'Kriminal'),

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -225,7 +225,7 @@ SECTION_CHOICES_VI = (
     ('FCS', 'Ban Tuân Thủ và Điều Phối Liên Bang'),
     ('HCE', 'Ban Gia Cư và Thực Thi Dân Sự'),
     ('IER', 'Ban  Di Trú và Quyền của Người Lao Động'),
-    ('POL', 'Policy'),    # Added to support SVI related report
+    ('POL', 'Ban Phần Chính Sách'),    # Added to support SVI related report
     ('SPL', 'Ban Tố Tụng Đặc Biệt'),
     ('VOT', 'Ban Bầu Cử'),
 )

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -186,6 +186,7 @@ SECTION_CHOICES_ES = (
     ('FCS', 'de Coordinación y Cumplimiento Federal'),
     ('HCE', 'de Coordinación y Cumplimiento Federal'),
     ('IER', 'de Derechos de Inmigrantes y Empleados'),
+    ('POL', 'de Políticas'),    # Added to support SVI related report form letter
     ('SPL', 'de Litigios Especiales'),
     ('VOT', 'de Votación'),
 )

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -238,6 +238,7 @@ SECTION_CHOICES_ZH_HANT = (
     ('FCS', '聮邦恊调與遵守'),
     ('HCE', '住房和民事执法'),
     ('IER', '移民與雇員權利'),
+    ('POL', '政策部分'),    # Added to support SVI related report form letter
     ('SPL', '特别訴訟'),
     ('VOT', '投票'),
 )

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -225,10 +225,12 @@ SECTION_CHOICES_VI = (
     ('FCS', 'Ban Tuân Thủ và Điều Phối Liên Bang'),
     ('HCE', 'Ban Gia Cư và Thực Thi Dân Sự'),
     ('IER', 'Ban  Di Trú và Quyền của Người Lao Động'),
+    ('POL', 'Policy'),    # Added to support SVI related report
     ('SPL', 'Ban Tố Tụng Đặc Biệt'),
     ('VOT', 'Ban Bầu Cử'),
 )
 
+#  Chinese Traditional
 SECTION_CHOICES_ZH_HANT = (
     ('ADM', '行政管理'),
     ('CRM', '刑事'),
@@ -243,6 +245,7 @@ SECTION_CHOICES_ZH_HANT = (
     ('VOT', '投票'),
 )
 
+#  Chinese Simplified
 SECTION_CHOICES_ZH_HANS = (
     ('ADM', '行政管理'),
     ('CRM', '刑事'),
@@ -252,6 +255,7 @@ SECTION_CHOICES_ZH_HANS = (
     ('FCS', '联邦协调与遵守'),
     ('HCE', '住房和民事执法'),
     ('IER', '移民与雇员权利'),
+    ('POL', '政策部分'),    # Added to support SVI related report form letter
     ('SPL', '特别诉讼'),
     ('VOT', '投票'),
 )


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1195)

## What does this change?
POL section form letter dropdown available in Spanish, Simplified Chinese, Traditional Chinese, Vietnamese, Tagalog and Korean.

## Screenshots (for front-end PR):

## Checklist:
Policy section displayed on form letter subject:
  Go to report detail assigned to POL section
  Select contact complainant button
  Select any language
  Subject line displayed with Policy Section in respective to language selection.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
