### PR TITLE
Add Template Previews to Admin Panel

### DIFF
--- a/crt_portal/api/urls.py
+++ b/crt_portal/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
-from api.views import ResponseList, ResponseDetail, ReportSummary, ReportCountView, ReportCWs, ReportList, ReportDetail, RelatedReports, FormLettersIndex, api_root, ResponseTemplatePreview
+from api.views import ResponseList, ResponseDetail, ReportSummary, ReportCountView, ReportCWs, ReportList, ReportDetail, RelatedReports, FormLettersIndex, api_root, ResponseTemplateFilePreview, ResponseTemplateFormPreview
 
 app_name = 'api'
 
@@ -10,7 +10,8 @@ urlpatterns = [
     path('reports/<int:pk>/', ReportDetail.as_view(), name='report-detail'),
     path('responses/', ResponseList.as_view(), name='response-list'),
     path('responses/<int:pk>/', ResponseDetail.as_view(), name='response-detail'),
-    path('preview-response/<filename>', ResponseTemplatePreview.as_view(), name='preview-response-file'),
+    path('preview-response/<filename>', ResponseTemplateFilePreview.as_view(), name='preview-response-file'),
+    path('preview-response/', ResponseTemplateFormPreview.as_view(), name='preview-response-form'),
     path('report-count/', ReportCountView.as_view(), name='report-count'),
     path('report-cws/', ReportCWs.as_view(), name='report-cws'),
     path('report-summary/', ReportSummary.as_view(), name='report-summary'),

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -99,8 +99,6 @@ class ReportDetail(generics.RetrieveUpdateAPIView):
 
 
 class ResponseTemplatePreviewBase:
-    permission_classes = [permissions.IsAuthenticated]
-
     _templates_dir = os.path.join(settings.BASE_DIR, 'cts_forms', 'response_templates')
 
     def _make_example_context(self):
@@ -128,6 +126,8 @@ class ResponseTemplatePreviewBase:
         })
 
     def _render_response_template(self, request, *, is_html=False, body='', **kwargs):
+        if isinstance(body, list):
+            body = ''.join(body)
         del kwargs  # Allow for extra, unused render variables.
         context = self._make_example_context()
         if is_html:
@@ -139,18 +139,16 @@ class ResponseTemplatePreviewBase:
 
 
 class ResponseTemplateFormPreview(generics.ListAPIView, ResponseTemplatePreviewBase):
-    """
-    API endpoint that allows responses to be viewed based on content.
-    """
+    """API endpoint that allows responses to be viewed based on content."""
+    permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
         return self._render_response_template(request, **request.data)
 
 
 class ResponseTemplateFilePreview(generics.ListAPIView, ResponseTemplatePreviewBase):
-    """
-    API endpoint that allows responses to be viewed given a filename.
-    """
+    """API endpoint that allows responses to be viewed given a filename."""
+    permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, filename):
         if not filename:

--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -228,7 +228,20 @@ class CampaignAdmin(admin.ModelAdmin):
 
 
 class ResponseTemplateAdmin(admin.ModelAdmin):
+    class Media:
+        js = ('js/response_template_preview.js',)
+        css = {
+            'all': ('css/compiled/admin.css',)
+        }
+
     exclude = ['is_user_created']
+    readonly_fields = ['preview']
+
+    @admin.display(description='Email Preview')
+    def preview(self, obj):
+        return mark_safe('<iframe class="response-template-preview"'
+                         'width="100%" height="100%"'
+                         '></iframe>')
 
 
 admin.site.register(CommentAndSummary)

--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -235,7 +235,11 @@ class ResponseTemplateAdmin(admin.ModelAdmin):
         }
 
     exclude = ['is_user_created']
-    readonly_fields = ['preview']
+    readonly_fields = ['template_help', 'preview']
+
+    @admin.display(description='Template Help')
+    def template_help(self, obj):
+        return mark_safe('For help with template variables and formatting, <a target="_blank" href="/api/preview-response">go here</a>')
 
     @admin.display(description='Email Preview')
     def preview(self, obj):

--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -68,7 +68,7 @@ def crt_send_mail(report, template, purpose=TMSEmail.MANUAL_EMAIL):
         return None
 
     if template.is_html:
-        md = markdown.markdown(message, extensions=['nl2br', CustomHTMLExtension()])
+        md = markdown.markdown(message, extensions=['extra', 'nl2br', CustomHTMLExtension()])
         html_message = render_to_string('email.html', {'content': md})
     else:
         # replace newlines, \n, with <br> so the API will generate formatted emails

--- a/crt_portal/cts_forms/templates/template_help.md
+++ b/crt_portal/cts_forms/templates/template_help.md
@@ -1,0 +1,255 @@
+# Template Writing Help
+
+This page explains what's available when writing custom response templates.
+
+The link to this page is [/api/preview-response](/api/preview-response).
+
+Here's what's on this page:
+
+[TOC]
+
+## Variables
+
+### What's available?
+
+All of our templates support a few special variables. They are:
+
+| Name                     | Example                      | Description                                           |
+| ------------------------ | ---------------------------- | ----------------------------------------------------- |
+| `addressee`              | Dear John Doe                | The salutation "Dear FirstName LastName" (sans comma) |
+| `contact_address_line_1` | 1 Demo Street                | The recipient's first address line                    |
+| `contact_address_line_2` | Apt 5                        | The recipient's second address line                   |
+| `contact_email`          | john@civilrights.justice.gov | The recipient's email address                         |
+| `date_of_intake`         | February 29, 1988            | The day the report was submitted                      |
+| `outgoing_date`          | February 31, 1988            | The day this reply is being sent (today)              |
+| `section_name`           | Voting                       | The section of the user sending the reply             |
+
+### How do I use them?
+
+{% verbatim %}
+To use a variable, you need to surround it with `{{ }}`.
+
+For instance, considering the above examples, to show:
+
+```
+Dear John Doe who lives at 1 Demo Street
+```
+
+you'd write:
+
+```
+{{ addressee }} who lives at {{ contact_address_line_1 }}
+```
+
+{% endverbatim %}
+
+### How do I know they're working?
+
+In the template preview, we don't have any real recipient info, so we just show its name, but underlined.
+
+If you don't see the following (for example, if you see `{ addressee }` instead of {{addressee}}) then the variable isn't working!
+
+| Name                     | Shows As                     |
+| ------------------------ | ---------------------------- |
+| `addressee`              | {{ addressee }}              |
+| `contact_address_line_1` | {{ contact_address_line_1 }} |
+| `contact_address_line_2` | {{ contact_address_line_2 }} |
+| `contact_email`          | {{ contact_email }}          |
+| `date_of_intake`         | {{ date_of_intake }}         |
+| `outgoing_date`          | {{ outgoing_date }}          |
+| `section_name`           | {{ section_name }}           |
+
+## Markdown (Text Formatting)
+
+### What is it?
+
+Our response templates are stored in a file format called Markdown. Markdown is a popular way to use plain text to express lists, headings, etc. You've probably seen it before to some extent in chat applications, Github, etc.
+
+As a quick example of what markdown looks like, here is how you'd write a list in markdown:
+
+```
+- Fruit
+    - Apples
+    - Bananas
+- Vegetables
+    - Tomato*
+    - Potato*
+
+_*Dependent on economic or taxonomic policy_
+```
+
+Which will show as:
+
+- Fruit
+  - Apples
+  - Bananas
+- Vegetables
+  - Tomato\*
+  - Potato\*
+
+_\*Dependent on economic or taxonomic policy_
+
+### What can I do with it?
+
+This page is rendered using our email markdown and styles - so what you see here is what you get!
+
+Here's all of the markdown things we support:
+
+#### Line Breaks
+
+This is going to look confusing with the rest of the page, but:
+
+```
+---
+```
+
+which becomes:
+
+---
+
+#### Links
+
+```
+[this is a link](http://www.google.com)
+```
+
+which becomes:
+
+[this is a link](http://www.google.com)
+
+---
+
+#### Text Styles
+
+```
+_This is italicized_
+__This is bold__
+```
+
+which becomes
+
+_This is italicized_
+**This is bold**
+
+---
+
+#### Lists
+
+```
+- Unordered
+    - Sublist
+    - Here
+- List
+- Here
+
+And for ordered:
+
+1. Ordered
+    1. Sublist
+    1. Here
+1. List
+1. Here
+```
+
+Which shows as:
+
+- Unordered
+  - Sublist
+  - Here
+- List
+- Here
+
+And for ordered:
+
+1. Ordered
+   1. Sublist
+   1. Here
+1. List
+1. Here
+
+---
+
+#### Tables
+
+```
+| Header     | Header     | Header     |
+| ---------- | ---------- | ---------- |
+| Cell Value | Cell Value | Cell Value |
+| Cell Value | Cell Value | Cell Value |
+| Cell Value | Cell Value | Cell Value |
+```
+
+which becomes:
+
+| Header     | Header     | Header     |
+| ---------- | ---------- | ---------- |
+| Cell Value | Cell Value | Cell Value |
+| Cell Value | Cell Value | Cell Value |
+| Cell Value | Cell Value | Cell Value |
+
+---
+
+#### Block Quotes
+
+```
+> I wrote a haiku
+> It is in this block quote now
+> Wow block quotes are great
+```
+
+which becomes:
+
+> I wrote a haiku
+> It is in this block quote now
+> Wow block quotes are great
+
+---
+
+#### Footnotes
+
+```
+Footnotes[^1], which have a label[^@#$%] and some content:
+
+[^1]: This is a footnote content.
+[^@#$%]: A footnote on the label: "@#$%".
+```
+
+which becomes:
+
+Footnotes[^1], which have a label[^@#$%] and some content:
+
+(These will show up at the bottom of the page, after all of the rest of the content)
+
+[^1]: This is a footnote content.
+[^@#$%]: A footnote on the label: "@#$%".
+
+---
+
+#### Headers
+
+```
+# Header 1
+## Header 2
+### Header 3
+#### Header 4
+##### Header 5
+###### Header 6
+```
+
+Which show as:
+
+# Header 1
+
+## Header 2
+
+### Header 3
+
+#### Header 4
+
+##### Header 5
+
+###### Header 6
+
+---
+
+And that's it (well, except the footnotes)!

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -65,6 +65,46 @@ class APIFormLettersIndex(TestCase):
         self.assertEqual(response.status_code, 403)
 
 
+class APIPreviewResponseFormTests(TestCase):
+    def setUp(self):
+        self.client = Client(raise_request_exception=False)
+        self.user = User.objects.create_user("DELETE_USER", "george@thebeatles.com", "")
+        self.url = reverse("api:preview-response-form")
+
+    def tearDown(self):
+        self.user.delete()
+
+    def test_preview_response_text(self):
+        """Makes sure our route for previewing markdown files works."""
+        self.client.login(username="DELETE_USER", password="")  # nosec
+
+        response = self.client.post(
+            self.url,
+            {"body": "hello, {{ addressee }}"}
+        )
+
+        self.assertContains(response, "hello, [Variable: Addressee Name]")
+
+    def test_preview_response_html(self):
+        """Makes sure our route for previewing markdown files works."""
+        self.client.login(username="DELETE_USER", password="")  # nosec
+
+        response = self.client.post(
+            self.url,
+            {"body": "hello, *{{ addressee }}*", "is_html": True}
+        )
+
+        self.assertContains(response, "hello, <em>[Variable: Addressee Name]</em>")
+
+    def test_unauthenticated(self):
+        """Only logged in users should be able to preview templates."""
+        self.client.logout()
+
+        response = self.client.get(self.url, follow=True)
+
+        self.assertEqual(response.status_code, 403)
+
+
 class APIPreviewResponseFileTests(TestCase):
     def setUp(self):
         self.client = Client(raise_request_exception=False)

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -83,7 +83,7 @@ class APIPreviewResponseFormTests(TestCase):
             {"body": "hello, {{ addressee }}"}
         )
 
-        self.assertContains(response, "hello, [Variable: Addressee Name]")
+        self.assertContains(response, 'hello, <span class="variable">Addressee Name</span>')
 
     def test_preview_response_html(self):
         """Makes sure our route for previewing markdown files works."""
@@ -94,7 +94,7 @@ class APIPreviewResponseFormTests(TestCase):
             {"body": "hello, *{{ addressee }}*", "is_html": True}
         )
 
-        self.assertContains(response, "hello, <em>[Variable: Addressee Name]</em>")
+        self.assertContains(response, 'hello, <em><span class="variable">Addressee Name</span></em>')
 
     def test_unauthenticated(self):
         """Only logged in users should be able to preview templates."""
@@ -123,7 +123,7 @@ class APIPreviewResponseFileTests(TestCase):
         response = self.client.get(self.url)
 
         self.assertContains(response, "Thank you for taking the time")
-        self.assertContains(response, "[Variable: Addressee Name]")
+        self.assertContains(response, '<span class="variable">Addressee Name</span>')
 
     def test_preview_response_html(self):
         """Makes sure our route for previewing markdown files works."""
@@ -135,7 +135,7 @@ class APIPreviewResponseFileTests(TestCase):
         response = self.client.get(self.url)
 
         self.assertContains(response, "Thank you for contacting")
-        self.assertContains(response, "[Variable: Addressee Name]")
+        self.assertContains(response, '<span class="variable">Addressee Name</span>')
         self.assertContains(response, "<li>If your")
 
     def test_unauthenticated(self):

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -74,6 +74,14 @@ class APIPreviewResponseFormTests(TestCase):
     def tearDown(self):
         self.user.delete()
 
+    def test_help_page_renders(self):
+        """Makes sure our route for previewing markdown files works."""
+        self.client.login(username="DELETE_USER", password="")  # nosec
+
+        response = self.client.get(self.url)
+
+        self.assertContains(response, 'This page explains')
+
     def test_preview_response_text(self):
         """Makes sure our route for previewing markdown files works."""
         self.client.login(username="DELETE_USER", password="")  # nosec
@@ -96,7 +104,15 @@ class APIPreviewResponseFormTests(TestCase):
 
         self.assertContains(response, 'hello, <em><span class="variable">Addressee Name</span></em>')
 
-    def test_unauthenticated(self):
+    def test_unauthenticated_post(self):
+        """Only logged in users should be able to preview templates."""
+        self.client.logout()
+
+        response = self.client.post(self.url, {'body': 'oops'}, follow=True)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_unauthenticated_get(self):
         """Only logged in users should be able to preview templates."""
         self.client.logout()
 

--- a/crt_portal/static/js/response_template_preview.js
+++ b/crt_portal/static/js/response_template_preview.js
@@ -1,0 +1,45 @@
+(function(root, dom) {
+  function setContent(iframe, content) {
+    iframe.contentWindow.document.open();
+    iframe.contentWindow.document.write(content);
+    iframe.contentWindow.document.close();
+  }
+
+  let populateController = new AbortController();
+  function populatePreviewContent(form, previewContainer) {
+    const formData = Object.fromEntries(new FormData(form));
+    populateController.abort();
+    populateController = new AbortController();
+    window
+      .fetch('/api/preview-response/', {
+        method: 'POST',
+        signal: populateController.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': formData.csrfmiddlewaretoken
+        },
+        mode: 'same-origin',
+        body: JSON.stringify(formData)
+      })
+      .then(response => response.text().then(rendered => setContent(previewContainer, rendered)))
+      .catch(error => {
+        console.error(error);
+      });
+  }
+
+  function listenForChanges(form, previewContainer) {
+    form.addEventListener('change', function() {
+      populatePreviewContent(form, previewContainer);
+    });
+  }
+
+  function setupPreview() {
+    const form = document.forms.responsetemplate_form;
+
+    const targets = dom.querySelectorAll('.response-template-preview');
+    targets.forEach(target => populatePreviewContent(form, target));
+    targets.forEach(target => listenForChanges(form, target));
+  }
+
+  root.addEventListener('load', setupPreview);
+})(window, document);

--- a/crt_portal/static/sass/admin.scss
+++ b/crt_portal/static/sass/admin.scss
@@ -10,3 +10,14 @@
   display: flex;
   gap: 5px;
 }
+
+.response-template-preview {
+  border: 0px;
+  background-color: white;
+}
+
+.field-preview .readonly {
+  display: flex;
+  width: auto;
+  height: 90vh;
+}

--- a/crt_portal/static/sass/template-preview.scss
+++ b/crt_portal/static/sass/template-preview.scss
@@ -1,0 +1,5 @@
+.variable {
+  cursor: alias;
+  text-decoration:underline;
+  text-decoration-style: dotted;
+}


### PR DESCRIPTION
## What does this change?

- 🌎 The response templates are maintained both on disk and in the DB.
- ⛔ Editing and previewing response templates right now is diffcult. We have to change content on disk and send emails before we can properly preview the output.
- ✅ This PR adds a preview panel to the response template page. When an admin user edits that page, an updated preview of how the email will be sent is shown.

This also turns on markdown _extras_ rendering, which supports features like tables, that'll be useful in future HTML content.

This only touches email rendering for now. Print rendering is a javascript process and is not currently as easy to replicate. Future work can incorporate referral sections to the preamble, for example.

## Screenshots (for front-end PR):

Here's an example of the process working:

![preview](https://user-images.githubusercontent.com/15126660/223270110-b1f1c340-ef32-4321-a5fe-aa6834bd3af0.gif)

And here's the help page, which is linked to from the admin panel and serves as self-rendering documentation for our email templating capabilities:

![localhost_8000_api_preview-response_ (1)](https://user-images.githubusercontent.com/15126660/223271661-c542d2cd-923b-40ad-b584-446c63a0e37c.png)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
