### PR TITLE
Add a print button for response template previews

### DIFF
--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -235,11 +235,15 @@ class ResponseTemplateAdmin(admin.ModelAdmin):
         }
 
     exclude = ['is_user_created']
-    readonly_fields = ['template_help', 'preview']
+    readonly_fields = ['template_help', 'print_template', 'preview']
 
     @admin.display(description='Template Help')
     def template_help(self, obj):
         return mark_safe('For help with template variables and formatting, <a target="_blank" href="/api/preview-response">go here</a>')
+
+    @admin.display(description='Print Email Preview')
+    def print_template(self, obj):
+        return mark_safe('<button class="button" id="print_template_preview">Print Email Preview</button>')
 
     @admin.display(description='Email Preview')
     def preview(self, obj):

--- a/crt_portal/static/js/response_template_preview.js
+++ b/crt_portal/static/js/response_template_preview.js
@@ -50,6 +50,12 @@
     form.addEventListener('change', function() {
       populatePreviewContent(form, previewContainer);
     });
+
+    const printButton = document.getElementById('print_template_preview');
+    printButton.addEventListener('click', function(event) {
+      previewContainer.contentWindow.print();
+      event.preventDefault();
+    });
   }
 
   function setupPreview() {


### PR DESCRIPTION
## What does this change?

- 🌎 When developing templates, it's helpful to share it as a pdf
- ⛔ Right now it's hard to print the specific template preview pane
- ✅ This commit adds a button to print just the that preview frame

## Screenshots (for front-end PR):

![preview](https://user-images.githubusercontent.com/15126660/224118673-78b71b62-52ef-43e5-abfd-004b0fda3fe0.gif)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
