### PR TITLE
Fix some flake8 errors on dev

### DIFF
--- a/crt_portal/cts_forms/page_through.py
+++ b/crt_portal/cts_forms/page_through.py
@@ -52,4 +52,4 @@ def pagination(paginator, page, per_page):
         'page_range_end': records.end_index(),
     }
 
-    return(records, page_format)
+    return records, page_format

--- a/crt_portal/cts_forms/validators.py
+++ b/crt_portal/cts_forms/validators.py
@@ -36,7 +36,7 @@ def validate_filename(file):
     regex_match = re.search(special_characters, thisfile)
 
     # verify if the regex search math found any special character.
-    if(regex_match is not None):
+    if regex_match is not None:
 
         raise ValidationError(f'Filename: {thisfile} have special characters, rename file before upload. Acceptable file name special characters are - (dash) and _ (underscore).')
 


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

There were a couple of flake8 errors happening on code that has not been changed.  This PR fixes those errors.

## Screenshots (for front-end PR):

<img width="848" alt="image" src="https://user-images.githubusercontent.com/6232068/182420528-86b21c5e-f8fa-48fb-b5ef-5ba21f02f9e0.png">


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
