### PR TITLE
Stop an extra API call for the detail page.

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
@@ -8,7 +8,7 @@
     <h3 class="complaint-card-heading text-uppercase">
       Personal description
       <small class="margin-left-auto">
-        <a class="related-reports show-count"
+        <a class="related-reports"
            href="{% url 'crt_forms:crt-forms-index' %}?violation_summary=^{{data.violation_summary | urlencode}}${% filter_for_all_sections %}">
             View
             <span


### PR DESCRIPTION
Stop an extra `undefined` API call for the detail page.

## What does this change?

- 🌎 The "show-count" class triggers an api call to add a number of matches suffix.
- ⛔ This page has two - and one doesn't have filter data to query.
- ✅ This commit removes the class, which was triggering an extra, unnecessary call.

## Screenshots (for front-end PR):

<img width="873" alt="image" src="https://user-images.githubusercontent.com/15126660/220983349-e2121715-9709-43e6-94ac-95306f6d0269.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
