### PR TITLE
Make proform require 1900 as a minimum for incident year

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -588,6 +588,7 @@ def date_cleaner(self, cleaned_data):
 
     return cleaned_data
 
+
 def crt_date_cleaner(self, cleaned_data):
     """This should give the most specific error message, if the date doesn't render for reasons other than what we are checking for, it will give the generic error."""
     invalid_date = False

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -588,11 +588,10 @@ def date_cleaner(self, cleaned_data):
 
     return cleaned_data
 
-
 def crt_date_cleaner(self, cleaned_data):
     """This should give the most specific error message, if the date doesn't render for reasons other than what we are checking for, it will give the generic error."""
     invalid_date = False
-    # Test month
+    # Test Receipt Month
     if 'crt_reciept_month' in cleaned_data:
         month = cleaned_data['crt_reciept_month']
         # These checks are to prevent existing report detail page edits to require the crt_. . . fields.  They are required in the pro form and that is caught through the existing "required" validation.
@@ -606,7 +605,7 @@ def crt_date_cleaner(self, cleaned_data):
     else:
         self.add_error('crt_reciept_month', ValidationError(DATE_ERRORS['month_required']))
         invalid_date = True
-    # Test Day
+    # Test Receipt Day
     if 'crt_reciept_day' in cleaned_data:
         day = cleaned_data['crt_reciept_day']
         if type(day) != int:
@@ -619,7 +618,7 @@ def crt_date_cleaner(self, cleaned_data):
     else:
         self.add_error('crt_reciept_day', ValidationError(DATE_ERRORS['day_required']))
         invalid_date = True
-    # Test year
+    # Test Receipt Year
     if 'crt_reciept_year' in cleaned_data:
         year = cleaned_data['crt_reciept_year']
         if type(year) != int:
@@ -643,7 +642,15 @@ def crt_date_cleaner(self, cleaned_data):
             ))
     else:
         self.add_error('crt_reciept_year', ValidationError(DATE_ERRORS['year_required']))
-
+    # Test Incident Year
+    if 'last_incident_year' in cleaned_data:
+        year = cleaned_data['last_incident_year']
+        if type(year) != int:
+            return cleaned_data
+        if year < 1900:
+            self.add_error('last_incident_year', ValidationError(
+                DATE_ERRORS['no_past'],
+            ))
     return cleaned_data
 
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -631,6 +631,9 @@ def crt_date_cleaner(self, cleaned_data):
         elif invalid_date:
             # Added if month and year are invalid.  We don't want to create a datetime with bad data, which happens in the next conditional.
             return cleaned_data
+    else:
+        self.add_error('crt_reciept_year', ValidationError(DATE_ERRORS['year_required']))
+    if 'crt_reciept_year' in cleaned_data and 'crt_reciept_month' in cleaned_data and 'crt_reciept_day' in cleaned_data:
         try:
             if datetime(year, month, day) > datetime.now():
                 self.add_error('crt_reciept_year', ValidationError(
@@ -641,9 +644,6 @@ def crt_date_cleaner(self, cleaned_data):
             self.add_error('crt_reciept_year', ValidationError(
                 DATE_ERRORS['crt_not_valid'],
             ))
-    else:
-        self.add_error('crt_reciept_year', ValidationError(DATE_ERRORS['year_required']))
-    # Test Incident Year
     if 'last_incident_year' in cleaned_data:
         year = cleaned_data['last_incident_year']
         if type(year) != int:

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -644,13 +644,35 @@ def crt_date_cleaner(self, cleaned_data):
             self.add_error('crt_reciept_year', ValidationError(
                 DATE_ERRORS['crt_not_valid'],
             ))
-    if 'last_incident_year' in cleaned_data:
-        year = cleaned_data['last_incident_year']
-        if type(year) != int:
+    if 'last_incident_day' in cleaned_data:
+        incident_day = cleaned_data['last_incident_day']
+        if type(incident_day) != int:
             return cleaned_data
-        if year < 1900:
+        elif incident_day > 31 or incident_day < 1:
+            self.add_error('last_incident_day', ValidationError(
+                DATE_ERRORS['day_invalid'],
+            ))
+        if 'last_incident_month' in cleaned_data:
+            incident_month = cleaned_data['last_incident_month']
+            if type(incident_month) != int:
+                return cleaned_data
+            elif incident_month > 12 or incident_month < 1:
+                self.add_error('last_incident_month', ValidationError(
+                    DATE_ERRORS['month_invalid'],
+                ))
+    if 'last_incident_year' in cleaned_data:
+        incident_year = cleaned_data['last_incident_year']
+        if type(incident_year) != int:
+            return cleaned_data
+        if incident_year < 1900:
             self.add_error('last_incident_year', ValidationError(
                 DATE_ERRORS['no_past'],
+            ))
+    if 'last_incident_year' in cleaned_data and 'last_incident_month' in cleaned_data and 'last_incident_day' in cleaned_data:
+        if datetime(incident_year, incident_month, incident_day) > datetime.now():
+            self.add_error('last_incident_year', ValidationError(
+                DATE_ERRORS['no_future'],
+                params={'value': datetime(incident_year, incident_month, incident_day).strftime('%x')},
             ))
     return cleaned_data
 

--- a/crt_portal/cts_forms/tests/test_intake_forms.py
+++ b/crt_portal/cts_forms/tests/test_intake_forms.py
@@ -20,6 +20,7 @@ from ..forms import (
 )
 from ..model_variables import (
     CONTACT_PHONE_INVALID_MESSAGE,
+    INTAKE_FORMAT_ERROR,
     PRIMARY_COMPLAINT_CHOICES,
     PRIMARY_COMPLAINT_ERROR, PROTECTED_CLASS_ERROR,
     PROTECTED_MODEL_CHOICES, SERVICEMEMBER_ERROR,
@@ -355,14 +356,14 @@ class Validation_Form_Tests(TestCase):
             'last_incident_month': 5,
             'last_incident_day': 5,
         })
-        self.assertTrue('<ul class="errorlist"><li>Please enter a year' in str(form.errors))
+        self.assertTrue(f'<ul class="errorlist"><li>{DATE_ERRORS["year_required"]}' in str(form.errors))
 
     def test_required_month(self):
         form = When(data={
             'last_incident_year': 2019,
             'last_incident_day': 5,
         })
-        self.assertTrue('<ul class="errorlist"><li>Please enter a month' in str(form.errors))
+        self.assertTrue(f'<ul class="errorlist"><li>{DATE_ERRORS["month_required"]}' in str(form.errors))
 
     def test_NOT_required_day(self):
         form = When(data={
@@ -676,8 +677,8 @@ class ProFormTest(TestCase):
     def test_required_fields(self):
         form = ProForm(data={})
         errors = str(form.errors)
-        self.assertTrue("Please select an intake format" in errors)
-        self.assertTrue("Please select a primary reason to continue." in errors)
+        self.assertTrue(f'<ul class="errorlist"><li>{INTAKE_FORMAT_ERROR}' in errors)
+        self.assertTrue(f'<ul class="errorlist"><li>{PRIMARY_COMPLAINT_ERROR}' in errors)
         self.assertTrue("crt_reciept_day" in errors)
         self.assertTrue("crt_reciept_month" in errors)
         self.assertTrue("crt_reciept_year" in errors)
@@ -687,29 +688,25 @@ class ProFormTest(TestCase):
         bad_month_data = self.data
         bad_month_data["crt_reciept_month"] = 13
         form = ProForm(data=bad_month_data)
-        errors = str(form.errors)
-        self.assertTrue("Please enter a valid month. Month must be between 1 and 12." in errors)
+        self.assertTrue(str(DATE_ERRORS['month_invalid']) in str(form.errors))
         self.assertFalse(form.is_valid())
 
     def test_day_validation(self):
         bad_day_data = self.data
         bad_day_data["crt_reciept_day"] = 32
         form = ProForm(data=bad_day_data)
-        errors = str(form.errors)
-        self.assertTrue("Please enter a valid day of the month. Day must be between 1 and the last day of the month." in errors)
+        self.assertTrue(str(DATE_ERRORS['day_invalid']) in str(form.errors))
         self.assertFalse(form.is_valid())
 
     def test_receipt_year_validation(self):
         bad_year_data = self.data
         bad_year_data["crt_reciept_year"] = 1899
         form = ProForm(data=bad_year_data)
-        errors = str(form.errors)
-        self.assertTrue("Please enter a year after 1999." in errors)
+        self.assertTrue(DATE_ERRORS['crt_no_past'] in str(form.errors))
         self.assertFalse(form.is_valid())
         bad_year_data["crt_reciept_year"] = 3000
         form = ProForm(data=bad_year_data)
-        errors = str(form.errors)
-        self.assertTrue("Date can not be in the future." in errors)
+        self.assertTrue(str(DATE_ERRORS['no_future']) in str(form.errors))
         self.assertFalse(form.is_valid())
 
     def test_last_incident_year_validation(self):
@@ -724,8 +721,7 @@ class ProFormTest(TestCase):
         bad_date_data["crt_reciept_month"] = 2
         bad_date_data["crt_reciept_day"] = 30
         form = ProForm(data=bad_date_data)
-        errors = str(form.errors)
-        self.assertTrue("Please use a valid date." in errors)
+        self.assertTrue(DATE_ERRORS['crt_not_valid'] in str(form.errors))
         self.assertFalse(form.is_valid())
 
     def test_full_example(self):

--- a/crt_portal/cts_forms/tests/test_intake_forms.py
+++ b/crt_portal/cts_forms/tests/test_intake_forms.py
@@ -709,11 +709,32 @@ class ProFormTest(TestCase):
         self.assertTrue(str(DATE_ERRORS['no_future']) in str(form.errors))
         self.assertFalse(form.is_valid())
 
+    def test_last_incident_month_validation(self):
+        bad_month_data = self.data
+        bad_month_data["last_incident_month"] = 22
+        form = ProForm(data=bad_month_data)
+        self.assertTrue(f'<ul class="errorlist"><li>{DATE_ERRORS["month_invalid"]}' in str(form.errors))
+        self.assertFalse(form.is_valid())
+
+    def test_last_incident_day_validation(self):
+        bad_day_data = self.data
+        bad_day_data["last_incident_day"] = 80
+        form = ProForm(data=bad_day_data)
+        self.assertTrue(f'<ul class="errorlist"><li>{DATE_ERRORS["day_invalid"]}' in str(form.errors))
+        self.assertFalse(form.is_valid())
+
     def test_last_incident_year_validation(self):
         bad_year_data = self.data
         bad_year_data["last_incident_year"] = 1899
         form = ProForm(data=bad_year_data)
         self.assertTrue(f'<ul class="errorlist"><li>{DATE_ERRORS["no_past"]}' in str(form.errors))
+        self.assertFalse(form.is_valid())
+
+    def test_last_incident_no_future_validation(self):
+        future_year_data = self.data
+        future_year_data["last_incident_year"] = 3001
+        form = ProForm(data=future_year_data)
+        self.assertTrue(f'<ul class="errorlist"><li>{DATE_ERRORS["no_future"]}' in str(form.errors))
         self.assertFalse(form.is_valid())
 
     def test_bad_date(self):

--- a/crt_portal/cts_forms/tests/test_intake_forms.py
+++ b/crt_portal/cts_forms/tests/test_intake_forms.py
@@ -699,7 +699,7 @@ class ProFormTest(TestCase):
         self.assertTrue("Please enter a valid day of the month. Day must be between 1 and the last day of the month." in errors)
         self.assertFalse(form.is_valid())
 
-    def test_year_validation(self):
+    def test_receipt_year_validation(self):
         bad_year_data = self.data
         bad_year_data["crt_reciept_year"] = 1899
         form = ProForm(data=bad_year_data)
@@ -710,6 +710,13 @@ class ProFormTest(TestCase):
         form = ProForm(data=bad_year_data)
         errors = str(form.errors)
         self.assertTrue("Date can not be in the future." in errors)
+        self.assertFalse(form.is_valid())
+
+    def test_last_incident_year_validation(self):
+        bad_year_data = self.data
+        bad_year_data["last_incident_year"] = 1899
+        form = ProForm(data=bad_year_data)
+        self.assertTrue(f'<ul class="errorlist"><li>{DATE_ERRORS["no_past"]}' in str(form.errors))
         self.assertFalse(form.is_valid())
 
     def test_bad_date(self):

--- a/crt_portal/cts_forms/tests/test_intake_forms.py
+++ b/crt_portal/cts_forms/tests/test_intake_forms.py
@@ -728,6 +728,15 @@ class ProFormTest(TestCase):
         form = ProForm(data=self.data)
         self.assertTrue(form.is_valid())
 
+    def test_multiple_errors(self):
+        data = self.data
+        data["crt_reciept_year"] = 1900
+        data.pop("crt_reciept_day")
+        form = ProForm(data=data)
+        self.assertTrue(DATE_ERRORS['day_required'] in str(form.errors))
+        self.assertTrue(DATE_ERRORS['crt_no_past'] in str(form.errors))
+        self.assertFalse(form.is_valid())
+
 
 class TestIntakeFormat(TestCase):
     def setUp(self):


### PR DESCRIPTION
[Fix minimum date for last_incident_year for proform](https://github.com/usdoj-crt/crt-portal-management/issues/1354)

## What does this change?
Previously, while filling out the proform, intake specialists could enter an incident year prior to 1900.  @JackRyan1989 noted this bug in his review of #1213.  I added a validation that prevents intake specialists from entering an incident year prior to 1900.

## Screenshots (for front-end PR):
![IncidentYearValidation](https://user-images.githubusercontent.com/80347702/179297663-18c6762a-4b4d-45ae-853e-082aac9cbfc1.png)



## Checklist:
+ [ ] Submit a pro form with an incident date prior to 1900.  Observe the error.

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
