### PR TITLE
deactivate trend refresh on cicd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,10 +458,10 @@ jobs:
       - run:
           name: Flag reports submitted by repeat writers or that have violation summaries identical to other reports
           command: cf run-task crt-portal-django -c "python crt_portal/manage.py flag_repeat_writers" --name flag-repeat-writers  
-      # Refresh the trend view in dev
-      - run:
-          name: Refresh trends view
-          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
+      # Refresh the trend view in dev deactivated
+      # - run:
+      #    name: Refresh trends view
+      #    command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
       # Clear expired sessions in staging session table
       - run:
           name: clearsessions management command

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,10 +380,10 @@ jobs:
       - run:
           name: Login to cloud.gov Production
           command: cf login -u ${CRT_USERNAME_PROD} -p ${CRT_PASSWORD_PROD} -o doj-crtportal -s ${CF_SPACE}
-      # Refresh the trend view in prod
-      - run:
-          name: Refresh trends view
-          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
+      # Refresh the trend view task in prod deactivated
+      # - run:
+      #    name: Refresh trends view
+      #    command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
       # Mark by_repeat_writer true on reports that were submitted by repeat writers or which have violation summaries identical to other reports
       - run:
           name: Flag reports submitted by repeat writers or that have violation summaries identical to other reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,10 +421,10 @@ jobs:
       - run:
           name: Flag reports submitted by repeat writers or that have violation summaries identical to other reports
           command: cf run-task crt-portal-django -c "python crt_portal/manage.py flag_repeat_writers" --name flag-repeat-writers 
-      # Refresh the trend view in staging
-      - run:
-          name: Refresh trends view
-          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
+      # Refresh the trend view in staging deactivated
+      # - run:
+      #     name: Refresh trends view
+      #     command: cf run-task crt-portal-django  -c "python crt_portal/manage.py refresh_trends" --name refresh-trends
       # Clear expired sessions in staging session table
       - run:
           name: clearsessions management command


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1431)

## What does this change?
Deactivate the trend refresh in CI/CD pipeline

## Checklist:
+ [ ] CI/CD config file commented out for trend refresh for dev, staging and prod.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
