### PR TITLE
Change minimum date for externally submitted report

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -570,7 +570,7 @@ def date_cleaner(self, cleaned_data):
                 DATE_ERRORS['no_future'],
                 params={'value': datetime(year, month, day).strftime('%x')},
             ))
-        elif datetime(year, month, day) < datetime(1899, 12, 31):
+        elif datetime(year, month, day) < datetime(1900, 1, 1):
             self.add_error('last_incident_year', ValidationError(
                 DATE_ERRORS['no_past'],
                 params={'value': datetime(year, month, day).strftime('%x')},


### PR DESCRIPTION
[Fix minimum date for report submission.](https://github.com/usdoj-crt/crt-portal-management/issues/1352)

## What does this change?
Previously, although the external-facing report submission process was only supposed to allow reports for events that had occurred in 1900 or later, users could enter December 31, 1899 for the event date.  This contradicted [validation error messages](https://github.com/usdoj-crt/crt-portal/blob/develop/crt_portal/cts_forms/model_variables.py#L452).  I did some code archaeology and found [the original PR](https://github.com/usdoj-crt/crt-portal/pull/246) that allowed December 31, 1899 as an event date.  I didn't see any justification for allowing this date, so I changed the cut-off to January 1, 1900.

## Screenshots (for front-end PR):
BEFORE
A report could be submitted with the December 31, 1899 date
![ReportDec311899](https://user-images.githubusercontent.com/80347702/178802080-99ac2f28-e67c-4cc7-9a55-556acba600f4.png)



AFTER
A report could not be submitted with the December 31, 1899 date
![Screen Shot 2022-07-13 at 1 41 27 PM](https://user-images.githubusercontent.com/80347702/178796766-63fcad76-b545-43b4-8dbf-445d3b33b090.png)



## Checklist:
+ [ ] Attempt to submit a report with December 31, 1899 as the event date.  Confirm the resulting error message exists.

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
