### PR TITLE
Grouping feature - fix issue with bulk actions

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -7,6 +7,7 @@
       novalidate
 >
   <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
+  <input type="hidden" value="{{ group_desc }}" name="group-desc" id="group-desc" />
 
   <div class="crt-xscroll">
     <table class="usa-table crt-table sort-table">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/grouped_index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/grouped_index.html
@@ -67,7 +67,7 @@
           {% include "forms/snippets/group_pagination.html" with page_format=group.data.page_format page_args=page_args group_params=group_params index=forloop.counter0 placement="top" %}
         </div>
       </div>
-        {% include "forms/complaint_view/index/complaints_table.html" with group_params=group_params grouping=grouping page_format=group.data.page_format data_dict=group.data.data_dict sort_state=group.data.sort_state filter_state=group.data.filter_state index=forloop.counter0 %}
+        {% include "forms/complaint_view/index/complaints_table.html" with group_desc=group.desc group_params=group_params grouping=grouping page_format=group.data.page_format data_dict=group.data.data_dict sort_state=group.data.sort_state filter_state=group.data.filter_state index=forloop.counter0 %}
     </div>
   </div>
   <div class="margin-bottom-5">

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -722,7 +722,10 @@ class ActionsView(LoginRequiredMixin, FormView):
     def get(self, request):
         return_url_args = request.GET.get('next', '')
         return_url_args = urllib.parse.unquote(return_url_args)
-
+        query_string = return_url_args
+        group_desc = request.GET.get('group-desc', None)
+        if group_desc is not None and group_desc != 'All other reports':
+            query_string = f'{return_url_args}&violation_summary=^{group_desc}$'
         ids = request.GET.getlist('id')
         # The select all option only applies if 1. user hits the
         # select all button and 2. we have more records in the query
@@ -730,7 +733,7 @@ class ActionsView(LoginRequiredMixin, FormView):
         selected_all = request.GET.get('all', '') == 'all'
 
         if selected_all:
-            requested_query = reconstruct_query(return_url_args)
+            requested_query = reconstruct_query(query_string)
         else:
             requested_query = Report.objects.filter(pk__in=ids)
 


### PR DESCRIPTION
[Issue #1513](https://github.com/usdoj-crt/crt-portal-management/issues/1513)

## What does this change?
Currently the option to complete a bulk action includes all results on the page rather than just the ones in the selected group. This PR fixes that bug so only the members of the group are part of the bulk action.

1. Group by matching description
2. Apply other filters to ensure that a group exists but there are less than 500 records
3. Select all in group and click to perform bulk action
4. Observe that the number in the second button now reflects the number of reports in the group

## Screenshots (for front-end PR):
![image](https://user-images.githubusercontent.com/18104884/230488086-c646b453-cecc-42ae-ae52-d9f53ea98ed8.png)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
