### PR TITLE
Il/1299 update localstack full

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - localstack
   localstack:
     container_name: "localstack_main"
-    image: localstack/localstack
+    image: localstack/localstack-full:latest
     ports:
       - "4566:4566"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,9 @@ services:
       - "4566:4566"
     environment:
       - SERVICES=s3
-      # - DEBUG=1
+      ## - DEBUG=1
+      ## this will be deprecated in future community version of local-stack
+      - LEGACY_PERSISTENCE=1
       - DATA_DIR=/tmp/localstack/data
     volumes:
       - "localstack-vol:/tmp/localstack"


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1299)

## What does this change?
This change explicitly set localstack docker image pull to localstal-full-latest.

## Screenshots (for front-end PR):

## Checklist:
NOTE: you may need to prune your current docker environment before doing docker-compose for clean build and test.
+ [x] local stack full version downloaded during docker-compose up --build.
+ [x] local docker log showing local stack running 
+ [x] check local stack health using this link https://127.0.0.1:4566 Note, ignore the HTTPS cert notification for own local docker validation.
+ [x] all style pages loaded correctly
+ [x] file attachment works on local docker /form/view > report detail page.


### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
