### PR TITLE
Il/1496 upgrade clamAV docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
        - 8025:8025 # web ui
      # command: -invite-jim=1 -jim-accept=0.50  # uncomment to enable and configure Jim (Chaos Monkey)
   clamav-rest:
-    image: ajilaag/clamav-rest:20220511   # ## 20201028
+    image: ajilaag/clamav-rest:20230321 # ##20220511
     environment:
       - MAX_FILE_SIZE=100M
       - SIGNATURE_CHECKS=1

--- a/manifest_dev.yaml
+++ b/manifest_dev.yaml
@@ -27,6 +27,6 @@ applications:
     MAX_FILE_SIZE: 100M
     SIGNATURE_CHECKS: 1
   docker:
-    image: ajilaag/clamav-rest:20220511 # ##20201028
+    image: ajilaag/clamav-rest:20230321    # ##20220511
   routes:
   - route: clamav-rest-dev.apps.internal

--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -31,6 +31,6 @@ applications:
     MAX_FILE_SIZE: 100M
     SIGNATURE_CHECKS: 8
   docker:
-    image: ajilaag/clamav-rest:20220511 # #ajilaag/clamav-rest:20201028
+    image: ajilaag/clamav-rest:20230321 # ##20220511
   routes:
   - route: clamav-rest-prod.apps.internal

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -30,6 +30,6 @@ applications:
     MAX_FILE_SIZE: 100M
     SIGNATURE_CHECKS: 2
   docker:
-    image: ajilaag/clamav-rest:20220511 # ##ajilaag/clamav-rest:20201028
+    image: ajilaag/clamav-rest:20230321    # ##20220511
   routes:
   - route: clamav-rest-staging.apps.internal


### PR DESCRIPTION
## What does this change?
This tech task upgrade the clamAV images to ajilaag/clamav-rest:20230321
for Local Docker, Dev, Staging and Prod environment.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
