### PR TITLE
Add a pre-push hook that runs unit tests

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -29,6 +29,6 @@ if [[ -n "$unstaged" ]]; then
   echo
 fi
 
-docker --log-level ERROR compose run --no-TTY web flake8
+docker --log-level ERROR compose run --interactive --no-TTY web flake8
 echo 'Flake8 passed!'
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,12 +9,13 @@ changes="$( \
     | grep '\.py$' || printf '' \
 )"
 if [[ -z "$changes" ]]; then
+  echo 'No python changes detected, skipping pre-commit flake8'
   exit 0  # Skip flake8 because we have no changed python code.
 fi
 
 # Run flake8 against all code in the `source_code` directory
 # Only output failures.
-echo 'Running flake8...'
+echo 'Running pre-commit flake8 (run again with --no-verify to skip)...'
 
 unstaged="$( \
   git ls-files -m \

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# If any command fails, exit immediately with that command's exit status
+set -eo pipefail
+
+echo 'Running pre-push tests (run again with --no-verify to skip)...'
+
+docker compose run --no-TTY web \
+    python /code/crt_portal/manage.py test cts_forms \
+    --noinput --parallel
+
+echo 'Tests passed!'

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,7 +5,7 @@ set -eo pipefail
 
 echo 'Running pre-push tests (run again with --no-verify to skip)...'
 
-docker compose run --no-TTY web \
+docker compose run --interactive --no-TTY web \
     python /code/crt_portal/manage.py test cts_forms \
     --noinput --parallel
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ After the strings are translated, the translation can be compiled back to Django
 
     docker-compose run -w /code/crt_portal/cts_forms web django-admin compilemessages
 
-Note: Sometimes links should be included in a translation because they might appear in different parts of the sentence in different languages.  If so, you need to change the quotes within the hyperlinks from double quotes to single quote.  eg 
+Note: Sometimes links should be included in a translation because they might appear in different parts of the sentence in different languages.  If so, you need to change the quotes within the hyperlinks from double quotes to single quote.  eg
 
 ```
 {% trans "To report civil rights violations, go to <a class='link--blue' href='https://civilrights.justice.gov/report/'>civilrights.justice.gov/report</a>" %} .
@@ -186,6 +186,8 @@ The volumes are the data elements in Docker. Note that you will need to re-creat
 ## Tests
 
 Tests run automatically with repos that are integrated with Circle CI. You can run those tests locally with the following instructions.
+
+To avoid pushing broken code, you can also configure tests to run locally automatically by following the instructions in [.githooks/README.md](.githooks/README.md).
 
 ### Unit tests
 
@@ -305,9 +307,9 @@ That will produce a report locally that you can view in your browser. It will gi
 
 ### End-to-End tests
 
-We're using [Playwright](https://github.com/microsoft/playwright-python) for automated end-to-end testing. 
+We're using [Playwright](https://github.com/microsoft/playwright-python) for automated end-to-end testing.
 
-To run Playwright tests locally, first install it by running 
+To run Playwright tests locally, first install it by running
 
     pipenv install playwright
 


### PR DESCRIPTION
## What does this change?

- 🌎 Project norms encourage running unit tests prior to pushing. This avoids circleci noise, and lets us make typo fixes via amend instead of via followup commits.
- ⛔ Right now this norm is only a norm - there's no automated enforcement.
- ✅ This commit provides an *opt-in* check to automatically run unit tests.
  - Even after opting in, it explains how to skip the check (and updates the pre-commit hook to explain, too) if a push is urgent or tests can't be run locally for whatever reason.

## Screenshots (for front-end PR):

<img width="823" alt="image" src="https://user-images.githubusercontent.com/15126660/210837944-0f36747c-0c07-485d-a565-d7c1ed72dffa.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
