### PR TITLE
Update the voting toggle on the landing dropdown.

### DIFF
--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -203,13 +203,13 @@
                 <li>
                   <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="crt-landing--examples" aria-label="select example">
                     <div id="crt-landing--example_option">
-                        {% voting_banner as votbanner %}
-                        {% if votbanner == 'True' %}
-                        <!-- display only when voting toggle is on -->
-                            {{ choices.voting.description }}
-                        {% else %}
-                            {{ choices.workplace.description }}
-                        {% endif %}
+                      {% voting_banner as votbanner %}
+                      {% if votbanner == 'True' %}
+                      <!-- display only when voting toggle is on -->
+                          {{ choices.voting.description }}
+                      {% else %}
+                          {{ choices.workplace.description }}
+                      {% endif %}
                     </div>
                   </button>
                   <ul id="crt-landing--examples" class="usa-nav__submenu" hidden>

--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -203,7 +203,13 @@
                 <li>
                   <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="crt-landing--examples" aria-label="select example">
                     <div id="crt-landing--example_option">
-                      {{ choices.workplace.description }}
+                        {% voting_banner as votbanner %}
+                        {% if votbanner == 'True' %}
+                        <!-- display only when voting toggle is on -->
+                            {{ choices.voting.description }}
+                        {% else %}
+                            {{ choices.workplace.description }}
+                        {% endif %}
                     </div>
                   </button>
                   <ul id="crt-landing--examples" class="usa-nav__submenu" hidden>
@@ -232,9 +238,17 @@
                   {% trans "Examples" %}
                 </p>
                 <div id="crt-landing--choice_examples" class="crt-landing--text">
-                  {% for example in choices.workplace.examples %}
-                    <p>{{ example|safe }}</p>
-                  {% endfor %}
+                  {% voting_banner as votbanner %}
+                  {% if votbanner == 'True' %}
+                  <!-- display only when voting toggle is on -->
+                    {% for example in choices.voting.examples %}
+                      <p>{{ example|safe }}</p>
+                    {% endfor %}
+                  {% else %}
+                    {% for example in choices.workplace.examples %}
+                      <p>{{ example|safe }}</p>
+                    {% endfor %}
+                  {% endif %}
                 </div>
                 <div hidden id="crt-landing--hate-crimes">
                   <a href="./hate-crime-human-trafficking">{% trans "Get help for hate crimes" %}</a>

--- a/crt_portal/cts_forms/views_public.py
+++ b/crt_portal/cts_forms/views_public.py
@@ -46,7 +46,7 @@ class LandingPageView(TemplateView):
     template_name = "landing.html"
 
     def get_context_data(self, **kwargs):
-        primary_complaint_dictionary = PRIMARY_COMPLAINT_DICT if is_voting_mode() else PRIMARY_COMPLAINT_DICT_VOTING
+        primary_complaint_dictionary = PRIMARY_COMPLAINT_DICT_VOTING if is_voting_mode() else PRIMARY_COMPLAINT_DICT
         all_complaints = {
             **primary_complaint_dictionary,
             **LANDING_COMPLAINT_DICT,
@@ -321,7 +321,7 @@ class CRTReportWizard(SessionWizardView):
             # this variable improves some conditional display logic in templates
             primary_complaint_key = form_data_dict['primary_complaint']
             # unpack values in data for display
-            primary_complaint_dictionary = PRIMARY_COMPLAINT_DICT if is_voting_mode() else PRIMARY_COMPLAINT_DICT_VOTING
+            primary_complaint_dictionary = PRIMARY_COMPLAINT_DICT_VOTING if is_voting_mode() else PRIMARY_COMPLAINT_DICT
             form_data_dict['primary_complaint'] = data_decode(
                 form_data_dict, primary_complaint_dictionary, 'primary_complaint'
             )


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1396)

## What does this change?

When in voting mode, the voting examples should be shown first on the landing page.  

## Screenshots (for front-end PR):

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/6232068/192551508-e41bc067-43fe-42f8-907a-af2747b964e0.png">


## Checklist:

+ [ ] Turn voting mode on, and make sure that voting is displayed first on the landing (home) page.
+ [ ] Click all the examples and make sure the correct examples are shown from the correct selector.
+ [ ] Repeat the above two steps with voting mode turned off.  It should return to defaulting to workplace violations.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
