### PR TITLE
update the package.lock file to work with "npm ci"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10095,6 +10095,7 @@
     },
     "uswds-gulp": {
       "version": "git+ssh://git@github.com/uswds/uswds-gulp.git#b4b0a910e86bed7c034d96c289e2a49bd480053d",
+      "integrity": "sha512-7K+DGf56LdXZsO/TElpROiYTSfTKhCh9EqxHda38nbdurFKYuI6M/VpzYwnzUaOQj8zEqAtq1x85CRvToeNFHA==",
       "from": "uswds-gulp@github:uswds/uswds-gulp",
       "requires": {}
     },


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

We need to update the package-lock file to work with the npm command used in circleci ("npm ci")

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
