### PR TITLE
Fix CircleCI Failures after Python 3.10.8 Upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,13 +119,13 @@ jobs:
       - run:
           name: Run pa11y-ci accessibility check
           command: |
-            curl --retry-delay 5 --retry 10 --retry-connrefused http://127.0.0.1:8000
+            curl --retry-delay 5 --retry 10 --retry-connrefused http://localhost:8000
             npm run test:a11y-without-report
       - store_artifacts:
           path: ./pa11y-screenshots
       - run:
           name: E2E tests
-          command: pipenv run pytest crt_portal/cts_forms/tests/integration/*.py --base-url=http://127.0.0.1:8000
+          command: pipenv run pytest crt_portal/cts_forms/tests/integration/*.py --base-url=http://localhost:8000
 
   e2e-test-dev:
     description: Runs E2E tests against dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,8 @@ jobs:
           background: true
       - run:
           name: Run pa11y-ci accessibility check
+          environment:
+            PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
           command: |
             curl --retry-delay 5 --retry 10 --retry-connrefused http://localhost:8000
             npm run test:a11y-without-report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,19 +114,18 @@ jobs:
             # create pa11y_tester
             echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_user('pa11y_tester', 'admin@myproject.com', '$PA11Y_PASSWORD')" | pipenv run crt_portal/manage.py shell
             # runserver
-            pipenv run crt_portal/manage.py runserver 8000
+            pipenv run crt_portal/manage.py runserver 0.0.0.0:8000
           background: true
-      # temporarily turning off Pa11y test to remove CI/CD blocker
-      #- run:
-      #    name: Run pa11y-ci accessibility check
-      #    command: |
-      #      curl --retry-delay 5 --retry 10 --retry-connrefused http://127.0.0.1:8000
-      #      npm run test:a11y-without-report
-      #- store_artifacts:
-      #    path: ./pa11y-screenshots
-      #- run:
-      #    name: E2E tests
-      #    command: pipenv run pytest crt_portal/cts_forms/tests/integration/*.py --base-url=http://127.0.0.1:8000
+      - run:
+          name: Run pa11y-ci accessibility check
+          command: |
+            curl --retry-delay 5 --retry 10 --retry-connrefused http://127.0.0.1:8000
+            npm run test:a11y-without-report
+      - store_artifacts:
+          path: ./pa11y-screenshots
+      - run:
+          name: E2E tests
+          command: pipenv run pytest crt_portal/cts_forms/tests/integration/*.py --base-url=http://127.0.0.1:8000
 
   e2e-test-dev:
     description: Runs E2E tests against dev
@@ -421,7 +420,7 @@ jobs:
       # Mark by_repeat_writer true on reports that were submitted by repeat writers or which have violation summaries identical to other reports
       - run:
           name: Flag reports submitted by repeat writers or that have violation summaries identical to other reports
-          command: cf run-task crt-portal-django -c "python crt_portal/manage.py flag_repeat_writers" --name flag-repeat-writers 
+          command: cf run-task crt-portal-django -c "python crt_portal/manage.py flag_repeat_writers" --name flag-repeat-writers
       # Refresh the trend view in staging deactivated
       # - run:
       #     name: Refresh trends view
@@ -458,7 +457,7 @@ jobs:
       # Mark by_repeat_writer true on reports that were submitted by repeat writers or which have violation summaries identical to other reports
       - run:
           name: Flag reports submitted by repeat writers or that have violation summaries identical to other reports
-          command: cf run-task crt-portal-django -c "python crt_portal/manage.py flag_repeat_writers" --name flag-repeat-writers  
+          command: cf run-task crt-portal-django -c "python crt_portal/manage.py flag_repeat_writers" --name flag-repeat-writers
       # Refresh the trend view in dev deactivated
       # - run:
       #    name: Refresh trends view

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,20 +85,19 @@ jobs:
       - run:
           name: Run prettier code formatting check
           command: npm run lint:check
-      # TEMP: removing to iterate faster in CircleCI
-      # - run:
-      #     name: Run unit tests & check coverage
-      #     command: |
-      #       pipenv run coverage run --source='crt_portal' crt_portal/manage.py test --settings=crt_portal.test_settings cts_forms
-      #       pipenv run coverage report --fail-under=85 -m
-      # - run:
-      #     name: Run bandit (Python security) tests
-      #     command: |
-      #       pipenv run bandit -r crt_portal/ --exclude cts_forms/tests
-      # - run:
-      #     name: Run flake8 test for Python code style
-      #     command: |
-      #       pipenv run flake8
+      - run:
+          name: Run unit tests & check coverage
+          command: |
+            pipenv run coverage run --source='crt_portal' crt_portal/manage.py test --settings=crt_portal.test_settings cts_forms
+            pipenv run coverage report --fail-under=85 -m
+      - run:
+          name: Run bandit (Python security) tests
+          command: |
+            pipenv run bandit -r crt_portal/ --exclude cts_forms/tests
+      - run:
+          name: Run flake8 test for Python code style
+          command: |
+            pipenv run flake8
       - run:
           name: add or update response templates
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,19 +85,20 @@ jobs:
       - run:
           name: Run prettier code formatting check
           command: npm run lint:check
-      - run:
-          name: Run unit tests & check coverage
-          command: |
-            pipenv run coverage run --source='crt_portal' crt_portal/manage.py test --settings=crt_portal.test_settings cts_forms
-            pipenv run coverage report --fail-under=85 -m
-      - run:
-          name: Run bandit (Python security) tests
-          command: |
-            pipenv run bandit -r crt_portal/ --exclude cts_forms/tests
-      - run:
-          name: Run flake8 test for Python code style
-          command: |
-            pipenv run flake8
+      # TEMP: removing to iterate faster in CircleCI
+      # - run:
+      #     name: Run unit tests & check coverage
+      #     command: |
+      #       pipenv run coverage run --source='crt_portal' crt_portal/manage.py test --settings=crt_portal.test_settings cts_forms
+      #       pipenv run coverage report --fail-under=85 -m
+      # - run:
+      #     name: Run bandit (Python security) tests
+      #     command: |
+      #       pipenv run bandit -r crt_portal/ --exclude cts_forms/tests
+      # - run:
+      #     name: Run flake8 test for Python code style
+      #     command: |
+      #       pipenv run flake8
       - run:
           name: add or update response templates
           command: |
@@ -121,12 +122,14 @@ jobs:
           environment:
             PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
           command: |
-            curl --retry-delay 5 --retry 10 --retry-connrefused http://localhost:8000
+            curl --retry-delay 5 --retry 10 --retry-all-errors http://localhost:8000
             npm run test:a11y-without-report
       - store_artifacts:
           path: ./pa11y-screenshots
       - run:
           name: E2E tests
+          environment:
+            PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
           command: pipenv run pytest crt_portal/cts_forms/tests/integration/*.py --base-url=http://localhost:8000
 
   e2e-test-dev:

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -75,7 +75,7 @@ ALLOWED_HOSTS = [
 ]
 
 if environment == 'UNDEFINED':
-    ALLOWED_HOSTS = ['127.0.0.1']
+    ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
 
 # Application definition
 

--- a/pa11y_scripts/.all-spanish.json
+++ b/pa11y_scripts/.all-spanish.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -10,7 +10,7 @@
       "screenCapture": "pa11y-screenshots/es-page1-contact.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -21,7 +21,7 @@
       "screenCapture": "pa11y-screenshots/es-page1-error.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -35,7 +35,7 @@
       "screenCapture": "pa11y-screenshots/es-page2-error.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -47,7 +47,7 @@
       "screenCapture": "pa11y-screenshots/es-page2-primary-issue.png"
     },
      {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -62,7 +62,7 @@
       "screenCapture": "pa11y-screenshots/es-page3-hatecrime.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -80,7 +80,7 @@
       "screenCapture": "pa11y-screenshots/es-page3-location-commercial.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -97,7 +97,7 @@
       "screenCapture": "pa11y-screenshots/es-page3-location-education.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -114,7 +114,7 @@
       "screenCapture": "pa11y-screenshots/es-page3-location-police.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -131,7 +131,7 @@
       "screenCapture": "pa11y-screenshots/es-page3-location-workplace.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -155,7 +155,7 @@
       "screenCapture": "pa11y-screenshots/es-page4-protected-class.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -182,7 +182,7 @@
       "screenCapture": "pa11y-screenshots/es-page4-date.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -217,7 +217,7 @@
       "screenCapture": "pa11y-screenshots/es-page5-date-error.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -248,7 +248,7 @@
       "screenCapture": "pa11y-screenshots/es-page6-details.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",
@@ -281,7 +281,7 @@
       "screenCapture": "pa11y-screenshots/es-page7-review.png"
     },
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "set field #i8n_select to es",
         "click element #language-select",

--- a/pa11y_scripts/.crt-details.json
+++ b/pa11y_scripts/.crt-details.json
@@ -1,13 +1,13 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/form/view/1/",
+      "url": "http://localhost:8000/form/view/1/",
       "actions": [
-        "wait for url to be http://127.0.0.1:8000/accounts/login/?next=/form/view/1/",
+        "wait for url to be http://localhost:8000/accounts/login/?next=/form/view/1/",
         "set field #id_username to pa11y_tester",
         "set field #id_password to imposing40Karl5monomial",
         "click #login",
-        "wait for url to be http://127.0.0.1:8000/form/view/1/",
+        "wait for url to be http://localhost:8000/form/view/1/",
         "wait for element #id_status to be visible"
       ],
       "screenCapture": "pa11y-screenshots/crt-detail.png"

--- a/pa11y_scripts/.crt-landing.json
+++ b/pa11y_scripts/.crt-landing.json
@@ -2,17 +2,17 @@
     "urls": [
         {
           "useIncognitoBrowserContext": true,
-          "url": "http://127.0.0.1:8000/",
+          "url": "http://localhost:8000/",
           "actions": [
-            "wait for url to be http://127.0.0.1:8000/"
+            "wait for url to be http://localhost:8000/"
           ],
           "screenCapture": "pa11y-screenshots/crt-landing-view.png"
         },
         {
           "useIncognitoBrowserContext": true,
-          "url": "http://127.0.0.1:8000/",
+          "url": "http://localhost:8000/",
           "actions": [
-            "wait for url to be http://127.0.0.1:8000/",
+            "wait for url to be http://localhost:8000/",
             "click #crt-landing--example_option",
             "wait for element #crt-landing--example-workplace to be visible"
           ],

--- a/pa11y_scripts/.crt-new.json
+++ b/pa11y_scripts/.crt-new.json
@@ -1,13 +1,13 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/form/new/",
+      "url": "http://localhost:8000/form/new/",
       "actions": [
-        "wait for url to be http://127.0.0.1:8000/accounts/login/?next=/form/new/",
+        "wait for url to be http://localhost:8000/accounts/login/?next=/form/new/",
         "set field #id_username to pa11y_tester",
         "set field #id_password to imposing40Karl5monomial",
         "click #login",
-        "wait for url to be http://127.0.0.1:8000/form/new/"
+        "wait for url to be http://localhost:8000/form/new/"
       ],
       "screenCapture": "pa11y-screenshots/crt-new.png"
     }

--- a/pa11y_scripts/.crt-privacy-policy.json
+++ b/pa11y_scripts/.crt-privacy-policy.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/privacy-policy",
+      "url": "http://localhost:8000/privacy-policy",
       "actions": [
         "wait for element #privacy-act-statement to be visible"
       ],

--- a/pa11y_scripts/.crt-trends.json
+++ b/pa11y_scripts/.crt-trends.json
@@ -2,13 +2,13 @@
     "urls": [
         {
           "useIncognitoBrowserContext": true,
-          "url": "http://127.0.0.1:8000/form/trends/",
+          "url": "http://localhost:8000/form/trends/",
           "actions": [
-            "wait for url to be http://127.0.0.1:8000/accounts/login/?next=/form/trends/",
+            "wait for url to be http://localhost:8000/accounts/login/?next=/form/trends/",
             "set field #id_username to pa11y_tester",
             "set field #id_password to imposing40Karl5monomial",
             "click #login",
-            "wait for url to be http://127.0.0.1:8000/form/trends/"
+            "wait for url to be http://localhost:8000/form/trends/"
           ],
           "screenCapture": "pa11y-screenshots/crt-trends.png"
         }

--- a/pa11y_scripts/.crt-view-date.json
+++ b/pa11y_scripts/.crt-view-date.json
@@ -2,9 +2,9 @@
     "urls": [
         {
             "useIncognitoBrowserContext": true,
-            "url": "http://127.0.0.1:8000/form/view/",
+            "url": "http://localhost:8000/form/view/",
             "actions": [
-                "wait for url to be http://127.0.0.1:8000/accounts/login/?next=/form/view/",
+                "wait for url to be http://localhost:8000/accounts/login/?next=/form/view/",
                 "set field #id_username to pa11y_tester",
                 "set field #id_password to imposing40Karl5monomial",
                 "click element #login",

--- a/pa11y_scripts/.crt-view-text-input-filters.json
+++ b/pa11y_scripts/.crt-view-text-input-filters.json
@@ -2,9 +2,9 @@
     "urls": [
         {
           "useIncognitoBrowserContext": true,
-          "url": "http://127.0.0.1:8000/form/view/",
+          "url": "http://localhost:8000/form/view/",
           "actions": [
-            "wait for url to be http://127.0.0.1:8000/accounts/login/?next=/form/view/",
+            "wait for url to be http://localhost:8000/accounts/login/?next=/form/view/",
             "set field #id_username to pa11y_tester",
             "set field #id_password to imposing40Karl5monomial",
             "click #login",

--- a/pa11y_scripts/.crt-view.json
+++ b/pa11y_scripts/.crt-view.json
@@ -2,9 +2,9 @@
   "urls": [
     {
       "useIncognitoBrowserContext": true,
-      "url": "http://127.0.0.1:8000/form/view/",
+      "url": "http://localhost:8000/form/view/",
       "actions": [
-        "wait for url to be http://127.0.0.1:8000/accounts/login/?next=/form/view/",
+        "wait for url to be http://localhost:8000/accounts/login/?next=/form/view/",
         "set field #id_username to pa11y_tester",
         "set field #id_password to imposing40Karl5monomial",
         "click element #login",
@@ -13,7 +13,7 @@
         "wait for element #submitted-sort to be visible",
         "screen capture pa11y-screenshots/crt-sort-view-extra-wait.png",
         "click element #submitted-sort",
-        "wait for url to be http://127.0.0.1:8000/form/view/?sort=-create_date&status=new&status=open"
+        "wait for url to be http://localhost:8000/form/view/?sort=-create_date&status=new&status=open"
       ],
       "screenCapture": "pa11y-screenshots/crt-sort-view.png"
     }

--- a/pa11y_scripts/.p1-contact.json
+++ b/pa11y_scripts/.p1-contact.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-contact_phone to be visible"
       ],

--- a/pa11y_scripts/.p1-error.json
+++ b/pa11y_scripts/.p1-error.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_0 to be visible",
         "wait for element #report-step-1-continue to be visible",

--- a/pa11y_scripts/.p2-error.json
+++ b/pa11y_scripts/.p2-error.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember to be visible",
         "click element #id_0-servicemember_0",

--- a/pa11y_scripts/.p2-primary-issue.json
+++ b/pa11y_scripts/.p2-primary-issue.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "click element #id_0-servicemember_0",
         "wait for element #report-step-1-continue to be visible",

--- a/pa11y_scripts/.p3-hatecrime.json
+++ b/pa11y_scripts/.p3-hatecrime.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",

--- a/pa11y_scripts/.p3-location-commercial.json
+++ b/pa11y_scripts/.p3-location-commercial.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_0 to be visible",
         "click element #id_0-servicemember_0",

--- a/pa11y_scripts/.p3-location-education.json
+++ b/pa11y_scripts/.p3-location-education.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_0 to be visible",
         "click element #id_0-servicemember_0",

--- a/pa11y_scripts/.p3-location-police.json
+++ b/pa11y_scripts/.p3-location-police.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_0 to be visible",
         "click element #id_0-servicemember_0",

--- a/pa11y_scripts/.p3-location-workplace.json
+++ b/pa11y_scripts/.p3-location-workplace.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_0 to be visible",
         "click element #id_0-servicemember_0",

--- a/pa11y_scripts/.p4-protected-class.json
+++ b/pa11y_scripts/.p4-protected-class.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",

--- a/pa11y_scripts/.p5-date.json
+++ b/pa11y_scripts/.p5-date.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",

--- a/pa11y_scripts/.p5-errors.json
+++ b/pa11y_scripts/.p5-errors.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",

--- a/pa11y_scripts/.p6-details.json
+++ b/pa11y_scripts/.p6-details.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",

--- a/pa11y_scripts/.p7-review.json
+++ b/pa11y_scripts/.p7-review.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",

--- a/pa11y_scripts/.p8-confirmation.json
+++ b/pa11y_scripts/.p8-confirmation.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     {
-      "url": "http://127.0.0.1:8000/report",
+      "url": "http://localhost:8000/report",
       "actions": [
         "wait for element #id_0-servicemember_1 to be visible",
         "click element #id_0-servicemember_1",

--- a/pa11y_scripts/.without-report.json
+++ b/pa11y_scripts/.without-report.json
@@ -1,31 +1,31 @@
 {
     "urls": [{
-            "url": "http://127.0.0.1:8000/",
+            "url": "http://localhost:8000/",
             "screenCapture": "pa11y-screenshots/crt-landing-view.png"
         },
         {
-            "url": "http://127.0.0.1:8000/",
+            "url": "http://localhost:8000/",
             "actions": [
-                "wait for url to be http://127.0.0.1:8000/",
+                "wait for url to be http://localhost:8000/",
                 "click #crt-landing--example_option",
                 "wait for element #crt-landing--example-workplace to be visible"
             ],
             "screenCapture": "pa11y-screenshots/crt-landing-dropdown.png"
         },
         {
-            "url": "http://127.0.0.1:8000/report",
+            "url": "http://localhost:8000/report",
             "screenCapture": "pa11y-screenshots/page1-contact.png"
         },
         {
-            "url": "http://127.0.0.1:8000/privacy-policy",
+            "url": "http://localhost:8000/privacy-policy",
             "screenCapture": "pa11y-screenshots/crt-privacy-policy.png"
         },
         {
-            "url": "http://127.0.0.1:8000/hate-crime-human-trafficking",
+            "url": "http://localhost:8000/hate-crime-human-trafficking",
             "screenCapture": "pa11y-screenshots/crt-hate-crime-human-trafficking.png"
         },
         {
-            "url": "http://127.0.0.1:8000/errors/404",
+            "url": "http://localhost:8000/errors/404",
             "screenCapture": "pa11y-screenshots/404.png"
         }
     ]


### PR DESCRIPTION
## What does this change?

Fixes our CircleCI failures following the update to python 3.10.8.

As a few versions got bumped during the switch (namely node and the browsers container image), there were a few things going on here that contributed to the failures:

### New path for `google-chrome`

- 🌎 Pa11y and e2e tests use Puppeteer to run chrome
- ⛔ Those tests were failing on circleci because puppeteer
  couldn't find the Chrome binary in the new python3.10.8-browsers image.
- ✅ We now explicitly say where to find the Chrome binary when running on
  CircleCI (`/usr/bin/google-chrome`)

### CURL not retrying

- 🌎 In CircleCI, before running a11y tests, we need to wait for the dev server to come up. We currently do that using `curl`
- ⛔ Curl's `retry-connrefused` flag isn't actually retrying on CCI - it tries
  once and fails
- ✅ We now retry _all_ errors, instead, giving the dev server time to come up before failing the tests

### 127.0.0.1 vs localhost

- 🌎 We were using `127.0.0.1` explicitly instead of `localhost`.
- ⛔ `127.0.0.1` only works for ipv4. Some versions of node, and thus pupeteer,
  now support ipv6 by default (see:
  https://github.com/puppeteer/puppeteer/issues/8873). This is not the full solution, but ipv6 is the way of the future, and we should allow for it now that Node prefers it.
- ✅ We now use localhost instead, which can resolve to either
  ipv4 or ipv6 as needed.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
