### PR TITLE
Fix clamav to use 9443 instead of 9000

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ First, you'll need to set OAUTH_PROVIDER_CLIENT_ID and OAUTH_PROVIDER_CLIENT_SEC
     3. Client type: Confidential
     4. Grant type: Authorization Code
     5. Algorithm: HMAC with SHA-2 256 (aka S256)
-    
+
 **NOTE: Make sure to copy the secret key _before_ saving the entry. Once saved, the secret will be hashed and can't be viewed again**
 
 Here's an example of what this will look like:
@@ -495,6 +495,8 @@ A [network policy](https://docs.cloudfoundry.org/devguide/deploy-apps/cf-network
 Direct traffic from the portal to the ClamAV REST API:
 
     cf add-network-policy crt-portal-django --destination-app clamav-rest --protocol tcp --port 9000
+
+    cf add-network-policy crt-portal-django --destination-app clamav-rest --protocol tcp --port 9443
 
 ### User roles and permissions
 

--- a/crt_portal/cts_forms/validators.py
+++ b/crt_portal/cts_forms/validators.py
@@ -43,8 +43,11 @@ def validate_filename(file):
 
 def _scan_file(file):
     try:
-        return requests.post(settings.AV_SCAN_URL, files={'file': file}, data={'name': file.name}, timeout=25)
-    except requests.exceptions.ConnectionError:
+        # ClamAV only listens on 9443, which is SSL, but it self-signs its cert.
+        # Because this request stays within the cloud.gov container, it's fine to not verify SSL.
+        return requests.post(settings.AV_SCAN_URL, files={'file': file}, data={'name': file.name}, timeout=25, verify=False)  # nosec
+    except requests.exceptions.ConnectionError as e:
+        logging.exception(e)
         raise ValidationError('We were unable to complete a security inspection of the file, please try again or contact support for assistance.')
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - LOCALSTACK_URL=http://localstack:4566
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
-      - AV_SCAN_URL=http://clamav-rest:9000/scan
+      - AV_SCAN_URL=https://clamav-rest:9443/scan
     build: .
     command: /code/run.sh
     volumes:
@@ -88,6 +88,7 @@ services:
       - SIGNATURE_CHECKS=1
     ports:
       - "9000:9000"
+      - "9443:9443"
 volumes:
   postgres_data:
   localstack-vol:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - LOCALSTACK_URL=http://localstack:4566
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
-      - AV_SCAN_URL=https://clamav-rest:9443/scan
+      - AV_SCAN_URL=http://clamav-rest:9000/scan
     build: .
     command: /code/run.sh
     volumes:
@@ -88,7 +88,6 @@ services:
       - SIGNATURE_CHECKS=1
     ports:
       - "9000:9000"
-      - "9443:9443"
 volumes:
   postgres_data:
   localstack-vol:

--- a/excluded_urls
+++ b/excluded_urls
@@ -9,3 +9,4 @@ https://www.lsc.gov/find-
 https://www.fbi.gov/contact-
 http://localhost:4566
 http://clamav-rest-dev.apps.internal:9000/scan
+https://clamav-rest-dev.apps.internal:9443/scan

--- a/manifest_dev.yaml
+++ b/manifest_dev.yaml
@@ -11,7 +11,7 @@ applications:
     NEW_RELIC_ENVIRONMENT: dev
     NEW_RELIC_APP_NAME: CRT PORTAL (dev)
     NEW_RELIC_LOG: stdout
-    AV_SCAN_URL: http://clamav-rest-dev.apps.internal:9000/scan
+    AV_SCAN_URL: https://clamav-rest-dev.apps.internal:9443/scan
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack

--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -15,7 +15,7 @@ applications:
     NEW_RELIC_ENVIRONMENT: production
     NEW_RELIC_APP_NAME: CRT PORTAL (prod)
     NEW_RELIC_LOG: stdout
-    AV_SCAN_URL: https://clamav-rest-dev.apps.internal:9443/scan
+    AV_SCAN_URL: https://clamav-rest-prod.apps.internal:9443/scan
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack

--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -15,7 +15,7 @@ applications:
     NEW_RELIC_ENVIRONMENT: production
     NEW_RELIC_APP_NAME: CRT PORTAL (prod)
     NEW_RELIC_LOG: stdout
-    AV_SCAN_URL: http://clamav-rest-prod.apps.internal:9000/scan
+    AV_SCAN_URL: https://clamav-rest-dev.apps.internal:9443/scan
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -14,7 +14,7 @@ applications:
     NEW_RELIC_ENVIRONMENT: staging
     NEW_RELIC_APP_NAME: CRT PORTAL (stage)
     NEW_RELIC_LOG: stdout
-    AV_SCAN_URL: https://clamav-rest-dev.apps.internal:9443/scan
+    AV_SCAN_URL: https://clamav-rest-staging.apps.internal:9443/scan
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -14,7 +14,7 @@ applications:
     NEW_RELIC_ENVIRONMENT: staging
     NEW_RELIC_APP_NAME: CRT PORTAL (stage)
     NEW_RELIC_LOG: stdout
-    AV_SCAN_URL: http://clamav-rest-staging.apps.internal:9000/scan
+    AV_SCAN_URL: https://clamav-rest-dev.apps.internal:9443/scan
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
   - python_buildpack


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

- 🌎 ClamAV no longer listens on 9000
- ⛔ Our app tries to use 9000, which fails
- ✅ This commit directs traffic to 9443 instead

## Screenshots (for front-end PR):

<img width="713" alt="image" src="https://user-images.githubusercontent.com/15126660/230165393-96d1d140-7258-435f-a4cb-b6a81a672672.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
