### PR TITLE
Fix bug with links containing underscores in response template admin panel

### DIFF
--- a/crt_portal/static/js/response_template_preview.js
+++ b/crt_portal/static/js/response_template_preview.js
@@ -31,10 +31,12 @@
     const turndown = new TurndownService();
     let pastedHtml = event.clipboardData.getData('text/html');
     // Turndown escapes underscores so maintain them in links by replacing them before processing
-    const aTags = pastedHtml.match(/(<[Aa]\s(.*)<\/[Aa]>)/g);
+    const parser = new DOMParser();
+    const htmlDoc = parser.parseFromString(pastedHtml, 'text/html');
+    const aTags = Array.from(htmlDoc.getElementsByTagName('a'));
     aTags.forEach(aTag => {
-      const newATag = aTag.replaceAll('_', '(UNDERSCORE)');
-      pastedHtml = pastedHtml.replaceAll(aTag, newATag);
+      const newhref = aTag['href'].replaceAll('_', '(UNDERSCORE)');
+      pastedHtml = pastedHtml.replaceAll(aTag['href'], newhref);
     });
     const markdown = turndown.turndown(pastedHtml);
     // Word sometimes includes comments in its HTML, so strip them:


### PR DESCRIPTION
## What does this change?

Currently there is a bug in the admin panel where the code that converts html pasted response templates into markdown escapes underscores thereby breaking links with underscores. This PR adds logic to replace underscores in links before processing the html and then putting them back from the markdown conversion is done.

## Checklist:

Navigate to /admin and add a link with an underscore in it to the one of the response templates. Verify that the link is correctly converted to markdown and the underscore is not escaped.

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
