### PR TITLE
Table Accessibility

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -12,7 +12,7 @@
     <table class="usa-table crt-table sort-table">
       <thead>
         <tr>
-          <th>
+          <th aria-label="Bulk Action Selection">
             <div class="usa-checkbox td-checkbox">
               <input type="checkbox"
                      name="all"
@@ -20,10 +20,10 @@
                      value="all"
                      id="checkbox-all"
               >
-              <label class="usa-checkbox__label crt-checkbox__label checkbox-all" for="checkbox-all" aria-label="select all records"></label>
+              <label class="usa-checkbox__label crt-checkbox__label checkbox-all" for="checkbox-all" aria-label="Select all records"></label>
             </div>
           </th>
-          <th>
+          <th aria-label="Detail toggles">
             <a aria-expanded="false" role="button" aria-label="Expand all detail rows" id="toggle-all" class="td-toggle-all display-flex" data-posted='false' href="#">
               <img aria-hidden="true" src="{% static "img/intake-icons/ic_chevron-right.svg" %}" class="icon">
             </a>
@@ -52,7 +52,7 @@
                          value="{{ datum.report.id }}"
                          id="checkbox-{{ datum.report.id }}"
                   >
-                  <label class="usa-checkbox__label crt-checkbox__label" for="checkbox-{{ datum.report.id }}" aria-label="select record {{ datum.report.id }}"></label>
+                  <label class="usa-checkbox__label crt-checkbox__label" for="checkbox-{{ datum.report.id }}" aria-label="Select record {{ datum.report.id }}"></label>
                 </div>
               </td>
               <td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -10,6 +10,13 @@
 
   <div class="crt-xscroll">
     <table class="usa-table crt-table sort-table">
+      {# This "fake" table makes nested headers available to screen readers #}
+      <span role="table" class="usa-sr-only">
+        <span role="row">
+          <span role="columnheader" class="usa-sr-only" id="crt-table-summary-header">Summary</span>
+          <span role="columnheader" class="usa-sr-only" id="crt-table-description-header">Personal Description</span>
+        </span>
+      </span>
       <thead>
         <tr>
           <th aria-label="Bulk Action Selection">
@@ -39,8 +46,6 @@
           {% render_sortable_heading 'Incident City/State' sort_state filter_state %}
           {% render_sortable_heading 'Incident Date' sort_state filter_state %}
         </tr>
-        <span class="usa-sr-only" role="columnheader" id="crt-table-summary-header">Summary</span>
-        <span class="usa-sr-only" role="columnheader" id="crt-table-description-header">Personal Description</span>
       </thead>
       {% if data_dict %}
         <tbody>
@@ -112,7 +117,9 @@
             </tr>
             {# this row is hidden by default #}
             <tr class="tr-quickview" id="tr-additional-{{ datum.report.id }}" hidden>
-              <td headers="crt-table-summary-header" class="quickview" colspan="6">
+              {# All screen readers don't yet read the headers attribute correctly, so we've added a redundant aria-label #}
+              {# https://a11ysupport.io/tech/html/headers_attribute #}
+              <td aria-label="Summary" headers="crt-table-summary-header" class="quickview" colspan="6">
                 <label aria-hidden="true" for="tr-quickview-summary-{{ datum.report.id }}" class="td-quickview">
                   Summary
                 </label>
@@ -122,7 +129,7 @@
                   {% endwith %}
                 </div>
               </td>
-              <td headers="crt-table-description-header" class="quickview" colspan="6">
+              <td aria-label="Personal Description" headers="crt-table-description-header" class="quickview" colspan="6">
                 <label aria-hidden="true" for="tr-quickview-description-{{ datum.report.id }}" class="td-quickview">
                   Personal Description
                 </label>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -32,7 +32,7 @@
           </th>
           <th aria-label="Detail toggles">
             <a aria-expanded="false" role="button" aria-label="Expand all detail rows" id="toggle-all" class="td-toggle-all display-flex" data-posted='false' href="#">
-              <img aria-hidden="true" src="{% static "img/intake-icons/ic_chevron-right.svg" %}" class="icon">
+              <img alt="" aria-hidden="true" src="{% static "img/intake-icons/ic_chevron-right.svg" %}" class="icon">
             </a>
           </th>
           {% render_sortable_heading 'Status' sort_state filter_state %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -39,6 +39,8 @@
           {% render_sortable_heading 'Incident City/State' sort_state filter_state %}
           {% render_sortable_heading 'Incident Date' sort_state filter_state %}
         </tr>
+        <span class="usa-sr-only" role="columnheader" id="crt-table-summary-header">Summary</span>
+        <span class="usa-sr-only" role="columnheader" id="crt-table-description-header">Personal Description</span>
       </thead>
       {% if data_dict %}
         <tbody>
@@ -109,23 +111,22 @@
               </td>
             </tr>
             {# this row is hidden by default #}
-            <tr id="tr-additional-{{ datum.report.id }}" hidden>
-              <td colspan="2"></td>
-              <td colspan="4">
-                <div class="td-quickview">
+            <tr class="tr-quickview" id="tr-additional-{{ datum.report.id }}" hidden>
+              <td headers="crt-table-summary-header" class="quickview" colspan="6">
+                <label aria-hidden="true" for="tr-quickview-summary-{{ datum.report.id }}" class="td-quickview">
                   Summary
-                </div>
-                <div class="td-summary">
+                </label>
+                <div role="textbox" aria-readonly="true" id="tr-quickview-summary-{{ datum.report.id }}" class="td-summary">
                   {% with summary=datum.report.get_summary %}
                     {{ summary.note|linebreaks|default:"-" }}
                   {% endwith %}
                 </div>
               </td>
-              <td colspan="4">
-                <div class="td-quickview">
+              <td headers="crt-table-description-header" class="quickview" colspan="6">
+                <label aria-hidden="true" for="tr-quickview-description-{{ datum.report.id }}" class="td-quickview">
                   Personal Description
-                </div>
-                <div class="td-summary word-break">
+                </label>
+                <div role="textbox" aria-readonly="true" id="tr-quickview-description-{{ datum.report.id }}" class="td-summary word-break">
                   {{ datum.report.violation_summary|linebreaks|default:"-" }}
                 </div>
               </td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -117,9 +117,12 @@
             </tr>
             {# this row is hidden by default #}
             <tr class="tr-quickview" id="tr-additional-{{ datum.report.id }}" hidden>
+              <td class="quickview">
+                <span class="usa-sr-only">Details for record {{ datum.report.id }}</span>
+              </td>
               {# All screen readers don't yet read the headers attribute correctly, so we've added a redundant aria-label #}
               {# https://a11ysupport.io/tech/html/headers_attribute #}
-              <td aria-label="Summary" headers="crt-table-summary-header" class="quickview" colspan="6">
+              <td aria-label="Summary" headers="crt-table-summary-header" class="quickview" colspan="5">
                 <label aria-hidden="true" for="tr-quickview-summary-{{ datum.report.id }}" class="td-quickview">
                   Summary
                 </label>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -11,7 +11,7 @@
   <div class="crt-xscroll">
     <table class="usa-table crt-table sort-table">
       {# This "fake" table makes nested headers available to screen readers #}
-      <span role="table" class="usa-sr-only">
+      <span tabindex="-1" role="table" class="usa-sr-only">
         <span role="row">
           <span role="columnheader" class="usa-sr-only" id="crt-table-summary-header">Summary</span>
           <span role="columnheader" class="usa-sr-only" id="crt-table-description-header">Personal Description</span>
@@ -126,7 +126,7 @@
                 <label aria-hidden="true" for="tr-quickview-summary-{{ datum.report.id }}" class="td-quickview">
                   Summary
                 </label>
-                <div role="textbox" aria-readonly="true" id="tr-quickview-summary-{{ datum.report.id }}" class="td-summary">
+                <div tabindex="0" role="textbox" aria-readonly="true" id="tr-quickview-summary-{{ datum.report.id }}" class="td-summary">
                   {% with summary=datum.report.get_summary %}
                     {{ summary.note|linebreaks|default:"-" }}
                   {% endwith %}
@@ -136,7 +136,7 @@
                 <label aria-hidden="true" for="tr-quickview-description-{{ datum.report.id }}" class="td-quickview">
                   Personal Description
                 </label>
-                <div role="textbox" aria-readonly="true" id="tr-quickview-description-{{ datum.report.id }}" class="td-summary word-break">
+                <div tabindex="0" role="textbox" aria-readonly="true" id="tr-quickview-description-{{ datum.report.id }}" class="td-summary word-break">
                   {{ datum.report.violation_summary|linebreaks|default:"-" }}
                 </div>
               </td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -1,5 +1,6 @@
 {% load sortable_table_heading %}
 {% load static %}
+
 <form class="usa-form"
       method="get"
       action="{% url 'crt_forms:crt-forms-actions' %}"
@@ -23,8 +24,8 @@
             </div>
           </th>
           <th>
-            <a class="td-toggle-all display-flex" data-posted='false' href="#">
-              <img src="{% static "img/intake-icons/ic_chevron-right.svg" %}" alt="show all rows containing additional information" class="icon">
+            <a aria-expanded="false" role="button" aria-label="Expand all detail rows" id="toggle-all" class="td-toggle-all display-flex" data-posted='false' href="#">
+              <img aria-hidden="true" src="{% static "img/intake-icons/ic_chevron-right.svg" %}" class="icon">
             </a>
           </th>
           {% render_sortable_heading 'Status' sort_state filter_state %}
@@ -55,8 +56,8 @@
                 </div>
               </td>
               <td>
-                <a data-id="{{ datum.report.id }}" class="td-toggle display-flex" href="#">
-                  <img src="{% static "img/intake-icons/ic_chevron-right.svg" %}" alt="show additional information in a new row" class="icon">
+                <a data-id="{{ datum.report.id }}" aria-expanded="false" aria-label="Expand details for Record {{datum.report.id}}" role="button" aria-controls="tr-additional-{{ datum.report.id }}" class="td-toggle display-flex" href="#">
+                  <img aria-hidden="true" src="{% static "img/intake-icons/ic_chevron-right.svg" %}" class="icon">
                 </a>
               </td>
               <td>

--- a/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-<th aria-label="{{heading}}" scope="col" class="{% if sort_url %}sort-cell{% endif %}" {% if nowrap %}nowrap{% endif %}>
+<th scope="col" class="{% if sort_url %}sort-cell{% endif %}" {% if nowrap %}nowrap{% endif %}>
   {% if sort_url %}
     <a
       id="{{id}}"
@@ -10,10 +10,10 @@
       class="sort-link display-block {% if is_descending %}sort-up{% else %}sort-down{% endif %}"
       aria-label="Sort complaints by {{ heading }} {% if is_descending %}descending{% else %}ascending{% endif %}"
     >
-      <span aria-hidden="true">{{ heading }}</span>
+      <span>{{ heading }}</span>
     </a>
   {% else %}
-    <span aria-hidden="true">
+    <span tabindex="0">
       {{ heading }}
     </span>
   {% endif %}

--- a/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-<th scope="col" class="{% if sort_url %}sort-cell{% endif %}" {% if nowrap %}nowrap{% endif %}>
+<th aria-label="{{heading}}" scope="col" class="{% if sort_url %}sort-cell{% endif %}" {% if nowrap %}nowrap{% endif %}>
   {% if sort_url %}
     <a
       id="{{id}}"
@@ -10,10 +10,10 @@
       class="sort-link display-block {% if is_descending %}sort-up{% else %}sort-down{% endif %}"
       aria-label="Sort complaints by {{ heading }} {% if is_descending %}descending{% else %}ascending{% endif %}"
     >
-      <span>{{ heading }}</span>
+      <span aria-hidden="true">{{ heading }}</span>
     </a>
   {% else %}
-    <span>
+    <span aria-hidden="true">
       {{ heading }}
     </span>
   {% endif %}

--- a/crt_portal/static/js/complaint_quick_view.js
+++ b/crt_portal/static/js/complaint_quick_view.js
@@ -7,10 +7,12 @@
       var id = target.dataset['id'];
       var image = target.children[0];
       var row = dom.getElementById('tr-additional-' + id);
-      if (image.classList.contains('rotate')) {
+      if (target.getAttribute('aria-expanded') === 'true') {
+        target.setAttribute('aria-expanded', 'false');
         image.classList.remove('rotate');
         row.setAttribute('hidden', '');
       } else {
+        target.setAttribute('aria-expanded', 'true');
         image.classList.add('rotate');
         row.removeAttribute('hidden');
 

--- a/crt_portal/static/js/dashboard_view_all.js
+++ b/crt_portal/static/js/dashboard_view_all.js
@@ -3,12 +3,13 @@
     const arrow = toggle.querySelector('.icon');
     const id = toggle.dataset['id'];
     const summary = dom.getElementById(`tr-additional-${id}`);
+    toggle.setAttribute('aria-expanded', isToggled(toggle) ? 'false' : 'true');
     arrow.classList.toggle('rotate');
     summary.toggleAttribute('hidden');
   }
 
   function isToggled(target) {
-    return target.querySelector('.icon').classList.contains('rotate');
+    return target.getAttribute('aria-expanded') === 'true';
   }
 
   function markAsViewed(ids) {
@@ -37,6 +38,7 @@
     event.preventDefault();
     const allToggled = isToggled(toggleAll);
     toggleAll.querySelector('.icon').classList.toggle('rotate');
+    toggleAll.setAttribute('aria-expanded', allToggled ? 'false' : 'true');
     const toggles = [...dom.querySelectorAll('a.td-toggle')].filter(
       toggle => isToggled(toggle) == allToggled
     );

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -148,7 +148,19 @@
       }
     }
 
+    td.quickview {
+      &:first-of-type {
+        // Skip the checkbox and expansion rows
+        padding-left: calc(65px + 42px + 1rem);
+      }
+      &:last-of-type {
+        // Skip the last two columns
+        padding-right: calc(150px + 167px + 1rem);
+      }
+    }
+
     .td-quickview {
+      display: block;
       font-weight: bold;
       text-transform: uppercase;
       margin-bottom: 0.5rem;

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -150,8 +150,8 @@
 
     td.quickview {
       &:first-of-type {
-        // Skip the checkbox and expansion rows
-        padding-left: calc(65px + 42px + 1rem);
+        // Skip the checkbox row
+        padding-left: calc(30px + 1rem);
       }
       &:last-of-type {
         // Skip the last two columns


### PR DESCRIPTION
## What does this change?

### Adds an expanded/collapsed indicator
- ⛔ The report list table doesn't include state (expanded/collapsed) or
  role (button, not link) properly, and the wording is off.
- ✅ This commit improves them by:
  * Tweaking some of the wording
  * Using aria-expanded and role to indicate properly that it's an
    expand/collapse button.

### Adds more accurate column headers
- 🌎 Screen readers read the column header when navigating between table
  cells to indicate which column you're on, e.g. "View Count. 15."
- ⛔ The report list were reads as "Sort by x ascending" for the column header.
- ✅ This commit changes the column label to the heading (Status, etc).
  * When readers are on the headers, they will say, "Status. Sort by status"
  * When readers are on the cells, they will say, "Status. Link. New."

### Improves checkbox/expansion wording
- 🌎 This commit relates to the accessibility of the /form/view table. Screen readers current read the checkbox header as "checkboxes".
- ⛔ That doesn't give any info about what the checkboxes do. Smart
  screen readers default to "Select all records" which isn't great,
  either, especially when it reads it on individual rows.
- ✅ This commit adds a header to the checkboxes and to the dropdowns to
  make it a bit more descriptive.

### Improves detail row interaction
- ⛔ Screen readers don't read the detail rows properly
- ✅ This commit helps make them more accessible by providing
  appropriate table headers and aria roles.

## Screenshots (for front-end PR):

A quick demo of this feature can be found here (note - this demo excludes the redundant headers found based on aXe failures):

https://user-images.githubusercontent.com/15126660/212344533-8ce50b76-2abe-4d82-abd4-d7b493968b1a.mp4

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
