### PR TITLE
Add constant writer icon to view all table

### DIFF
--- a/crt_portal/api/urls.py
+++ b/crt_portal/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
-from api.views import ResponseList, ResponseDetail, ReportSummary, ReportCountView, ReportList, ReportDetail, RelatedReports, FormLettersIndex, api_root
+from api.views import ResponseList, ResponseDetail, ReportSummary, ReportCountView, ReportCWs, ReportList, ReportDetail, RelatedReports, FormLettersIndex, api_root
 
 app_name = 'api'
 
@@ -11,6 +11,7 @@ urlpatterns = [
     path('responses/', ResponseList.as_view(), name='response-list'),
     path('responses/<int:pk>/', ResponseDetail.as_view(), name='response-detail'),
     path('report-count/', ReportCountView.as_view(), name='report-count'),
+    path('report-cws/', ReportCWs.as_view(), name='report-cws'),
     path('report-summary/', ReportSummary.as_view(), name='report-summary'),
     path('related-reports/', RelatedReports.as_view(), name='related-reports'),
     path('form-letters/', FormLettersIndex.as_view(), name='form-letters'),

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -6,7 +6,7 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from cts_forms.views import mark_report_as_viewed, mark_reports_as_viewed
-from api.filters import form_letters_filter, reports_accessed_filter, autoresponses_filter
+from api.filters import form_letters_filter, reports_accessed_filter, autoresponses_filter, report_cws
 from cts_forms.filters import report_filter
 from rest_framework.permissions import IsAuthenticated
 from api.serializers import ReportSerializer, ResponseTemplateSerializer, RelatedReportSerializer
@@ -30,7 +30,8 @@ def api_root(request, format=None):
         'responses': reverse('api:response-list', request=request, format=format),
         'report-count': reverse('api:report-count', request=request, format=format),
         'related-reports': reverse('api:related-reports', request=request, format=format),
-        'form-letters': reverse('api:form-letters', request=request, format=format)
+        'form-letters': reverse('api:form-letters', request=request, format=format),
+        'report-cws': reverse('api:report-cws', request=request, format=format)
     })
 
 
@@ -132,6 +133,18 @@ class ReportSummary(APIView):
     def get(self, request, format=None):
         filtered, _ = report_filter(request.GET)
         return Response({"report_count": filtered.count()})
+
+
+class ReportCWs(APIView):
+    """
+    A view that returns a boolean of whether the email associated with a report has been sent the constant writer email accessed in JSON.
+    Example: api/report-cws/
+    """
+    permission_classes = (IsAuthenticated,)
+
+    def post(self, request):
+        report_cws_payload = report_cws(request.data)
+        return Response(report_cws_payload)
 
 
 class RelatedReports(generics.ListAPIView):

--- a/crt_portal/cts_forms/migrations/0164_create_actstream_description_index.py
+++ b/crt_portal/cts_forms/migrations/0164_create_actstream_description_index.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+from django.db import connection
+
+def create_actstream_description_index(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute("""
+        CREATE INDEX IF NOT EXISTS actstream_action_description_idx
+            ON public.actstream_action USING btree
+            (description)
+        """)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cts_forms', '0163_crm_form_letters_update'),
+    ]
+    operations = [
+        migrations.RunPython(create_actstream_description_index)
+    ]

--- a/crt_portal/cts_forms/migrations/0165_create_report_contact_email_index.py
+++ b/crt_portal/cts_forms/migrations/0165_create_report_contact_email_index.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+from django.db import connection
+
+def create_report_contact_email_index(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute("""
+        CREATE INDEX IF NOT EXISTS cts_forms_report_contact_email_idx
+            ON public.cts_forms_report USING btree
+            (contact_email)
+        """)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cts_forms', '0164_create_actstream_description_index'),
+    ]
+    operations = [
+        migrations.RunPython(create_report_contact_email_index)
+    ]

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -77,7 +77,15 @@
               <td>
                 <a class="td-link display-block" href="{{datum.url}}">
                   {% with count=datum.report.related_reports_count|default:"—" %}
-                    {{ count }}
+                  <div class="report-count"><span>{{ count }}</span>
+                    <span
+                      class="show-cw hidden"
+                      data-id="{{ datum.report.id }}"
+                      data-email="{{ datum.report.contact_email|default:'' }}">
+                        <img src="{% static "img/mail_outline.svg" %}" alt="Constant writer" class="cw-icon">
+                        <span class="cw-text">CW</span>
+                    </span>
+                  </div>
                   {% endwith %}
                 </a>
               </td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -44,4 +44,5 @@
 <script src="{% static 'js/complaint_view_filters.min.js' %}"></script>
 <script src="{% static 'js/complaint_actions.min.js' %}"></script>
 <script src="{% static 'js/dashboard_view_all.min.js'%}"></script>
+<script src="{% static 'js/constant_writer.min.js'%}"></script>
 {% endblock %}

--- a/crt_portal/static/img/mail_outline.svg
+++ b/crt_portal/static/img/mail_outline.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M20 4H4C2.9 4 2.01 4.9 2.01 6L2 18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V6C22 4.9 21.1 4 20 4ZM20 18H4V8L12 13L20 8V18ZM12 11L4 6H20L12 11Z" fill="black"/>
+</svg>

--- a/crt_portal/static/js/constant_writer.js
+++ b/crt_portal/static/js/constant_writer.js
@@ -1,0 +1,36 @@
+(function(root, dom) {
+  function getCWs(targets, reports) {
+    for (const [id, report] of Object.entries(reports.reports)) {
+      if (!report.constant_writer) continue;
+      const target = Array.from(targets).find(target => target.getAttribute('data-id') === id);
+      target.classList.remove('hidden');
+    }
+  }
+
+  function makeQuery() {
+    const targets = dom.querySelectorAll('.show-cw');
+    const report_objects = {};
+    targets.forEach(target => {
+      if (target.getAttribute('data-email') === '') {
+        return;
+      }
+      report_objects[target.dataset.id] = target.getAttribute('data-email');
+    });
+    window
+      .fetch(`/api/report-cws/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': Cookies.get('csrftoken')
+        },
+        mode: 'same-origin',
+        body: `${JSON.stringify(report_objects)}`
+      })
+      .then(response => response.json().then(reports => getCWs(targets, reports)))
+      .catch(error => {
+        console.log(error);
+      });
+  }
+
+  root.addEventListener('load', makeQuery);
+})(window, document);

--- a/crt_portal/static/sass/custom/table.scss
+++ b/crt_portal/static/sass/custom/table.scss
@@ -195,6 +195,27 @@
   }
 }
 
+.report-count {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.show-cw.hidden .cw-icon, .show-cw.hidden .cw-text{
+  display: none;
+}
+
+.show-cw {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-left: 12px;
+}
+
+.cw-icon {
+  margin: 0 8px 0 12px;
+}
+
 // Styles for complaint statuses in View All Table
 
 .status-new {


### PR DESCRIPTION
## What does this change?
This PR adds a constant writer icon to the view all reports table to flag reports from users whose contact email addresses had already received a repeat writer email.
## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/18104884/217007007-e4ecd436-29ad-472f-823b-51dc0c5243b2.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
