### PR TITLE
Only run the memory intensive distinct search when needed. 

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -132,7 +132,12 @@ def report_filter(querydict):
             elif filter_options[field] == 'violation_summary':
                 search_query = querydict.getlist(field)[0]
                 qs = qs.filter(violation_summary_search_vector=_make_search_query(search_query))
-    qs = qs.filter(**kwargs).distinct()
+    # Check to see if there are multiple values in report_reason search and run distinct if so.  If not, run a regular
+    # much faster search.
+    if len(kwargs.get('protected_class__value__in', [])) > 1:
+        qs = qs.filter(**kwargs).distinct()
+    else:
+        qs = qs.filter(**kwargs)
     return qs, filters
 
 


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1274)

## What does this change?

the .dintinct() DB search is adding some memory constraints on our already taxed DB.  We only need to run it if we are searching through multiple reported_reasons, which is not the majority of searches.

NOTE: we might want to hotfix this into production, especially if we cannot improve the DB size quickly. 

## Screenshots (for front-end PR):

+ [x] Make sure searches work with no reported reason EG http://localhost:8000/form/view/?status=new&status=open&status=closed&no_status=false
+ [x] Make sure searches work with one reported reason EG http://localhost:8000/form/view/?status=new&status=open&status=closed&reported_reason=age&no_status=false
+ [x] Make sure searches work with multiple reported reasons EG http://localhost:8000/form/view/?status=new&status=open&status=closed&reported_reason=age&reported_reason=disability&reported_reason=family_status&reported_reason=gender&reported_reason=genetic&reported_reason=immigration&reported_reason=language&reported_reason=national_origin&reported_reason=pregnancy&reported_reason=race%2Fcolor&reported_reason=religion&reported_reason=sex&reported_reason=orientation&reported_reason=none&reported_reason=other&no_status=false

You might check the SQL time length.  

Before:
<img width="334" alt="image" src="https://user-images.githubusercontent.com/6232068/165834336-1bb4a167-b136-45db-a43b-330a5fcc3272.png">


After
<img width="312" alt="image" src="https://user-images.githubusercontent.com/6232068/165834200-95c55f1b-bb1d-4b66-abb3-6e2a13a0e1b9.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
