### PR TITLE
Formatting upgrade for bulk actions page

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -14,7 +14,7 @@
         <div class="tablet:grid-col-10 grid-offset-1 padding-left-05">
           <div class="complaint-filter-navigation display-flex flex-row flex-justify">
             <div class="display-flex">
-              <a class="outline-button outline-button--dark" href="{% url 'crt_forms:crt-forms-index' %}{{ return_url_args }}">
+              <a class="outline-button outline-button--dark bulk-action-back-button" href="{% url 'crt_forms:crt-forms-index' %}{{ return_url_args }}">
                 <img src="{% static "img/intake-icons/ic_arrow_forward.svg" %}" alt="back arrow" class="icon">
                 Back to all
               </a>

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -562,6 +562,16 @@ form#cts-forms-profile {
   }
 }
 
+.bulk-action-back-button {
+  padding: 0.75rem 1.5rem 0.75rem 1rem;
+}
+
+#id_assigned_toaria-autocomplete-1-input {
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid #565C64;
+}
+
 #complaint-view-actions, #bulk_actions_section {
   .crt-dropdown {
     &.crt-dropdown__shrink-to-contents {


### PR DESCRIPTION
I updated the formatting for the bulk actions page.

[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1284)

## What does this change?

## Screenshots (for front-end PR):
![Screen Shot 2022-06-15 at 11 34 34 AM](https://user-images.githubusercontent.com/80347702/173868971-ffbe5ac4-3dee-4ccd-b3f6-e5baa3539868.png)


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
