### PR TITLE
Add a route for rendering templates from a file

### DIFF
--- a/crt_portal/api/urls.py
+++ b/crt_portal/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
-from api.views import ResponseList, ResponseDetail, ReportSummary, ReportCountView, ReportCWs, ReportList, ReportDetail, RelatedReports, FormLettersIndex, api_root
+from api.views import ResponseList, ResponseDetail, ReportSummary, ReportCountView, ReportCWs, ReportList, ReportDetail, RelatedReports, FormLettersIndex, api_root, ResponseTemplatePreview
 
 app_name = 'api'
 
@@ -10,6 +10,7 @@ urlpatterns = [
     path('reports/<int:pk>/', ReportDetail.as_view(), name='report-detail'),
     path('responses/', ResponseList.as_view(), name='response-list'),
     path('responses/<int:pk>/', ResponseDetail.as_view(), name='response-detail'),
+    path('preview-response/<filename>', ResponseTemplatePreview.as_view(), name='preview-response-file'),
     path('report-count/', ReportCountView.as_view(), name='report-count'),
     path('report-cws/', ReportCWs.as_view(), name='report-cws'),
     path('report-summary/', ReportSummary.as_view(), name='report-summary'),

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -65,6 +65,51 @@ class APIFormLettersIndex(TestCase):
         self.assertEqual(response.status_code, 403)
 
 
+class APIPreviewResponseFileTests(TestCase):
+    def setUp(self):
+        self.client = Client(raise_request_exception=False)
+        self.user = User.objects.create_user("DELETE_USER", "george@thebeatles.com", "")
+
+    def tearDown(self):
+        self.user.delete()
+
+    def test_preview_response_text(self):
+        """Makes sure our route for previewing markdown files works."""
+        self.url = reverse(
+            "api:preview-response-file",
+            kwargs={"filename": 'crt_non_actionable.md'})
+        self.client.login(username="DELETE_USER", password="")  # nosec
+
+        response = self.client.get(self.url)
+
+        self.assertContains(response, "Thank you for taking the time")
+        self.assertContains(response, "[Variable: Addressee Name]")
+
+    def test_preview_response_html(self):
+        """Makes sure our route for previewing markdown files works."""
+        self.url = reverse(
+            "api:preview-response-file",
+            kwargs={"filename": 'hce_form_letter.md'})
+        self.client.login(username="DELETE_USER", password="")  # nosec
+
+        response = self.client.get(self.url)
+
+        self.assertContains(response, "Thank you for contacting")
+        self.assertContains(response, "[Variable: Addressee Name]")
+        self.assertContains(response, "<li>If your")
+
+    def test_unauthenticated(self):
+        """Only logged in users should be able to preview templates."""
+        self.url = reverse(
+            "api:preview-response-file",
+            kwargs={"filename": 'crt_non_actionable.md'})
+        self.client.logout()
+
+        response = self.client.get(self.url, follow=True)
+
+        self.assertEqual(response.status_code, 403)
+
+
 class APIReportListTests(TestCase):
     def setUp(self):
         self.client = Client()


### PR DESCRIPTION
Add a route for rendering templates from a file

(This is just for speed of development, for now. There's ways we could include this in the admin panel, or in in-app previews, in the future, though)

## What does this change?

- 🌎 When making template changes, we need to:
  * Change the file
  * Run manage.py update_response_templates and wait
  * Re-print the template from localhost
- ⛔ That takes a lot of time, making it difficult to iterate on new template designs quickly.
- ✅ This commit adds a route for authenticated users to preview templates based on a template filename (e.g., /api/preview-response/hce_form_letter.md).

## Screenshots (for front-end PR):

<img width="1469" alt="image" src="https://user-images.githubusercontent.com/15126660/220447996-0197e7e5-8d2d-4558-90fe-70d15736b3d7.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
