### PR TITLE
Grouping mega caret fix

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -30,7 +30,7 @@
             </div>
           </th>
           <th aria-label="Detail toggles">
-            <a aria-expanded="false" role="button" aria-label="Expand all detail rows" id="toggle-all" class="td-toggle-all display-flex" data-posted='false' href="#">
+            <a aria-expanded="false" role="button" aria-label="Expand all detail rows" class="td-toggle-all display-flex" data-posted='false' href="#">
               <img alt="" aria-hidden="true" src="{% static "img/intake-icons/ic_chevron-right.svg" %}" class="icon">
             </a>
           </th>

--- a/crt_portal/static/js/dashboard_view_all.js
+++ b/crt_portal/static/js/dashboard_view_all.js
@@ -42,11 +42,11 @@
       const toggles = [...parentTable.querySelectorAll('a.td-toggle')].filter(
         toggle => isToggled(toggle) == allToggled
       );
-  
+
       toggles.forEach(toggle => toggleTarget(toggle));
-  
+
       if (allToggled || toggleAll.dataset['posted'] === 'true') return;
-  
+
       markAsViewed(toggles.map(toggle => Number(toggle.dataset['id'])));
       // Set a flag on the toggle so we don't resubmit data multiple times per session.
       toggleAll.dataset['posted'] = 'true';
@@ -57,5 +57,5 @@
   toggleAllButtons.forEach(toggleAll => {
     const parentTable = toggleAll.closest('.usa-table.crt-table');
     addToggleListener(toggleAll, parentTable);
-  })
+  });
 })(window, document);

--- a/crt_portal/static/js/dashboard_view_all.js
+++ b/crt_portal/static/js/dashboard_view_all.js
@@ -33,22 +33,29 @@
       });
   }
 
-  const toggleAll = dom.querySelector('a.td-toggle-all');
-  toggleAll.onclick = function(event) {
-    event.preventDefault();
-    const allToggled = isToggled(toggleAll);
-    toggleAll.querySelector('.icon').classList.toggle('rotate');
-    toggleAll.setAttribute('aria-expanded', allToggled ? 'false' : 'true');
-    const toggles = [...dom.querySelectorAll('a.td-toggle')].filter(
-      toggle => isToggled(toggle) == allToggled
-    );
+  function addToggleListener(toggleAll, parentTable) {
+    toggleAll.addEventListener('click', event => {
+      event.preventDefault();
+      const allToggled = isToggled(toggleAll);
+      toggleAll.querySelector('.icon').classList.toggle('rotate');
+      toggleAll.setAttribute('aria-expanded', allToggled ? 'false' : 'true');
+      const toggles = [...parentTable.querySelectorAll('a.td-toggle')].filter(
+        toggle => isToggled(toggle) == allToggled
+      );
+  
+      toggles.forEach(toggle => toggleTarget(toggle));
+  
+      if (allToggled || toggleAll.dataset['posted'] === 'true') return;
+  
+      markAsViewed(toggles.map(toggle => Number(toggle.dataset['id'])));
+      // Set a flag on the toggle so we don't resubmit data multiple times per session.
+      toggleAll.dataset['posted'] = 'true';
+    });
+  }
 
-    toggles.forEach(toggle => toggleTarget(toggle));
-
-    if (allToggled || toggleAll.dataset['posted'] === 'true') return;
-
-    markAsViewed(toggles.map(toggle => Number(toggle.dataset['id'])));
-    // Set a flag on the toggle so we don't resubmit data multiple times per session.
-    toggleAll.dataset['posted'] = 'true';
-  };
+  const toggleAllButtons = dom.querySelectorAll('.td-toggle-all');
+  toggleAllButtons.forEach(toggleAll => {
+    const parentTable = toggleAll.closest('.usa-table.crt-table');
+    addToggleListener(toggleAll, parentTable);
+  })
 })(window, document);


### PR DESCRIPTION
[#1517](https://github.com/usdoj-crt/crt-portal-management/issues/1517)

## What does this change?

Currently when the mega caret is clicked in any of the groups besides the first one it does not work. If it is clicked on the first group it applies on all the groups.

This PR fixes the bug so when a user clicks a mega caret it only applies to the group it's in

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
