### PR TITLE
Removed relatedReports minified js from complaint view index template.

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -97,5 +97,4 @@
 <script src="{% static 'js/print_report.min.js' %}"></script>
 <script src="{% static 'js/routing_guide.min.js' %}"></script>
 <script src="{% static 'js/attachments.min.js' %}"></script>
-<script src="{% static 'js/dist/relatedReports.min.js' %}"></script>
 {%endblock%}


### PR DESCRIPTION
[Link to GitHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1301)

## What does this change?
We had a stray call to a non-existent minified JS file in the report/view page. The call was logging a 404 to the console. The call to the file has been removed from /crt_portal/cts_forms/templates/forms/complaint_view/show/index.html

## Screenshots (for front-end PR):

## Checklist:
+ [x] Navigate to /report/view and select an individual report to view
+ [x] Open the developer console, and confirm that no errors related to missing JS files are logged to the console. 

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
