### PR TITLE
Improve copy experience for Campaign URLs

### DIFF
--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -7,6 +7,7 @@ from django.core.paginator import Paginator
 from django.db.models import Prefetch
 from django.http import StreamingHttpResponse
 from django.contrib.auth.models import User
+from django.utils.html import mark_safe
 from django.db.models.functions import Lower
 
 from .models import (CommentAndSummary, HateCrimesandTrafficking, Profile,
@@ -211,12 +212,19 @@ class VotingModeAdmin(admin.ModelAdmin):
 
 
 class CampaignAdmin(admin.ModelAdmin):
+    class Media:
+        js = ('js/admin_copy.js',)
+        css = {
+            'all': ('css/compiled/admin.css',)
+        }
+
     list_display = ['uuid', 'internal_name', 'campaign_url']
     readonly_fields = ['campaign_url']
 
     @admin.display(description='Campaign URL')
     def campaign_url(self, obj):
-        return obj.get_absolute_url()
+        url = obj.get_absolute_url()
+        return mark_safe(f'<input disabled="disabled" class="admin-copy absolute-url" value="{url}"/>')
 
 
 admin.site.register(CommentAndSummary)

--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -224,7 +224,7 @@ class CampaignAdmin(admin.ModelAdmin):
     @admin.display(description='Campaign URL')
     def campaign_url(self, obj):
         url = obj.get_absolute_url()
-        return mark_safe(f'<input disabled="disabled" class="admin-copy absolute-url" value="{url}"/>')
+        return mark_safe(f'<input aria-label="Campaign URL" disabled="disabled" class="admin-copy absolute-url" value="{url}"/>')
 
 
 admin.site.register(CommentAndSummary)

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -126,7 +126,7 @@ class Campaign(models.Model):
     show_in_filters = models.BooleanField(default=True, null=False)
 
     def get_absolute_url(self):
-        return f'https://civilrights.justice.gov/report?utm_campaign={self.uuid}'
+        return f'/report?utm_campaign={self.uuid}'
 
     def __str__(self):
         return self.internal_name

--- a/crt_portal/static/js/admin_copy.js
+++ b/crt_portal/static/js/admin_copy.js
@@ -1,0 +1,39 @@
+(function(root, dom) {
+  const COPY = "Copy to Clipboard";
+
+  function markAsCopied(button) {
+    button.innerText = 'Copied!';
+    button.setAttribute('disabled', 'disabled');
+    setTimeout(() => {
+      button.innerText = COPY;
+      button.removeAttribute('disabled');
+    }, 3000);
+  }
+
+  function createCopyButton(target) {
+    const copyButton = document.createElement('button');
+    copyButton.className = 'admin-copy-button button';
+    const buttonContent = document.createTextNode(COPY);
+    copyButton.appendChild(buttonContent);
+
+    copyButton.onclick = () => {
+      navigator.clipboard.writeText(target.value);
+      markAsCopied(copyButton);
+    };
+
+    target.parentElement.appendChild(copyButton);
+  }
+
+  function makeAbsolute(input) {
+    if (!input.classList.contains('absolute-url')) return;
+    input.value = `${window.location.origin}${input.value}`;
+  }
+
+  function setupButtons() {
+    const targets = dom.querySelectorAll('.admin-copy');
+    targets.forEach(makeAbsolute);
+    targets.forEach(createCopyButton);
+  }
+
+  root.addEventListener('load', setupButtons);
+})(window, document);

--- a/crt_portal/static/js/admin_copy.js
+++ b/crt_portal/static/js/admin_copy.js
@@ -21,6 +21,7 @@
       markAsCopied(copyButton);
     };
 
+    target.parentElement.classList.add('admin-copy-button-parent');
     target.parentElement.appendChild(copyButton);
   }
 

--- a/crt_portal/static/js/admin_copy.js
+++ b/crt_portal/static/js/admin_copy.js
@@ -1,5 +1,5 @@
 (function(root, dom) {
-  const COPY = "Copy to Clipboard";
+  const COPY = 'Copy to Clipboard';
 
   function markAsCopied(button) {
     button.innerText = 'Copied!';

--- a/crt_portal/static/sass/admin.scss
+++ b/crt_portal/static/sass/admin.scss
@@ -1,0 +1,3 @@
+.admin-copy-button {
+  margin: 0 10px !important;
+}

--- a/crt_portal/static/sass/admin.scss
+++ b/crt_portal/static/sass/admin.scss
@@ -1,3 +1,12 @@
+.admin-copy {
+  flex-grow: 1;
+}
+
 .admin-copy-button {
   margin: 0 10px !important;
+}
+
+.admin-copy-button-parent {
+  display: flex;
+  gap: 5px;
 }


### PR DESCRIPTION
## What does this change?

- 🌎 The admin page includes a list of campaigns
- ⛔ The common use-case is to copy the campaign URL, but the URL is:
  * Static text, so you have to click to copy
  * Prepended with the incorrect host when not on production
- ✅ This commit adds a (re-usable) copy script that makes links easier to copy, and deals with relative vs absolute urls.

## Screenshots (for front-end PR):

![copy](https://user-images.githubusercontent.com/15126660/213283819-6ff3e896-c9b7-4741-933d-ebf5af28f786.gif)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
