### PR TITLE
Removing down arrow that is not needed on css language buttons

### DIFF
--- a/crt_portal/static/sass/custom/banner.scss
+++ b/crt_portal/static/sass/custom/banner.scss
@@ -48,6 +48,12 @@
         }
       }
 
+      .usa-banner__button.language-selection__button {
+        &:after {
+          display: none;
+        }
+      }
+
       img {
         height: 1rem;
         margin-top: .25rem;


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

We accidentally removed some CSS that was required in the language selection buttons.  This PR adds that CSS back, but only where needed.

## Screenshots (for front-end PR):

Before: (Note pesky down arrows next to language buttons)
<img width="1393" alt="image" src="https://user-images.githubusercontent.com/6232068/177825048-d3a34052-634c-4e94-b725-88ce6fa05f1a.png">

After:
<img width="1542" alt="image" src="https://user-images.githubusercontent.com/6232068/177824841-69ccfcc6-7fc7-4942-ba2c-a6ac79fb745b.png">


## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
