### PR TITLE
Add quotes to show they are needed when creating .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Clone the project locally:
 
 In the top level directory create a .env file in the top of your directory and add the following environment variables. Set `SECRET_KEY` to a long, random string and `POSTGRES_PASSWORD` to any string you like.
 
-    SECRET_KEY=this_is_a_long_random_string
-    POSTGRES_PASSWORD=rando_pw
+    SECRET_KEY="this_is_a_long_random_string"
+    POSTGRES_PASSWORD="rando_pw"
 
 To build the project
     You will need to build the project for the first time and when there are package updates to apply.


### PR DESCRIPTION
## What does this change?

Simple change to markdown to show users quotes are needed on .env variables.  (multiple developers have had problems when installing a fresh copy)

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
