### PR TITLE
fix import

### DIFF
--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from crt_portal.cts_forms.models import FormLettersSent
+from cts_forms.models import FormLettersSent
 from cts_forms.tests.factories import ReportFactory
 from datetime import datetime
 import random


### PR DESCRIPTION
This is a small bug fix with no related ticket.

## What does this change?
An error in the import for `create_mock_reports.py` made the command fail.  This PR fixes the import.

## Screenshots (for front-end PR):
None

## Testing plan
+ [ ] Check out this branch locally, run `$ docker-compose run web python crt_portal/manage.py create_mock_reports 10
` and confirm that data is created without triggering any errors.


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
