### PR TITLE
[WIP] updated clamav ldocker image to ajilaag/clamav-rest:20220511

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
        - 8025:8025 # web ui
      # command: -invite-jim=1 -jim-accept=0.50  # uncomment to enable and configure Jim (Chaos Monkey)
   clamav-rest:
-    image: ajilaag/clamav-rest:20201028
+    image: ajilaag/clamav-rest:20220511   # ## 20201028
     environment:
       - MAX_FILE_SIZE=100M
       - SIGNATURE_CHECKS=1


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1298)

## What does this change?
this PR updates current clamAV docker images to https://github.com/usdoj-crt/crt-portal-management/issues/1298

## Checklist:
[ ] check docker log for clamAV image version is ajilaag/clamav-rest:20220511
[ ] check CI/CD build image clamAV version is ajilaag/clamav-rest:20220511 for dev once merged to dev

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
