### PR TITLE
per_page filter tag removed

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -54,7 +54,8 @@ filter_options = {
     'summary': 'summary',  # aka "CRT summary"
     'location_name': '__icontains',
     'other_class': '__search',  # not in filter controls?
-    'per_page': '__pass',  # adding so a filter tag will show up in /form/view.  No filtering will actually happen.
+    # this is not a db query filter, not needed here, duplicate tag fix, removed from the filter tag list
+    # 'per_page': '__pass',  # adding so a filter tag will show up in /form/view.  No filtering will actually happen.
 }
 
 # To add a new filter option for Reports, add the field name and expected filter behavior


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1382)

## What does this change?
It removes the 'per page' tag from the form view page filter section area.

## Screenshots (for front-end PR):

## Checklist:
[x] per page tag does not display while applying other filters.
[x] per page tag does not display while sorting display records
[x] per page tag does not display while paginating through multipage results
[x] per page tag does not display when use the 'Back to all' button from the report detail page
[x] 'Back to all' button keep the previous search filter intact
[x] Clear all Filter keep the pagination intact, i.e. doe not reset the pagination value.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
