### PR TITLE
WIP: Fix console error from undefined element

### DIFF
--- a/crt_portal/static/js/form_letter.js
+++ b/crt_portal/static/js/form_letter.js
@@ -221,16 +221,17 @@
       letter_placeholder.classList.add('form-letter-text');
       letter_placeholder.appendChild(el);
       // HTML letter
+      el.remove();
     } else if (!letter_html.hidden) {
       const el = letter_html.cloneNode(true);
       // Prevent id collision
       el.id = el.id + '_rand' + Math.floor(Math.random() * 1000000);
       letter_placeholder.appendChild(el);
+      el.remove();
     }
     letterhead.removeAttribute('hidden');
     document.body.appendChild(letterhead);
     window.print();
-    el.remove();
     letter_placeholder.classList.remove('form-letter-text');
     document.body.removeChild(letterhead);
     root.CRT.closeModal(modal);


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1210)

## What does this change?
Previously, an error appeared in the console when a user would click "print" and then click "cancel."  That error no longer appears.

## Screenshots (for front-end PR):
![Screen Shot 2022-03-03 at 5 36 58 PM](https://user-images.githubusercontent.com/80347702/156664576-df2291c4-69c4-4bfe-a937-dfc0729d9045.png)


## Checklist:

+ [ ] Navigate to `/form/view` and open the console.
+ [ ] Click on “print,” then click “cancel.” 
+ [ ] Observe that there are no errors in the console.

### Author

+ [X] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [n/a] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [n/a] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [X] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:
@billyhunt I noticed that when I click "cancel" I would still see a pop-up message saying that a letter was printed.  I would also see incorrect activity that said a report had been printed.
![Screen Shot 2022-03-03 at 5 40 47 PM](https://user-images.githubusercontent.com/80347702/156665087-6ad1f818-0d1e-4781-9be2-885a1c0f40f0.png)
I think you are aware of the bug, however, I still wanted to note it.  I would be up for investigating it in a future PR.
