### PR TITLE
Fix Short URLs on Production

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -301,6 +301,7 @@ if environment in ['PRODUCTION', 'STAGE']:
         'LOGIN_EXEMPT_URLS': [
             '^$',
             '^report',
+            '^link',
             '^robots.txt',
             '^privacy-policy',
             '^hate-crime-human-trafficking',

--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -246,7 +246,10 @@ class ReferralContactAdmin(admin.ModelAdmin):
 
 class CampaignAdmin(admin.ModelAdmin):
     class Media:
-        js = ('js/admin_copy.js',)
+        js = (
+            'js/admin_copy.js',
+            'js/absolute_url.js',
+        )
         css = {
             'all': ('css/compiled/admin.css',)
         }

--- a/crt_portal/static/js/absolute_url.js
+++ b/crt_portal/static/js/absolute_url.js
@@ -1,0 +1,21 @@
+(function(root, dom) {
+  function makeAbsolute(input) {
+    const origin = getOrigin();
+    input.value = `${origin}${input.value}`;
+  }
+
+  function getOrigin() {
+    const origin = window.location.origin;
+    if (origin.includes('crt-portal-django-prod.app.cloud.gov')) {
+      return 'https://civilrights.justice.gov';
+    }
+
+    return origin;
+  }
+
+  function setup() {
+    dom.querySelectorAll('.absolute-url').forEach(makeAbsolute);
+  }
+
+  root.addEventListener('load', setup);
+})(window, document);

--- a/crt_portal/static/js/admin_copy.js
+++ b/crt_portal/static/js/admin_copy.js
@@ -25,15 +25,8 @@
     target.parentElement.appendChild(copyButton);
   }
 
-  function makeAbsolute(input) {
-    if (!input.classList.contains('absolute-url')) return;
-    input.value = `${window.location.origin}${input.value}`;
-  }
-
   function setupButtons() {
-    const targets = dom.querySelectorAll('.admin-copy');
-    targets.forEach(makeAbsolute);
-    targets.forEach(createCopyButton);
+    const targets = dom.querySelectorAll('.admin-copy').forEach(createCopyButton);
   }
 
   root.addEventListener('load', setupButtons);


### PR DESCRIPTION
## What does this change?

There were two problems:
- The fix for absolute urls on production had not yet made it into a merged PR
- The ADFS auth was prevent access to /link/etc

This PR fixes both

## Screenshots (for front-end PR):

NOTE: We can't test the ADFS fix until we're on at least Stage, because it relies on ADFS being available.

Tested the absolute url fix by hardcoding `localhost` instead of crt-portal:

<img width="494" alt="image" src="https://user-images.githubusercontent.com/15126660/227958759-a2149340-9446-4e44-8430-a06782e5c83d.png">

Which produces:

<img width="291" alt="image" src="https://user-images.githubusercontent.com/15126660/227958860-02d71598-53c5-4ac0-8475-c5c56d2096ed.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
