### PR TITLE
upgrade ClamAV memory

### DIFF
--- a/crt_portal/cts_forms/validators.py
+++ b/crt_portal/cts_forms/validators.py
@@ -45,7 +45,7 @@ def _scan_file(file):
     try:
         # ClamAV only listens on 9443, which is SSL, but it self-signs its cert.
         # Because this request stays within the cloud.gov container, it's fine to not verify SSL.
-        return requests.post(settings.AV_SCAN_URL, files={'file': file}, data={'name': file.name}, timeout=25, verify=False)  # nosec
+        return requests.post(settings.AV_SCAN_URL, files={'file': file}, data={'name': file.name}, verify=False)  # nosec
     except requests.exceptions.ConnectionError as e:
         logging.exception(e)
         raise ValidationError('We were unable to complete a security inspection of the file, please try again or contact support for assistance.')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
       - SIGNATURE_CHECKS=1
     ports:
       - "9000:9000"
+      - "9443:9443"
 volumes:
   postgres_data:
   localstack-vol:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,6 @@ services:
       - SIGNATURE_CHECKS=1
     ports:
       - "9000:9000"
-      - "9443:9443"
 volumes:
   postgres_data:
   localstack-vol:

--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -26,7 +26,7 @@ applications:
   - VCAP_SERVICES
 - name: clamav-rest
   instances: 1
-  memory: 2G
+  memory: 4G
   env:
     MAX_FILE_SIZE: 100M
     SIGNATURE_CHECKS: 8


### PR DESCRIPTION
## What does this change?
This upgrade the clamAV memory allocation to 4GB for prod instances.

## Checklist:
+ [ ]  Able to scan file locally during file upload with intake form.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
