### PR TITLE
Add random dates and more activity to reports

### DIFF
--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -23,7 +23,7 @@ def random_date():
     end_date = UTC.localize(datetime.now())
     delta = end_date - start_date
     int_delta = (delta.days * 24 * 60 * 60) + delta.seconds
-    random_second = randrange(int_delta)
+    random_second = randrange(int_delta)  # nosec
     return start_date + timedelta(seconds=random_second)
 
 

--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -9,6 +9,21 @@ from cts_forms.models import EmailReportCount, ProtectedClass
 from cts_forms.model_variables import PROTECTED_MODEL_CHOICES
 from cts_forms.forms import add_activity
 from django.contrib.auth.models import User
+from random import randrange
+from datetime import timedelta
+
+def random_date():
+    """
+    This function will return a random datetime between two datetime
+    objects.
+    """
+    UTC = timezone('UTC')
+    start_date = UTC.localize(datetime(2020, 1, 1))
+    end_date = UTC.localize(datetime.now())
+    delta = end_date - start_date
+    int_delta = (delta.days * 24 * 60 * 60) + delta.seconds
+    random_second = randrange(int_delta)
+    return start_date + timedelta(seconds=random_second)
 
 
 class Command(BaseCommand):  # pragma: no cover
@@ -60,9 +75,9 @@ class Command(BaseCommand):  # pragma: no cover
         for i in range(number_reports):
             report = ReportFactory.build()
             UTC = timezone('UTC')
-            report.create_date = UTC.localize(datetime.now())
-            # This save creates the report id, report.pk, so we can create a public_id
+            date = random_date()
             report.save()
+            report.create_date = date
             salt_chars = salt()
             report.public_id = f'{report.pk}-{salt_chars}'
 
@@ -110,6 +125,10 @@ class Command(BaseCommand):  # pragma: no cover
                 report.create_date = UTC.localize(datetime(2021, 1, 1, 0, 0, 0))
             # 50% chance of sending an email
             elif rand <= 50:
+                add_activity(user3, 'Contacted complainant:', f"Email sent: '{random_form_letters[i]}' to {report.contact_email} via govDelivery TMS", report)
+                add_activity(user3, 'Contacted complainant:', f"Email sent: '{random_form_letters[i]}' to {report.contact_email} via govDelivery TMS", report)
+                add_activity(user3, 'Contacted complainant:', f"Email sent: '{random_form_letters[i]}' to {report.contact_email} via govDelivery TMS", report)
+                add_activity(user3, 'Contacted complainant:', f"Email sent: '{random_form_letters[i]}' to {report.contact_email} via govDelivery TMS", report)
                 add_activity(user3, 'Contacted complainant:', f"Email sent: '{random_form_letters[i]}' to {report.contact_email} via govDelivery TMS", report)
                 protected_example = ProtectedClass.objects.get(value=PROTECTED_MODEL_CHOICES[0][0])
                 report.protected_class.add(protected_example)

--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -12,6 +12,7 @@ from django.contrib.auth.models import User
 from random import randrange
 from datetime import timedelta
 
+
 def random_date():
     """
     This function will return a random datetime between two datetime


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1416)

## What does this change?

When testing locally, we were just adding a couple of dates to mock reports that were generated.  This PR will make the reports have random dates within the correct range, and add a couple of edge cases for testing. 

Note this will never be run anywhere but locally. 

## Screenshots (for front-end PR):

## Checklist:

+ [x] run ```docker-compose run web python crt_portal/manage.py create_mock_reports 50```
+ [x] check create dates on the new reports and make sure they fall within the range of 2020-present.

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
