### PR TITLE
Pin npm version for local, staging, and prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,7 @@ jobs:
             wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
             apt-get update && \
             apt-get install -yqq nodejs && \
-            npm i -g npm@^8 && \
+            npm i -g npm@8.5.5 && \
             rm -rf /var/lib/apt/lists/*
             npm ci --production
             node node_modules/gulp/bin/gulp build-sass
@@ -336,7 +336,7 @@ jobs:
             wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
             apt-get update && \
             apt-get install -yqq nodejs && \
-            npm i -g npm@^8 && \
+            npm i -g npm@8.5.5 && \
             rm -rf /var/lib/apt/lists/*
             npm ci --production
             node node_modules/gulp/bin/gulp build-sass

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN \
   apt-get update && \
   apt-get install -yqq nodejs && \
   pip install -U pip && pip install pipenv && \
-  npm i -g npm@^8 && \
+  npm i -g npm@8.5.5 && \
   rm -rf /var/lib/apt/lists/*
 
 # Install app dependencies


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

Related to #1156

We are pinning the npm version to the last successful build of node-sass for the uswds to avoid build errors.  This was already tested in Dev, and now are are modifying the config to work in Staging, Production, and locally.

**NOTE:** We do not want to keep npm pinned for very long, as it could cause other problems.  We need to explore a solution to the root cause of conflicts between gulp-sass in the us web design system, and our own use of gulp sass.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
