### PR TITLE
Allow searching only for exact matches

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -131,7 +131,11 @@ def report_filter(querydict):
                 kwargs[field] = querydict.getlist(field)
             elif field_options == 'violation_summary':
                 search_query = querydict.getlist(field)[0]
-                qs = qs.filter(violation_summary_search_vector=_make_search_query(search_query))
+                if search_query.startswith('^') and search_query.endswith('$'):
+                    # Allow for "exact match" using the common regex syntax.
+                    qs = qs.filter(violation_summary=search_query[1:-1])
+                else:
+                    qs = qs.filter(violation_summary_search_vector=_make_search_query(search_query))
             elif field_options == 'contact_phone':
                 # Removes all non digit characters, then breaks the number into blocks to search individually
                 # EG (123) 456-7890 will search to see if  "123" AND "456" AND "7890" are in the number

--- a/crt_portal/cts_forms/templates/forms/complaint_view/search_help.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/search_help.html
@@ -62,7 +62,7 @@
         <input type="text" name="search_example_1" class="usa-input border-0 margin-y-1" value='"mask vaccine"'>
       </div>
       <div class="tablet:grid-col-fill">
-        <strong>“</strong>Mask Vaccine<strong>”</strong>: Gets results for reports with similar matching words in the quotation marks<sup>*</sup>.
+        <strong>“</strong>Mask Vaccine<strong>”</strong>: Gets results for reports containing the phrase in the quotation marks.<sup>*</sup>
       </div>
     </div>
     <div class="grid-row grid-gap display-flex flex-align-center usa-form">
@@ -70,7 +70,7 @@
         <input type="text" name="search_example_1" class="usa-input border-0 margin-y-1" value="mask and (vaccine OR shot)">
       </div>
       <div class="tablet:grid-col-fill">
-        Mask <strong>AND (</strong>Vaccine <strong>OR</strong> Shot<strong>)</strong>: Gets results that have both Mark and Vaccine plus also reports with both Mask and Shot<sup>*</sup>.
+        Mask <strong>AND (</strong>Vaccine <strong>OR</strong> Shot<strong>)</strong>: Gets results that have both Mark and Vaccine plus also reports with both Mask and Shot.<sup>*</sup>
       </div>
     </div>
     <div class="grid-row grid-gap display-flex flex-align-center usa-form">
@@ -78,7 +78,7 @@
         <input type="text" name="search_example_1" class="usa-input border-0 margin-y-1" value='^mask vaccine$'>
       </div>
       <div class="tablet:grid-col-fill">
-        <strong>^</strong>Mask Vaccine<strong>$</strong>: Look only for records exactly matching "Mask Vaccine".
+        <strong>^</strong>Mask Vaccine<strong>$</strong>: Look only for records where the full text of the description matches "Mask Vaccine". For example, searching for "^a test$" would not match the description "this is a test" or "a test description". It would only match "a test".
       </div>
     </div>
     <div class="grid-row">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/search_help.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/search_help.html
@@ -73,6 +73,14 @@
         Mask <strong>AND (</strong>Vaccine <strong>OR</strong> Shot<strong>)</strong>: Gets results that have both Mark and Vaccine plus also reports with both Mask and Shot<sup>*</sup>.
       </div>
     </div>
+    <div class="grid-row grid-gap display-flex flex-align-center usa-form">
+      <div class="tablet:grid-col-3">
+        <input type="text" name="search_example_1" class="usa-input border-0 margin-y-1" value='^mask vaccine$'>
+      </div>
+      <div class="tablet:grid-col-fill">
+        <strong>^</strong>Mask Vaccine<strong>$</strong>: Look only for records exactly matching "Mask Vaccine".
+      </div>
+    </div>
     <div class="grid-row">
       <div class="grid-col">
         <p>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
@@ -9,11 +9,11 @@
       Personal description
       <small class="margin-left-auto">
         <a class="related-reports show-count"
-           href="{% url 'crt_forms:crt-forms-index' %}?violation_summary={{data.violation_summary | urlencode}}{% filter_for_all_sections %}">
+           href="{% url 'crt_forms:crt-forms-index' %}?violation_summary=^{{data.violation_summary | urlencode}}${% filter_for_all_sections %}">
             View
             <span
               class="show-count"
-              data-count-params="?violation_summary={{data.violation_summary | urlencode}}{% filter_for_all_sections %}"></span>
+              data-count-params="?violation_summary=^{{data.violation_summary | urlencode}}${% filter_for_all_sections %}"></span>
             reports matching this description
           </a>
       </small>

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -523,7 +523,7 @@ class FormNavigationTests(TestCase):
         self.assertEqual(response.status_code, 200)
         content = str(response.content)
         expected = ('/form/view/'
-                    '?violation_summary=this%20is%20my%20summary'
+                    '?violation_summary=^this%20is%20my%20summary$'
                     '&amp;assigned_section=ADM')
         self.assertIn(expected, content)
 


### PR DESCRIPTION
## What does this change?

Allow filtering personal description by exact match.

- 🌎 The personal description filter is actually a search. Typing "this is a test" into the box will also match "this is a fun test", "oh no this is a test", etc. That search doesn't have an "exact full match" functionality (the quote behavior doesn't behave that way, and doesn't provide for _full_ matches, anyway)
- ⛔ That's not going to work for the exact match count/link on the detail page. We only want to show _exact_ matches, there.
- ✅ This commit introduces a way to ask for "exact" matches, documents it, and uses it on the filter page.

## Screenshots (for front-end PR):

![Demo showing the issue and solve](https://user-images.githubusercontent.com/15126660/217351246-4de07a7d-86a1-4c42-9fed-5f25f7b0b7fa.gif)

<img width="739" alt="image" src="https://user-images.githubusercontent.com/15126660/217360305-f9c27fcd-67a9-4118-b434-9c8634d38109.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
