### PR TITLE
voting banner added for voting mode

### DIFF
--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -2,6 +2,7 @@
 
 {% load static %}
 {% load i18n %}
+{% load get_voting_mode %}
 
 {% block page_header %}
   <header class="crt-landing--header crt-landing--blue">
@@ -72,7 +73,15 @@
 {% block main_class %} class="margin-top-0 margin-bottom-0"{% endblock %}
 
 {% block content %}
-  {% include "partials/important_message.html" %}
+
+  {% voting_mode as votetoggle %}
+  {% if votetoggle == True %}
+  <!-- display only when voting toggle is on -->
+      {% include "partials/important_message_voting.html" %}
+      {% include "partials/message_hate_crime.html" %}
+  {% else %}
+      {% include "partials/important_message.html" %}
+  {% endif %}
 
   <div class="crt-landing--section crt-landing--hero crt-landing--lightblue">
     <div class="grid-container">

--- a/crt_portal/cts_forms/templates/partials/important_message_voting.html
+++ b/crt_portal/cts_forms/templates/partials/important_message_voting.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+
+<div class="crt-landing--important-message bg-gold padding-y-1">
+  <div class="grid-container">
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-12">
+        <a href="{% url 'vot_resources' %}" class="text-bold text-ink hover:text-ink hover:text-no-underline">
+          {% trans "Report voting issues" %}
+        </a>, {% trans "including threats against voters and election fraud." %}
+      </div>
+    </div>
+  </div>
+</div>

--- a/crt_portal/cts_forms/templates/partials/message_hate_crime.html
+++ b/crt_portal/cts_forms/templates/partials/message_hate_crime.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+
+<div class="crt-landing--important-message bg-white padding-y-1">
+  <div class="grid-container">
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-12">
+        {% trans "Have you been a victim of a hate crime or human trafficking?" %}
+        <a href="{% url 'hate_crime_human_trafficking' %}" class="text-bold text-ink hover:text-ink hover:text-no-underline">
+          {% trans "Get help NOW!" %}
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/crt_portal/cts_forms/templatetags/get_voting_mode.py
+++ b/crt_portal/cts_forms/templatetags/get_voting_mode.py
@@ -1,0 +1,11 @@
+
+from django.conf import settings
+
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def voting_mode():
+    return settings.VOTING_MODE


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1386)

## What does this change?
When voting mode is true:
This display voting banner as primary banner on landing page.
This shows hate crime as secondary banner on landing page

When voting mode is false:
This display hater crime as primary banner and no voting banner displayed.


## Checklist:
+ [x]  Voting banner displayed as primary when .env VOTING_MODE = True
+ [x]  Hate Crime banner displayed as secondary when .env VOTING_MODE = True
+ [x]  Hate Crime banner displayed as primary when .env VOTING_MODE = False

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

Please, rerun docker compose up when toggling between VOTING_MODE = True or False to clear and reset VOTING_MODE for validating.

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
