### PR TITLE
Add a "View all matching descriptions" button

### DIFF
--- a/crt_portal/api/urls.py
+++ b/crt_portal/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
-from api.views import ResponseList, ResponseDetail, ReportCountView, ReportList, ReportDetail, RelatedReports, FormLettersIndex, api_root
+from api.views import ResponseList, ResponseDetail, ReportSummary, ReportCountView, ReportList, ReportDetail, RelatedReports, FormLettersIndex, api_root
 
 app_name = 'api'
 
@@ -11,6 +11,7 @@ urlpatterns = [
     path('responses/', ResponseList.as_view(), name='response-list'),
     path('responses/<int:pk>/', ResponseDetail.as_view(), name='response-detail'),
     path('report-count/', ReportCountView.as_view(), name='report-count'),
+    path('report-summary/', ReportSummary.as_view(), name='report-summary'),
     path('related-reports/', RelatedReports.as_view(), name='related-reports'),
     path('form-letters/', FormLettersIndex.as_view(), name='form-letters'),
 ]

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from cts_forms.views import mark_report_as_viewed, mark_reports_as_viewed
 from api.filters import form_letters_filter, reports_accessed_filter, autoresponses_filter
+from cts_forms.filters import report_filter
 from rest_framework.permissions import IsAuthenticated
 from api.serializers import ReportSerializer, ResponseTemplateSerializer, RelatedReportSerializer
 from django.contrib.auth.decorators import login_required
@@ -50,6 +51,20 @@ class ReportList(generics.ListAPIView):
         reports = Report.objects.filter(pk__in=report_pks).all()
         mark_reports_as_viewed(reports, request.user)
         return HttpResponse(status=200)
+
+
+class ReportCountView(APIView):
+    """
+    A view that returns the count of reports matching given filters.
+
+
+    Example: api/report/?start_date=2022-02-01&end_date=2022-04-14&intake_specialist=USER_1
+    """
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, format=None):
+        reports_accessed_payload = reports_accessed_filter(request.GET)
+        return Response(reports_accessed_payload)
 
 
 class ReportDetail(generics.RetrieveUpdateAPIView):
@@ -105,18 +120,18 @@ class ResponseDetail(generics.RetrieveAPIView):
         return Response(serialized_data)
 
 
-class ReportCountView(APIView):
+class ReportSummary(APIView):
     """
-    A view that returns the count of reports accessed in JSON.
+    A view that returns counts of reports matching filters.
 
 
-    Example: api/report-count/?start_date=2022-02-01&end_date=2022-04-14&intake_specialist=USER_1
+    Example: api/report-summary/?violation_summary=some%20summary
     """
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, format=None):
-        reports_accessed_payload = reports_accessed_filter(request.GET)
-        return Response(reports_accessed_payload)
+        filtered, _ = report_filter(request.GET)
+        return Response({"report_count": filtered.count()})
 
 
 class RelatedReports(generics.ListAPIView):

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
@@ -9,9 +9,12 @@
       Personal description
       <small class="margin-left-auto">
         <a class="related-reports show-count"
-           data-count-params="?violation_summary={{data.violation_summary | urlencode}}{% filter_for_all_sections %}"
            href="{% url 'crt_forms:crt-forms-index' %}?violation_summary={{data.violation_summary | urlencode}}{% filter_for_all_sections %}">
-              View all matching descriptions
+            View
+            <span
+              class="show-count"
+              data-count-params="?violation_summary={{data.violation_summary | urlencode}}{% filter_for_all_sections %}"></span>
+            reports matching this description
           </a>
       </small>
     </h3>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
@@ -8,7 +8,9 @@
     <h3 class="complaint-card-heading text-uppercase">
       Personal description
       <small class="margin-left-auto">
-          <a class="related-reports" href="{% url 'crt_forms:crt-forms-index' %}?violation_summary={{data.violation_summary | urlencode}}{% filter_for_all_sections %}">
+        <a class="related-reports show-count"
+           data-count-params="?violation_summary={{data.violation_summary | urlencode}}{% filter_for_all_sections %}"
+           href="{% url 'crt_forms:crt-forms-index' %}?violation_summary={{data.violation_summary | urlencode}}{% filter_for_all_sections %}">
               View all matching descriptions
           </a>
       </small>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
@@ -1,10 +1,18 @@
 {% load i18n %}
+{% load all_sections %}
 {% get_available_languages as LANGUAGES %}
 {% get_language_info_list for LANGUAGES as languages %}
 
 <div class="crt-portal-card crt-description-card">
   <div class="crt-portal-card__content">
-    <h3 class="complaint-card-heading text-uppercase">Personal description</h3>
+    <h3 class="complaint-card-heading text-uppercase">
+      Personal description
+      <small class="margin-left-auto">
+          <a class="related-reports" href="{% url 'crt_forms:crt-forms-index' %}?violation_summary={{data.violation_summary | urlencode}}{% filter_for_all_sections %}">
+              View all matching descriptions
+          </a>
+      </small>
+    </h3>
     <div class="word-break">
       {{ description|linebreaks }}
     </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -89,6 +89,7 @@
 
 {% block page_js %}
 {{ block.super }}
+<script src="{% static 'vendor/js.cookie.min.js' %}"></script>
 <script defer src="{% static 'vendor/marked.min.js' %}"></script>
 <script src="{% static 'js/edit_contact_info.min.js' %}"></script>
 <script src="{% static 'js/edit_details.min.js' %}"></script>
@@ -96,4 +97,5 @@
 <script src="{% static 'js/form_letter.min.js' %}"></script>
 <script src="{% static 'js/print_report.min.js' %}"></script>
 <script src="{% static 'js/attachments.min.js' %}"></script>
+<script src="{% static 'js/show_count.min.js'%}"></script>
 {%endblock%}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/related_reports.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/related_reports.html
@@ -26,7 +26,7 @@
         {% else %}
             is
         {% endif %}
-        {{data.related_reports_count}} report{{ data.related_reports_count|pluralize }} associated with this contact.
+        {{data.related_reports_count}} report{{ data.related_reports_count|pluralize }} associated with this email address.
 </small>
 
 {% for status, reports in data.related_reports_display %}

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -512,6 +512,21 @@ class FormNavigationTests(TestCase):
         self.assertEqual(content.count('complaint-nav'), 2)
         self.assertEqual(content.count('disabled-nav'), 1)
 
+    def test_view_all_descriptions(self):
+        first = self.reports[-1]
+        first.violation_summary = 'this is my summary'
+        first.save()
+
+        response = self.client.get(
+            reverse('crt_forms:crt-forms-show', args=[first.id])
+        )
+        self.assertEqual(response.status_code, 200)
+        content = str(response.content)
+        expected = ('/form/view/'
+                    '?violation_summary=this%20is%20my%20summary'
+                    '&amp;assigned_section=ADM')
+        self.assertIn(expected, content)
+
     def test_email_filtering(self):
         # generate random reports associated with a different email address
         ReportFactory.create_batch(5, assigned_section='VOT', contact_email='SomeoneElse@usa.gov')

--- a/crt_portal/static/js/show_count.js
+++ b/crt_portal/static/js/show_count.js
@@ -1,0 +1,33 @@
+(function(root, dom) {
+  function updateCount(target, summary) {
+    const count = summary.report_count;
+    const span = document.createElement('span');
+    span.className = 'added-count';
+    span.appendChild(document.createTextNode(`(${count})`));
+    target.appendChild(span);
+  }
+
+  function makeQuery(target) {
+    const params = target.dataset.countParams;
+    window
+      .fetch(`/api/report-summary/${params}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': Cookies.get('csrftoken')
+        },
+        mode: 'same-origin'
+      })
+      .then(response => response.json().then(summary => updateCount(target, summary)))
+      .catch(error => {
+        console.error(error);
+      });
+  }
+
+  function makeQueries() {
+    const targets = dom.querySelectorAll('.show-count');
+    targets.forEach(makeQuery);
+  }
+
+  root.addEventListener('load', makeQueries);
+})(window, document);

--- a/crt_portal/static/js/show_count.js
+++ b/crt_portal/static/js/show_count.js
@@ -3,7 +3,7 @@
     const count = summary.report_count;
     const span = document.createElement('span');
     span.className = 'added-count';
-    span.appendChild(document.createTextNode(`(${count})`));
+    span.appendChild(document.createTextNode(count));
     target.appendChild(span);
   }
 

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -65,6 +65,16 @@ $complaint-header-min-height: 200px;
   }
 }
 
+.complaint-card-heading {
+  small {
+    text-transform: none;
+  }
+
+  .margin-left-auto {
+    float: right;
+  }
+}
+
 .bold {
   font-weight: bold;
 }

--- a/crt_portal/static/sass/custom/print.scss
+++ b/crt_portal/static/sass/custom/print.scss
@@ -86,6 +86,10 @@
       max-height: none;
       overflow-y: visible;
     }
+
+    small {
+      display: none;
+    }
   }
 
   .bulk-print-report {

--- a/crt_portal/static/sass/styles.scss
+++ b/crt_portal/static/sass/styles.scss
@@ -49,3 +49,7 @@
 @forward "custom/modal";
 @forward "custom/print";
 @forward "custom/error";
+
+.usa-sr-only {
+  max-width: 999em;
+}


### PR DESCRIPTION
## What does this change?

This adds a "View all matching descriptions" button to the detail page (https://github.com/usdoj-crt/crt-portal-management/issues/1462)


## Screenshots (for front-end PR):

![matching](https://user-images.githubusercontent.com/15126660/216335527-aad4796d-ae15-446e-bde4-64f0a96f7de0.gif)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
