### PR TITLE
WIP: Dedupe results from report_filter for searches with multiple reported reasons

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -86,7 +86,7 @@ def _change_datetime_to_end_of_day(dateObj, field):
 def report_filter(querydict):
     kwargs = {}
     filters = {}
-    qs = Report.objects.filter().distinct()
+    qs = Report.objects.filter()
     for field in filter_options.keys():
         filter_list = querydict.getlist(field)
 
@@ -132,7 +132,7 @@ def report_filter(querydict):
             elif filter_options[field] == 'violation_summary':
                 search_query = querydict.getlist(field)[0]
                 qs = qs.filter(violation_summary_search_vector=_make_search_query(search_query))
-    qs = qs.filter(**kwargs)
+    qs = qs.filter(**kwargs).distinct()
     return qs, filters
 
 

--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -86,7 +86,7 @@ def _change_datetime_to_end_of_day(dateObj, field):
 def report_filter(querydict):
     kwargs = {}
     filters = {}
-    qs = Report.objects.filter()
+    qs = Report.objects.filter().distinct()
     for field in filter_options.keys():
         filter_list = querydict.getlist(field)
 

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -19,6 +19,7 @@ class ReportFilterTests(TestCase):
     def setUp(self):
         age = ProtectedClass.objects.get(value='age')
         gender = ProtectedClass.objects.get(value='gender')
+        language = ProtectedClass.objects.get(value='language')
         test_data = SAMPLE_REPORT.copy()
 
         test_data['violation_summary'] = 'plane'
@@ -29,6 +30,7 @@ class ReportFilterTests(TestCase):
         r2 = Report.objects.create(**test_data)
         r2.protected_class.add(age)
         r2.protected_class.add(gender)
+        r2.protected_class.add(language)
 
         test_data['violation_summary'] = 'boat'
         Report.objects.create(**test_data)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -185,7 +185,7 @@ def index_view(request):
     per_page = request.GET.get('per_page', 15)
     page = request.GET.get('page', 1)
 
-    requested_reports = report_query.annotate(email_count=F('email_report_count__email_count'))
+    requested_reports = report_query.distinct().annotate(email_count=F('email_report_count__email_count'))
 
     sort_expr, sorts = report_sort(request.GET)
     requested_reports = requested_reports.order_by(*sort_expr)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -185,7 +185,7 @@ def index_view(request):
     per_page = request.GET.get('per_page', 15)
     page = request.GET.get('page', 1)
 
-    requested_reports = report_query.distinct().annotate(email_count=F('email_report_count__email_count'))
+    requested_reports = report_query.annotate(email_count=F('email_report_count__email_count'))
 
     sort_expr, sorts = report_sort(request.GET)
     requested_reports = requested_reports.order_by(*sort_expr)


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1216)

## What does this change?
Previously, when a user searched for a report with multiple reported reasons, e.g. "age" and "disability," if a report had multiple of these input reasons, then the same report would show up multiple times.  I made a fix so that a report will only display one time.
This PR is ready for review, however, I made it a draft because I don't yet have my DOJ laptop.

## Screenshots (for front-end PR):
BEFORE
![Screen Shot 2022-03-14 at 3 13 03 PM](https://user-images.githubusercontent.com/80347702/158244695-7516a80b-0407-4b3e-99ef-cb544770d0ae.png)



AFTER
![Screen Shot 2022-03-14 at 3 13 41 PM](https://user-images.githubusercontent.com/80347702/158244716-2e941e2a-7822-4161-a9c2-3925b0eda2b2.png)



## Checklist:

+ [ ] Create a report with multiple reported reasons, such as “age,” “race,” and “disability” 
+ [ ] Navigate to `/form/view` and search for all of the reported reasons that are associated with the newly created report
+ [ ] Confirm that the recently created report only displays once

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
