### PR TITLE
remove extra x-axis arrows in team mgmt table

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/complaints_table.html
@@ -7,7 +7,7 @@
 >
   <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
 
-  <div class="crt-xscroll">
+  <div>
     {% if selected_actor %}
     <table class="usa-table crt-table dashboard-table">
       <thead>


### PR DESCRIPTION
[Team Management Page has extra arrows on Microsoft Edge.](https://github.com/usdoj-crt/crt-portal-management/issues/1321)

## What does this change?
Before, the team management page had extra arrows on the x axis of the table, below "Activity Log."  This PR removes those arrows.

## Screenshots (for front-end PR):
BEFORE

![](https://user-images.githubusercontent.com/6232068/175129285-a88ad575-b4d8-4c61-989b-943bb9500f76.png)


AFTER
![Screen Shot 2022-07-05 at 2 17 30 PM](https://user-images.githubusercontent.com/80347702/177390664-b37dc223-94a9-4748-a9a8-8e3a311bc5f2.png)

## Checklist:
+ [ ] Test [in dev](https://crt-portal-django-dev.app.cloud.gov/form/dashboard/) and ensure there are no horizontal arrows below "Activity log" when there are no records in the table.

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
