### PR TITLE
Set primary_statute to none when assigned section is changed.

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1544,7 +1544,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         # if section is changed, override assignee and status
         # explicitly, even if they are set by the user.
         if 'assigned_section' in updates:
-            updates['primary_statute'] = ''
+            updates['primary_statute'] = None
             updates['assigned_to'] = ''
             updates['status'] = 'new'
 

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -375,6 +375,7 @@ class Report(models.Model):
         """
         self.assigned_to = None
         self.status = 'new'
+        self.primary_statute = None
 
     @cached_property
     def related_reports(self):

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -982,7 +982,7 @@ class BulkActionsFormTests(TestCase):
 
         updates = form.get_updates()
         self.assertEqual(updates['assigned_section'], 'APP')
-        self.assertEqual(updates['primary_statute'], '')
+        self.assertEqual(updates['primary_statute'], None)
         self.assertEqual(updates['assigned_to'], '')
         self.assertEqual(updates['status'], 'new')
 
@@ -1010,7 +1010,7 @@ class BulkActionsFormTests(TestCase):
 
         updates = form.get_updates()
         self.assertEqual(updates['assigned_section'], 'APP')
-        self.assertEqual(updates['primary_statute'], '')
+        self.assertEqual(updates['primary_statute'], None)
         self.assertEqual(updates['assigned_to'], '')
         self.assertEqual(updates['status'], 'new')
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -475,8 +475,9 @@ class ShowView(LoginRequiredMixin, View):
             if 'assigned_section' in form.changed_data:
                 primary_statute = report.primary_statute
                 report.status_assignee_reset()
-                description = f'Updated from "{primary_statute}" to None'
-                add_activity(request.user, "Primary classification:", description, report)
+                if primary_statute:
+                    description = f'Updated from "{primary_statute}" to "None"'
+                    add_activity(request.user, "Primary classification:", description, report)
 
             # District and location are on different forms so handled here.
             # If the incident location changes, update the district.

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -473,7 +473,10 @@ class ShowView(LoginRequiredMixin, View):
 
             # Reset Assignee and Status if assigned_section is changed
             if 'assigned_section' in form.changed_data:
+                primary_statute = report.primary_statute
                 report.status_assignee_reset()
+                description = f'Updated from "{primary_statute}" to None'
+                add_activity(request.user, "Primary classification:", description, report)
 
             # District and location are on different forms so handled here.
             # If the incident location changes, update the district.


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1197)

## What does this change?

When a report is reassigned, the primary classification needs to be reset.  This PR takes care of that.  

## Screenshots (for front-end PR):

<img width="457" alt="image" src="https://user-images.githubusercontent.com/6232068/155611320-62599dac-1d7d-4192-9f7c-9de6e13220bb.png">


## Checklist:

+ [x] Select a report.  Assign a primary classification to it.  Click Apply.
+ [x] Note that the log was updated with something like 'Updated from "None" to "144"'
+ [x] Change the Section.  In addition to  the section change reflected in the log, you should see the primary classification is reset, and something in the log like "Updated from "144" to "None"
+ [x] Click a couple of reports and add a primary classification through bulk actions
+ [x] Click those same reports, and change the section
+ [x] Go into the report details pages of the changed reports, and make sure there is no primary_classification set, and the log says something like "Updated from "144" to "None"


### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
