### PR TITLE
Bh/update mobile menu padding

### DIFF
--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -27,7 +27,7 @@
       <div class="crt-menu--section grid-col-auto">
         <div class="usa-nav-container">
           <div class="crt-menu--navbar">
-            <button class="crt-menu--mobile usa-menu-btn">{% trans "Menu" %}</button>
+            <button class="crt-menu--mobile usa-menu-btn tablet-menu-button">{% trans "Menu" %}</button>
           </div>
           <div class="usa-nav">
             <button class="usa-nav__close">

--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -7,7 +7,9 @@ $arrow-height: 24px;
 
 .crt-landing--logo_section  {
   p.crt-landing--logo_heading {
-    font-size: 1.25rem;
+    @include at-media-max(mobile-lg) {
+      font-size: 1.25rem;
+    }
   }
 }
 

--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -5,6 +5,12 @@
 
 $arrow-height: 24px;
 
+.crt-landing--logo_section  {
+  p.crt-landing--logo_heading {
+    font-size: 1.25rem;
+  }
+}
+
 .crt-landing--emergency_contact .crt-external--link {
     color: #fff;
   &::after {
@@ -12,7 +18,13 @@ $arrow-height: 24px;
   content: url(../../img/ic_external-link-white.svg);
 }
 }
-
+.crt-landing--header {
+  .crt-landing--header_section {
+    .tablet-menu-button {
+      margin-top: .5rem;
+    }
+  }
+}
 .crt-landing--section {
   padding-top: 3rem;
   padding-bottom: 3rem;


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1336)

## What does this change?

There are a couple of small changes that need to happen to the header in Mobile.  The Menu button is not correctly vertically aligned, and the Sub Title is a little too big.  This change will update.


## Screenshots (for front-end PR):
Currently in dev
<img width="389" alt="image" src="https://user-images.githubusercontent.com/6232068/176704342-f3fdd910-39cc-4063-ab18-130961745760.png">

What it should look like.
<img width="393" alt="image" src="https://user-images.githubusercontent.com/6232068/176704497-09c0d3dd-fa0c-4bd7-b826-c6777e1a5e8c.png">
## Checklist:

+ [ ] Review the header in full view, tablet, and mobile on common browsers.  Make sure that It looks as it does on civilrights.justice.gov

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
