### PR TITLE
Response templates fetched via API

### DIFF
--- a/crt_portal/api/serializers.py
+++ b/crt_portal/api/serializers.py
@@ -11,7 +11,12 @@ class ReportSerializer(serializers.ModelSerializer):
         model = Report
         fields = ['url', 'pk', 'viewed']
 
-class ResponseTemplateSerializer(serializers.HyperlinkedModelSerializer):
+
+class ResponseTemplateSerializer(serializers.ModelSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name='api:response-detail',
+    )
+
     class Meta:
         model = ResponseTemplate
-        fields = ['title', 'subject', 'body', 'language']
+        fields = ['url', 'pk', 'title', 'subject', 'body', 'language', 'is_html']

--- a/crt_portal/api/serializers.py
+++ b/crt_portal/api/serializers.py
@@ -1,4 +1,4 @@
-from cts_forms.models import Report
+from cts_forms.models import Report, ResponseTemplate
 from rest_framework import serializers
 
 
@@ -10,3 +10,8 @@ class ReportSerializer(serializers.ModelSerializer):
     class Meta:
         model = Report
         fields = ['url', 'pk', 'viewed']
+
+class ResponseTemplateSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = ResponseTemplate
+        fields = ['title', 'subject', 'body', 'language']

--- a/crt_portal/api/urls.py
+++ b/crt_portal/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
-from api.views import ReportList, ReportDetail, api_root
+from api.views import ResponseList, ReportList, ReportDetail, api_root
 
 app_name = 'api'
 
@@ -8,6 +8,7 @@ urlpatterns = [
     path('', api_root, name='api-base'),
     path('reports/', ReportList.as_view(), name='report-list'),
     path('reports/<int:pk>/', ReportDetail.as_view(), name='report-detail'),
+    path('responses/', ResponseList.as_view(), name='response-list'),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/crt_portal/api/urls.py
+++ b/crt_portal/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
-from api.views import ResponseList, ReportList, ReportDetail, api_root
+from api.views import ResponseList, ResponseDetail, ReportList, ReportDetail, api_root
 
 app_name = 'api'
 
@@ -9,6 +9,7 @@ urlpatterns = [
     path('reports/', ReportList.as_view(), name='report-list'),
     path('reports/<int:pk>/', ReportDetail.as_view(), name='report-detail'),
     path('responses/', ResponseList.as_view(), name='response-list'),
+    path('responses/<int:pk>/', ResponseDetail.as_view(), name='response-detail'),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -1,4 +1,4 @@
-from cts_forms.models import Report
+from cts_forms.models import Report, ResponseTemplate
 from rest_framework import generics
 from rest_framework import permissions
 from rest_framework.decorators import api_view
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from cts_forms.views import mark_report_as_viewed
 from rest_framework.permissions import IsAuthenticated
-from api.serializers import ReportSerializer
+from api.serializers import ReportSerializer, ResponseTemplateSerializer
 from django.contrib.auth.decorators import login_required
 
 REST_FRAMEWORK = {
@@ -21,6 +21,7 @@ REST_FRAMEWORK = {
 def api_root(request, format=None):
     return Response({
         'reports': reverse('api:report-list', request=request, format=format),
+        'responses': reverse('api:response-list', request=request, format=format)
     })
 
 
@@ -57,3 +58,12 @@ class ReportDetail(generics.RetrieveUpdateAPIView):
             if not report.viewed:
                 mark_report_as_viewed(report, request.user)
         return self.update(request, *args, **kwargs)
+
+
+class ResponseList(generics.ListAPIView):
+    """
+    API endpoint that allows responses to be viewed.
+    """
+    queryset = ResponseTemplate.objects.all()
+    serializer_class = ResponseTemplateSerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1249,10 +1249,7 @@ class ResponseActions(Form):
         templates = ResponseTemplate.objects.order_by('title')
         data = {
             template.id: {
-                'description': template.render_subject(self.report),
-                'content': template.render_body(self.report),
                 'language': template.language,
-                'is_html': template.is_html,
             }
             for template in templates
         }

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template.html
@@ -8,6 +8,7 @@
   {% csrf_token %}
   <input type="hidden" value="{{ return_url_args }}" name="next" id="modal_next" />
   <input type="hidden" value="{{ index }}" name="index" id="index" />
+  <input type="hidden" value="{{ data.id }}" name="id" id="template-report-id" />
   <div id="intake_template" hidden>
     <div class="modal-wrapper intake-template--modal">
       <div class="modal-content modal-content--large">

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -378,15 +378,11 @@ class ResponseActionTests(TestCase):
         # Add datetime without timezone to make sure its converted to EST
         self.report.create_date = datetime(2020, 12, 31, 23, 0, 0)
         self.report.save()
-        response = self.client.post(
+        response = self.client.get(
             reverse(
-                'crt_forms:crt-forms-response',
-                kwargs={'id': self.report.id},
-            ),
-            {
-                'next': '?per_page=15',
-            },
-            follow=True
+                'api:response-detail',
+                kwargs={'pk': 1},
+            ) + f"?report_id={self.report.id}"
         )
         self.assertEqual(response.status_code, 200)
         content = str(response.content)
@@ -398,15 +394,11 @@ class ResponseActionTests(TestCase):
         self.report.create_date = datetime(2020, 12, 31, 23, 0, 0)
         self.report.intake_format = 'web'
         self.report.save()
-        response = self.client.post(
+        response = self.client.get(
             reverse(
-                'crt_forms:crt-forms-response',
-                kwargs={'id': self.report.id},
-            ),
-            {
-                'next': '?per_page=15',
-            },
-            follow=True
+                'api:response-detail',
+                kwargs={'pk': 1},
+            ) + f"?report_id={self.report.id}"
         )
         self.assertEquals(response.status_code, 200)
         content = str(response.content)
@@ -419,15 +411,11 @@ class ResponseActionTests(TestCase):
         self.report.crt_reciept_day = None
         self.report.intake_format = 'fax'
         self.report.save()
-        response = self.client.post(
+        response = self.client.get(
             reverse(
-                'crt_forms:crt-forms-response',
-                kwargs={'id': self.report.id},
-            ),
-            {
-                'next': '?per_page=15',
-            },
-            follow=True
+                'api:response-detail',
+                kwargs={'pk': 1},
+            ) + f"?report_id={self.report.id}"
         )
         self.assertEquals(response.status_code, 200)
         content = str(response.content)
@@ -439,15 +427,11 @@ class ResponseActionTests(TestCase):
         self.report.create_date = datetime(2020, 12, 31, 23, 0, 0)
         self.report.intake_format = 'fax'
         self.report.save()
-        response = self.client.post(
+        response = self.client.get(
             reverse(
-                'crt_forms:crt-forms-response',
-                kwargs={'id': self.report.id},
-            ),
-            {
-                'next': '?per_page=15',
-            },
-            follow=True
+                'api:response-detail',
+                kwargs={'pk': 1},
+            ) + f"?report_id={self.report.id}"
         )
         self.assertEquals(response.status_code, 200)
         content = str(response.content)

--- a/crt_portal/static/js/form_letter.js
+++ b/crt_portal/static/js/form_letter.js
@@ -86,24 +86,32 @@
     send_email.setAttribute('disabled', 'disabled');
   };
 
-  var description = document.getElementById('intake_description');
-  var options = document.getElementById('intake_select');
-  options.onchange = function(event) {
+  const description = document.getElementById('intake_description');
+  const options = document.getElementById('intake_select');
+  const reportId = document.getElementById('template-report-id').value;
+  options.addEventListener('change', function(event) {
     event.preventDefault();
-    var index = event.target.selectedIndex;
-    var option = event.target.options[index];
+    const index = event.target.selectedIndex;
+    const option = event.target.options[index];
+    const value = event.target.value;
+    window
+      .fetch('/api/responses/' + value + '/?report_id=' + reportId)
+      .then(function(response) {
+        return response.json();
+      })
+      .then(function(data) {
+        description.innerHTML = data.subject || '(select a response template)';
+        if (data.is_html) {
+          letter.hidden = true;
+          letter_html.hidden = false;
+          letter_html.innerHTML = marked.parse(data.body || '');
+        } else {
+          letter_html.hidden = true;
+          letter.hidden = false;
+          letter.innerHTML = data.body || '';
+        }
+      });
     addReferralAddress(option);
-    description.innerHTML = option.dataset['description'] || '(select a response template)';
-    var isHtml = option.dataset['is_html'] !== undefined;
-    if (isHtml) {
-      letter.hidden = true;
-      letter_html.hidden = false;
-      letter_html.innerHTML = marked.parse(option.dataset['content'] || '');
-    } else {
-      letter_html.hidden = true;
-      letter.hidden = false;
-      letter.innerHTML = option.dataset['content'] || '';
-    }
     if (index >= 1) {
       copy.removeAttribute('disabled');
       print.removeAttribute('disabled');
@@ -113,7 +121,7 @@
     } else {
       reset();
     }
-  };
+  });
 
   var setLanguageCookie = function(lang) {
     document.cookie = 'form-letter-language' + '=' + lang;


### PR DESCRIPTION
## What does this change?

We wanted to prove out the value of Django Rest Framework in another low-hanging fruit context, loading response templates dynamically in the "Contact complainant" modal. This cuts down on pre-loading every response template in a complaint view, saving about 300 KB of HTML (cutting the HTML size down by 60-75%).

Loading time for each letter locally should be fast (~100-200ms) but testing this on Cloud.gov infrastructure will give us more accurate results (and hopefully even better response times).


## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
