### PR TITLE
Use the favicon on the admin site

### DIFF
--- a/crt_portal/templates/admin/base_site.html
+++ b/crt_portal/templates/admin/base_site.html
@@ -1,0 +1,5 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+{% block extrahead %}
+    <link rel="icon" href="{% static "img/favicon.png" %}">
+{% endblock %}


### PR DESCRIPTION
## What does this change?

Super quick fix to add a favicon to the admin site - I kept losing the tab because it didn't have an image.

- ⛔ The admin site was 404'ing looking for favicon.ico
- ✅ This commit adds a place for us to customize the admin template, including the favicon

## Screenshots (for front-end PR):

<img width="289" alt="image" src="https://user-images.githubusercontent.com/15126660/213302227-4601dfa1-fb18-4ebd-ad72-8aa5f5f8549a.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
