### PR TITLE
Standardize outgoing email templates

### DIFF
--- a/crt_portal/cts_forms/migrations/0162_constant_writer_form_letter_update.py
+++ b/crt_portal/cts_forms/migrations/0162_constant_writer_form_letter_update.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+def modify_constant_writer_form_letter(apps, schema_editor):
+    ResponseTemplate = apps.get_model('cts_forms', 'ResponseTemplate')
+    constant_writer_form_letter = ResponseTemplate.objects.get(title='CRT - Constant Writer')
+    constant_writer_form_letter.subject = 'Response: Your Civil Rights Division Report - {{ record_locator }} from the {{ section_name }} Section'
+    constant_writer_form_letter.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('cts_forms', '0161_add_responsetemplate_fields'),
+    ]
+
+    operations = [
+        migrations.RunPython(modify_constant_writer_form_letter)
+    ]

--- a/crt_portal/cts_forms/migrations/0163_crm_form_letters_update.py
+++ b/crt_portal/cts_forms/migrations/0163_crm_form_letters_update.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def modify_crm_form_letters(apps, schema_editor):
+    ResponseTemplate = apps.get_model('cts_forms', 'ResponseTemplate')
+    crm_r1_form_letter = ResponseTemplate.objects.get(title='CRM - R1 Form Letter')
+    crm_r2_form_letter = ResponseTemplate.objects.get(title='CRM - R2 Form Letter')
+    subject = 'Response: Your Civil Rights Division Report - {{ record_locator }} from the {{ section_name }} Section'
+    crm_r1_form_letter.subject = subject
+    crm_r2_form_letter.subject = subject
+    crm_r1_form_letter.save()
+    crm_r2_form_letter.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('cts_forms', '0162_constant_writer_form_letter_update'),
+    ]
+
+    operations = [
+        migrations.RunPython(modify_crm_form_letters)
+    ]
+    

--- a/crt_portal/cts_forms/response_templates/crt_doe_referral_letter.md
+++ b/crt_portal/cts_forms/response_templates/crt_doe_referral_letter.md
@@ -1,9 +1,9 @@
 ---
 title: CRT - Dept of Ed Referral Form Letter
-subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from {{ section_name }} Section"
+subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from the {{ section_name }} Section"
 language: en
 ---
-Re:		Civil Rights Division Complaint – {{ record_locator }} from {{ section_name }}
+Re:		Civil Rights Division Complaint – {{ record_locator }} from the {{ section_name }} Section
 
 Thank you for contacting the Department of Justice on {{ date_of_intake }}.  We have reviewed the information you provided and have determined that the complaint raises issues that are more appropriately addressed by another federal agency.  We are, therefore, referring this complaint to the following agency for further action:
 

--- a/crt_portal/cts_forms/response_templates/crt_dot_referral_letter.md
+++ b/crt_portal/cts_forms/response_templates/crt_dot_referral_letter.md
@@ -1,9 +1,9 @@
 ---
 title: CRT - DOT Referral Form Letter
-subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from {{ section_name }} Section"
+subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from the {{ section_name }} Section"
 language: en
 ---
-Re:		Civil Rights Division Complaint – {{ record_locator }} from {{ section_name }}
+Re:		Civil Rights Division Complaint – {{ record_locator }} from the {{ section_name }} Section
 
 Thank you for contacting the Department of Justice on {{ date_of_intake }}.  We have reviewed the information you provided and have determined that the complaint raises issues that are more appropriately addressed by another federal agency.  We are, therefore, referring this complaint to the following agency for further action:
 

--- a/crt_portal/cts_forms/response_templates/crt_eeoc_referral_form_letter.md
+++ b/crt_portal/cts_forms/response_templates/crt_eeoc_referral_form_letter.md
@@ -1,9 +1,9 @@
 ---
 title: CRT - EEOC Referral Form Letter
-subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from {{ section_name }} Section"
+subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from the {{ section_name }} Section"
 language: en
 ---
-Re:		Civil Rights Division Complaint – {{ record_locator }} from {{ section_name }}
+Re:		Civil Rights Division Complaint – {{ record_locator }} from the {{ section_name }} Section
 
 Thank you for contacting the Department of Justice on {{ date_of_intake }}.  We have reviewed the information you provided and have determined that the complaint raises issues that are more appropriately addressed by another federal agency.  We are, therefore, referring this complaint to the following agency for further action:
 

--- a/crt_portal/cts_forms/response_templates/crt_eeoc_referral_letter.md
+++ b/crt_portal/cts_forms/response_templates/crt_eeoc_referral_letter.md
@@ -1,6 +1,6 @@
 ---
 title: CRT - EEOC Referral Letter
-subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from {{ section_name }} Section"
+subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from the {{ section_name }} Section"
 language: en
 ---
 {{ addressee }},

--- a/crt_portal/cts_forms/response_templates/crt_hhs_referral_letter.md
+++ b/crt_portal/cts_forms/response_templates/crt_hhs_referral_letter.md
@@ -1,9 +1,9 @@
 ---
 title: CRT - HHS Referral Form Letter
-subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from {{ section_name }} Section"
+subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from the {{ section_name }} Section"
 language: en
 ---
-Re:		Civil Rights Division Complaint – {{ record_locator }} from {{ section_name }}
+Re:		Civil Rights Division Complaint – {{ record_locator }} from the {{ section_name }} Section
 
 Thank you for contacting the Department of Justice on {{ date_of_intake }}.  We have reviewed the information you provided and have determined that the complaint raises issues that are more appropriately addressed by another federal agency.  We are, therefore, referring this complaint to the following agency for further action:
 

--- a/crt_portal/cts_forms/response_templates/eos_doe_ocr_referral_form_letter.md
+++ b/crt_portal/cts_forms/response_templates/eos_doe_ocr_referral_form_letter.md
@@ -1,6 +1,6 @@
 ---
 title: EOS - Department of Ed OCR Referral Form Letter
-subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from Educational Opportunities Section"
+subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from the Educational Opportunities Section"
 language: en
 ---
 Re: Your Civil Rights Division Complaint – {{ record_locator }} from the Educational Opportunities Section

--- a/crt_portal/cts_forms/response_templates/eos_eeoc_referral_letter.md
+++ b/crt_portal/cts_forms/response_templates/eos_eeoc_referral_letter.md
@@ -1,6 +1,6 @@
 ---
 title: EOS - EEOC Referral Form Letter
-subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from {{ section_name }} Section"
+subject: "Response: Your Civil Rights Division Report - {{ record_locator }} from the {{ section_name }} Section"
 language: en
 html: true
 ---


### PR DESCRIPTION
[Issue #1467](https://github.com/usdoj-crt/crt-portal-management/issues/1467)

## What does this change?
This PR updates the subject and re: lines of the response templates to be consistent. All response templates should now have the word "the" in front of the section name and the word "section" after the section name.
## Screenshots (for front-end PR):
![Screenshot (1)](https://user-images.githubusercontent.com/18104884/216632984-437c1e00-0aa7-48e6-a9fb-462dde4a9e11.png)
![Screenshot (2)](https://user-images.githubusercontent.com/18104884/216633025-12386bc8-5c84-4d0b-9bd6-b54628fba170.png)
![Screenshot (3)](https://user-images.githubusercontent.com/18104884/216633231-603f4e6f-87f8-4ac4-969b-fdab51b937fa.png)
![Screenshot (4)](https://user-images.githubusercontent.com/18104884/216633161-ea37c201-e919-43e0-814b-845635ecbe48.png)
![Screenshot (5)](https://user-images.githubusercontent.com/18104884/216633188-aa26fb4f-655f-459f-b8cc-66368917d17b.png)
![Screenshot (6)](https://user-images.githubusercontent.com/18104884/216633269-639a41fa-414c-4f2f-ab0a-96916bf4504b.png)
![Screenshot (7)](https://user-images.githubusercontent.com/18104884/216633285-23043f81-d799-40c4-8522-1fa1dc29a143.png)
![Screenshot (8)](https://user-images.githubusercontent.com/18104884/216633302-f571786a-f0a9-4ba2-bda9-5dc5f08f372e.png)
![Screenshot (9)](https://user-images.githubusercontent.com/18104884/216633318-12b6231f-bc73-41af-af7c-364b3b4fec2c.png)
![Screenshot (10)](https://user-images.githubusercontent.com/18104884/216633327-4bb93a7d-08ca-4551-ad6e-612e4668e9ed.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
