### PR TITLE
Add code to make sure element is in print dialog.

### DIFF
--- a/crt_portal/static/js/form_letter.js
+++ b/crt_portal/static/js/form_letter.js
@@ -229,13 +229,11 @@
       letter_placeholder.classList.add('form-letter-text');
       letter_placeholder.appendChild(el);
       // HTML letter
-      el.remove();
     } else if (!letter_html.hidden) {
       const el = letter_html.cloneNode(true);
       // Prevent id collision
       el.id = el.id + '_rand' + Math.floor(Math.random() * 1000000);
       letter_placeholder.appendChild(el);
-      el.remove();
     }
     letterhead.removeAttribute('hidden');
     document.body.appendChild(letterhead);


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

A bug was introduced into dev which caused the print form to be empty.  This PR fixes that problem. 

## Screenshots (for front-end PR):

**Before:**
<img width="927" alt="image" src="https://user-images.githubusercontent.com/6232068/160439141-a6298383-eb45-43b4-bcca-65144213057c.png">

**After:**
<img width="878" alt="image" src="https://user-images.githubusercontent.com/6232068/160439277-1d08c3b1-835d-4bba-82f8-fd00584daae6.png">


## Checklist:

+ [ ] Make sure you can see the print information when you go to print a response template.

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
