### PR TITLE
fix(landing): external link popup for national human trafficking hotline

### DIFF
--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -230,9 +230,7 @@
                   <a href="./hate-crime-human-trafficking">{% trans "Get help for hate crimes" %}</a>
                 </div>
                 <div hidden id="crt-landing--humantrafficking">
-                  <a aria-label="{% trans "Were you forced to work against your will?" %} {% trans "Get help from the National Human Trafficking Hotline" %}" href=" https://humantraffickinghotline.org/">{% trans "Get help from the National Human Trafficking Hotline" %}
-                    <img src="{% static 'img/external_link.svg'%}" alt="external link" class="icon" />
-                  </a>
+                  <a aria-label="{% trans "Were you forced to work against your will?" %} {% trans "Get help from the National Human Trafficking Hotline" %}" class="external-link--blue external-link--popup" href=" https://humantraffickinghotline.org/">{% trans "Get help from the National Human Trafficking Hotline" %}</a>
                 </div>
               </div>
               <div class="grid-row grid-gap">


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1189)

## What does this change?

Adds an external link popup to the "National Human Trafficking Hotline" on the landing page.

We discussed removing external link popups from the site in accordance with USWDS linking guidelines (see linked issue for more information), but this policy is being reconsidered across all of the justice.gov domain. Until that happens, we should be internally consistent with how we treat external links.

## Screenshots (for front-end PR):

![Feb-16-2022 13-39-25](https://user-images.githubusercontent.com/2553268/154334078-aa66fde6-b9a4-4d1b-85cf-df6eb1d525b4.gif)


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
