### PR TITLE
Fix date on EOS letters

### DIFF
--- a/crt_portal/cts_forms/response_templates/eos_doe_ocr_referral_form_letter.md
+++ b/crt_portal/cts_forms/response_templates/eos_doe_ocr_referral_form_letter.md
@@ -5,7 +5,7 @@ language: en
 ---
 Re: Your Civil Rights Division Complaint – {{ record_locator }} from the Educational Opportunities Section
 
-Thank you for contacting the Department of Justice on December 10, 2021.  We have reviewed the information you provided and have determined that the complaint raises issues that are more appropriately addressed by another federal agency.  We are, therefore, referring this complaint to the following agency for further action:
+Thank you for contacting the Department of Justice on {{ date_of_intake }}.  We have reviewed the information you provided and have determined that the complaint raises issues that are more appropriately addressed by another federal agency.  We are, therefore, referring this complaint to the following agency for further action:
 
 U.S. Department of Education, Office for Civil Rights  
 (800) 421-3481; (202) 453-6012 (fax); (800) 877-8339 (TDD)  

--- a/crt_portal/cts_forms/response_templates/eos_eeoc_referral_letter.md
+++ b/crt_portal/cts_forms/response_templates/eos_eeoc_referral_letter.md
@@ -6,7 +6,7 @@ html: true
 ---
 Re: Your Civil Rights Division Complaint – {{ record_locator }} from the Educational Opportunities Section
 
-Thank you for contacting the Department of Justice on December 10, 2021.  We have reviewed the information you provided and have determined that the complaint raises issues that are more appropriately addressed by another federal agency.  We are, therefore, referring this complaint to the following agency for further action:
+Thank you for contacting the Department of Justice on {{ date_of_intake }}.  We have reviewed the information you provided and have determined that the complaint raises issues that are more appropriately addressed by another federal agency.  We are, therefore, referring this complaint to the following agency for further action:
 
 U.S. Equal Employment Opportunity Commission  
 1-800-669-4000  


### PR DESCRIPTION

## What does this change?

Fixes a bug where the date for eos letters was hard coded.  

## Screenshots (for front-end PR):

## Checklist:

+ [ ] Check to make sure EOS form letters have the correct date.  Not December 10, 2021.

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
