### PR TITLE
display X button for "how you know" menu on mobile

### DIFF
--- a/crt_portal/static/sass/custom/banner.scss
+++ b/crt_portal/static/sass/custom/banner.scss
@@ -56,10 +56,6 @@
       .language-selection__button-active {
         text-decoration: underline;
       }
-
-      .usa-banner__button::after {
-        display: none;
-      }
     }
   }
 }


### PR DESCRIPTION
['X' is missing on iPhone when clicking the "Here's how you know" link at the top.](https://github.com/usdoj-crt/crt-portal-management/issues/1331)

## What does this change?
- The "X" will now appear when a mobile user clicks the "here's how you know" link at the top.

## Screenshots (for front-end PR):
BEFORE

https://user-images.githubusercontent.com/80347702/177345171-e1a8b7b8-33a5-491b-810f-5fc1bef25859.mov

AFTER

https://user-images.githubusercontent.com/80347702/177345719-a8faf91a-3c36-43a6-bca2-fe73b1fc57b8.mov




## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
