### PR TITLE
Add housing-resources to urls that don't need auth

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -287,6 +287,7 @@ if environment in ['PRODUCTION', 'STAGE']:
             '^hate-crime-human-trafficking',
             '^i18n',
             '^email',
+            '^housing-resources',
         ],
     }
 


### PR DESCRIPTION


## What does this change?

Hotfix to production to make housing-resources.html accessible without a login.  

## Screenshots (for front-end PR):

Before
<img width="1606" alt="image" src="https://user-images.githubusercontent.com/6232068/157328207-f336d582-846b-4dda-9383-fb184d4e2631.png">


After
<img width="1809" alt="image" src="https://user-images.githubusercontent.com/6232068/157328277-58b18221-808f-48ba-9fb1-48f376d2b4c9.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
