### PR TITLE
Fix "groups" of 1 bug

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -90,11 +90,13 @@ def report_grouping(querydict):
     all_qs, filters = report_filter(querydict)
     for group in groups:
         description = group['violation_summary']
-        summaries.append(description)
-        group_queries.append({
-            "qs": all_qs.filter(violation_summary=description),
-            "desc": description
-        })
+        qs = all_qs.filter(violation_summary=description)
+        if qs.count() > 1:
+            summaries.append(description)
+            group_queries.append({
+                "qs": all_qs.filter(violation_summary=description),
+                "desc": description
+            })
     group_queries.append({
         "qs": all_qs.exclude(violation_summary__in=summaries),
         "desc": "All other reports"

--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -91,12 +91,13 @@ def report_grouping(querydict):
     for group in groups:
         description = group['violation_summary']
         qs = all_qs.filter(violation_summary=description)
-        if qs.count() > 1:
-            summaries.append(description)
-            group_queries.append({
-                "qs": all_qs.filter(violation_summary=description),
-                "desc": description
-            })
+        if qs.count() <= 1:
+            continue
+        summaries.append(description)
+        group_queries.append({
+            "qs": all_qs.filter(violation_summary=description),
+            "desc": description,
+        })
     group_queries.append({
         "qs": all_qs.exclude(violation_summary__in=summaries),
         "desc": "All other reports"


### PR DESCRIPTION
[Issue #1515](https://github.com/usdoj-crt/crt-portal-management/issues/1515)

## What does this change?

Currently the grouping feature does not account for filters when the reports are first grouped so it's possible for a "group" to only have one member. This PR updates the logic to add results from one member "groups" back into the rest of the results rather than trying to group them.

1. Select a section to filter by
2. Group by matching descriptions
3. Observe that there are no groups of one

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
