### PR TITLE
Fix time zone error for closed date

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -368,7 +368,8 @@ class Report(models.Model):
         Remove assignee and record date of call
         """
         self.assigned_to = None
-        self.closed_date = datetime.now(timezone.utc)
+        local_tz = pytz.timezone('US/Eastern')
+        self.closed_date = datetime.now(local_tz)
 
     def status_assignee_reset(self):
         """

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -1,7 +1,7 @@
 """All models need to be added to signals.py for proper logging."""
 import logging
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 from babel.dates import format_date
 
 from django.contrib.auth import get_user_model

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -1,7 +1,7 @@
 """All models need to be added to signals.py for proper logging."""
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from babel.dates import format_date
 
 from django.contrib.auth import get_user_model
@@ -368,7 +368,7 @@ class Report(models.Model):
         Remove assignee and record date of call
         """
         self.assigned_to = None
-        self.closed_date = datetime.now()
+        self.closed_date = datetime.now(timezone.utc)
 
     def status_assignee_reset(self):
         """


### PR DESCRIPTION
[Time zone audit.](https://github.com/usdoj-crt/crt-portal-management/issues/1351)

## What does this change?
Previously, when an intake specialist closed a report, it caused a `RuntimeWarning: DateTimeField Report.closed_date received a naive datetime` warning.  I fixed this by specifying the time zone for the closed date in the `closeout_report(self)` method.


## Screenshots (for front-end PR):
Logs Before the Change
![LocalLogsBeforeFixedTimezone](https://user-images.githubusercontent.com/80347702/178767763-08f0e444-4074-40ae-97a7-4615970c20c0.png)



Logs After The Change (I included a screenshot of the local app, in order to show that the report was successfully closed)
![LocalLogsAfterFixedTimezone](https://user-images.githubusercontent.com/80347702/178767787-0d735aae-413f-47e1-80e1-ac8f07cf2ac2.png)



## Checklist:
+ [ ] Close a report and confirm that no naive datetime warnings appear in logs


### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
