### PR TITLE
Add header to No Capacity letter.

### DIFF
--- a/crt_portal/cts_forms/response_templates/crt_no_capacity.md
+++ b/crt_portal/cts_forms/response_templates/crt_no_capacity.md
@@ -21,14 +21,14 @@ We are not determining that your report lacks merit. Your issue may still be act
 ## To find a local office:
 
 American Bar Association
-[www.americanbar.org/groups/legal_services/flh-home](https://www.americanbar.org/groups/legal_services/flh-home)
+[https://www.americanbar.org/groups/legal_services/flh-home](https://www.americanbar.org/groups/legal_services/flh-home)
 (800) 285-2221
 
 Legal Services Corporation (or Legal Aid Offices)
-[www.lsc.gov/find-legal-aid](https://www.lsc.gov/find-legal-aid)
+[https://www.lsc.gov/find-legal-aid](https://www.lsc.gov/find-legal-aid)
 (202) 295-1500
 
-How you have helped:
+# How you have helped:
 
 While we don’t have the capacity to take on each individual report, your report can help us find issues affecting multiple people or communities. It also helps us understand emerging trends and topics.
 

--- a/crt_portal/cts_forms/response_templates/crt_non_actionable.md
+++ b/crt_portal/cts_forms/response_templates/crt_non_actionable.md
@@ -6,33 +6,31 @@ is_html: true
 ---
 {{ addressee }},
 
-You contacted the Department of Justice on {{date_of_intake}}. After careful review of what you submitted, we have decided not to take any further action on your complaint.
+You contacted the Department of Justice on {{ date_of_intake }}. After careful review of what you submitted, we have decided not to take any further action on your complaint.
 
 # What we did:
 
-Team members from the Civil Rights Division reviewed the information you submitted.  Based on our review, we have decided not to take any further action on your complaint.  We receive several thousand reports of civil rights violations each year.  We unfortunately do not have the resources to take direct action for every report.
+Team members from the Civil Rights Division reviewed the information you submitted.  Based on this information, our team determined that the federal civil rights laws we enforce do not cover the situation you described.  Therefore, we cannot take further action.
 
-Your report number was {{record_locator}}.
+Your report number is {{ record_locator }}.
 
 # What you can do:
 
-We are not determining that your report lacks merit. Your issue may still be actionable by others - your state bar association or local legal aid office may be able to help.
+Your issue may be covered by other federal, state, or local laws that we do not have the authority to enforce. We are not determining that your report lacks merit.
+
+Your state bar association or local legal aid office may be able to help with your issue even though the Department of Justice cannot.
 
 ## To find a local office:
 
 American Bar Association
-[www.americanbar.org/groups/legal_services/flh-home](https://www.americanbar.org/groups/legal_services/flh-home)
+[https://www.americanbar.org/groups/legal_services/flh-home](https://www.americanbar.org/groups/legal_services/flh-home)
 (800) 285-2221
 
 Legal Services Corporation (or Legal Aid Offices)
-[www.lsc.gov/find-legal-aid](https://www.lsc.gov/find-legal-aid)
+[https://www.lsc.gov/find-legal-aid](https://www.lsc.gov/find-legal-aid)
 (202) 295-1500
 
-How you have helped:
-
-While we don’t have the capacity to take on each individual report, your report can help us find issues affecting multiple people or communities. It also helps us understand emerging trends and topics.
-
-Thank you for taking the time to contact the Department of Justice about your concerns.  We regret we are not able to provide more help on this matter.
+Thank you for taking the time to contact the Department of Justice about your concerns. We regret that we are not able to provide more help on this matter.
 
 Sincerely,
 


### PR DESCRIPTION
## What does this change?

Adds a header to the No Capacity "How you have helped" section.

## Screenshots (for front-end PR):

<img width="592" alt="image" src="https://user-images.githubusercontent.com/15126660/228359933-468e3275-982c-4ea9-9d07-49dd01e0dedf.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
