### PR TITLE
Disable the bottom submit button

### DIFF
--- a/crt_portal/static/js/disable_submit_button.js
+++ b/crt_portal/static/js/disable_submit_button.js
@@ -3,9 +3,11 @@
   function disableSubmitButton() {
     const submitNextButton = document.getElementById('submit-next');
     const submitNextTopButton = document.getElementById('submit-next-top');
+    const submitNextBottomButton = document.getElementById('submit-next-bottom');
     const submitButton = document.getElementById('submit');
     if (submitNextButton) submitNextButton.disabled = true;
     if (submitNextTopButton) submitNextTopButton.disabled = true;
+    if (submitNextBottomButton) submitNextBottomButton.disabled = true;
     if (submitButton) submitButton.disabled = true;
   }
 })(window);


### PR DESCRIPTION
## What does this change?

The bottom submit button wasn't disabled, which can lead to duplicate reports if users submit twice.

## Screenshots (for front-end PR):

## Checklist:

- [ ] Go to submit a report via /report.
- [ ] Click the bottom "Submit Report" button multiple times.
- [ ] Confirm it is grayed out and only one report is submitted.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
