### PR TITLE
update zap file for scan settings

### DIFF
--- a/.circleci/zap.conf
+++ b/.circleci/zap.conf
@@ -40,6 +40,7 @@
 10057	WARN	(Username Hash Found)
 10061	WARN	(X-AspNet-Version Response Header Scanner)
 10062	WARN	(PII Scanner)
+10063   IGNORE  (Permissions Policy Header Not Set) Intentional architecture decision
 10096	IGNORE	(Timestamp Disclosure)
 10097	WARN	(Hash Disclosure)
 10098	WARN	(Cross-Domain Misconfiguration)
@@ -50,6 +51,7 @@
 3	WARN	(Session ID in URL Rewrite)
 50001	WARN	(Script Passive Scan Rules)
 90001	WARN	(Insecure JSF ViewState)
+90003   IGNORE  (Sub Resource Integrity Attribute Missing) Intentional architecture decision
 90011	WARN	(Charset Mismatch)
 90022	WARN	(Application Error Disclosure)
 90033	WARN	(Loosely Scoped Cookie)


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1418)

## What does this change?
This reset owasp scan setting in the zapfile for 
WARN-NEW: Permissions Policy Header Not Set [10063]
WARN-NEW: Sub Resource Integrity Attribute Missing [90003] x 15

## Checklist:
This only can be checked during merge to dev, stage and prod.
Changes can be reviewed by checking the zap.conf file latest changes.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
