### PR TITLE
fix(popup): break long links

### DIFF
--- a/crt_portal/static/sass/custom/modal.scss
+++ b/crt_portal/static/sass/custom/modal.scss
@@ -225,6 +225,12 @@ body.is-modal {
     margin-top: 0.5rem;
   }
 
+  /* Break long links */
+  #external-link--address {
+    word-wrap: break-word;
+    word-break: break-word;
+  }
+
   #external-link--cancel {
     &:focus {
       color: color($theme-color-primary-darker) !important;


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1199)

## What does this change?

Long links should break instead of overflowing from modal.

## Screenshots (for front-end PR):

<img width="568" alt="Screen Shot 2022-02-17 at 1 43 36 PM" src="https://user-images.githubusercontent.com/2553268/154549551-f86c5cc9-19d1-49a0-9695-35683631550c.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
