### PR TITLE
Update Template Selection Modal

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1382,14 +1382,27 @@ class ResponseActions(Form):
             for template in templates
         }
         attrs = {
-            "id": "intake_select",
-            "class": "usa-select",
             "aria-label": "template selection"
         }
-        self.fields['templates'] = ModelChoiceField(
-            queryset=templates.filter(show_in_dropdown=True),
+        self.fields['selected_tab'] = CharField(widget=HiddenInput())
+        self.fields['templates_default'] = ModelChoiceField(
+            queryset=templates.filter(show_in_dropdown=True,
+                                      referral_contact__isnull=True),
             empty_label="(no template chosen)",
-            widget=DataAttributesSelect(data=data, attrs=attrs),
+            widget=DataAttributesSelect(data=data, attrs={
+                **attrs,
+                "class": "intake-select usa-select response-template-default",
+            }),
+            required=False,
+        )
+        self.fields['templates_referral'] = ModelChoiceField(
+            queryset=templates.filter(show_in_dropdown=True,
+                                      referral_contact__isnull=False),
+            empty_label="(no template chosen)",
+            widget=DataAttributesSelect(data=data, attrs={
+                **attrs,
+                "class": "intake-select usa-select response-template-referral",
+            }),
             required=False,
         )
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template.html
@@ -22,9 +22,6 @@
               {{data.contact_email|default_if_none:"-"}}
             </strong>
           </p>
-          <p class="intake-template--description">
-            Subject: <strong id="intake_description">(no template chosen)</strong>
-          </p>
           <span>
             Template Language:
           </span>
@@ -33,18 +30,11 @@
               <option value="{{ language.code }}" aria-label="template language selection" {% if language.code == 'en' %}selected{% endif %}>{{ language.name }}</option>
             {% endfor %}
           </select>
-          <span>
-            Template:
-          </span>
-          {{ responses.templates }}
-          <div class="modal-main">
-            <div id="intake_letter_html" class="form-letter" hidden></div>
-            <textarea disabled aria-label="intake letter" id="intake_letter" rows="10" cols="80"></textarea>
-          </div>
+          {% include 'forms/complaint_view/show/response_template_content.html' %}
           <div class="modal-footer">
-            <button disabled id="intake_copy" class="usa-button" type="submit" name="type" value="copy">Copy</button>
-            <button disabled id="intake_print" class="usa-button" type="submit" name="type" value="print">Print</button>
             <button disabled id="intake_send" data-email-enabled="{{email_enabled}}" class="usa-button" type="submit" name="type" value="send">Send</button>
+            <button disabled id="intake_print" class="usa-button" type="submit" name="type" value="print">Print</button>
+            <button disabled id="intake_copy" class="usa-button" type="submit" name="type" value="copy">Copy letter</button>
             <button id="intake_template_cancel" class="usa-button usa-button--unstyled">Cancel</button>
           </div>
         </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template_content.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template_content.html
@@ -1,0 +1,42 @@
+
+<div class="intake-tabbed-area">
+  {{ responses.selected_tab }}
+
+  <header class="intake-tabbed-header">
+    <div class="intake-tabbed-nav-container">
+      <nav aria-label="Primary navigation" class="intake-tabbed-nav">
+        <ul class="intake-tabbed-nav__primary intake-tabbed-accordion">
+          <li class="intake-tabbed-nav__primary-item">
+            <a href="#" data-tab="response-template-default" class="intake-tabbed-nav-link intake-tabbed-current"><span>CRT responses</span></a>
+          </li>
+          <li class="intake-tabbed-nav__primary-item">
+            <a href="#" data-tab="response-template-referral" class="intake-tabbed-nav-link"><span>Referral letters</span></a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <div class="intake-tab-content">
+
+    <div class="modal-main">
+      <div id='response-modal-form' class="modal-form">
+        <div class="modal-main">
+          <span class="response-template-default">CRT response letter:</span>
+          <span class="response-template-referral">Referral letter:</span>
+          {{ responses.templates_default }}
+          {{ responses.templates_referral }}
+
+          <p class="intake-template--description">
+            Subject: <strong id="intake_description">(no template chosen)</strong>
+          </p>
+
+          <div id="intake_letter_html" class="form-letter" hidden></div>
+          <textarea disabled aria-label="intake letter" id="intake_letter" rows="10" cols="80"></textarea>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</div>

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -328,16 +328,18 @@ class ResponseActionTests(TestCase):
         self.report = Report.objects.create(**SAMPLE_REPORT_1)
         self.template = ResponseTemplate.objects.create(**SAMPLE_RESPONSE_TEMPLATE)
 
-    def post_template_action(self, what):
+    def post_template_action(self, what, **form_kwargs):
         response = self.client.post(
             reverse(
                 'crt_forms:crt-forms-response',
                 kwargs={'id': self.report.id},
             ),
             {
-                'templates': self.template.id,
+                'templates_default': self.template.id,
+                'selected_tab': 'response-template-default',
                 'type': what,
                 'next': '?per_page=15',
+                **form_kwargs,
             },
             follow=True
         )

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -526,8 +526,12 @@ class ResponseView(LoginRequiredMixin, View):
         url = preserve_filter_parameters(report, request.POST)
 
         if form.is_valid() and form.has_changed():
-
-            template = form.cleaned_data['templates']
+            tab = form.cleaned_data['selected_tab']
+            template_kind = {
+                'response-template-default': 'templates_default',
+                'response-template-referral': 'templates_referral',
+            }[tab]
+            template = form.cleaned_data[template_kind]
             button_type = request.POST['type']
 
             if button_type == 'send':  # We're going to send an email!

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -527,7 +527,6 @@ class ResponseView(LoginRequiredMixin, View):
         form = ResponseActions(request.POST, instance=report)
         url = preserve_filter_parameters(report, request.POST)
 
-        print('boop', form.is_valid(), form.has_changed())
         if not form.has_changed():
             return redirect(url)
         if not form.is_valid():

--- a/crt_portal/static/js/form_letter.js
+++ b/crt_portal/static/js/form_letter.js
@@ -62,6 +62,7 @@
     letter_html.hidden = true;
     letter.innerHTML = '';
     letter.hidden = false;
+    document.querySelectorAll('.intake-select').forEach(s => (s.selectedIndex = 0));
     copy.setAttribute('disabled', 'disabled');
     print.setAttribute('disabled', 'disabled');
     send_email.setAttribute('disabled', 'disabled');
@@ -111,6 +112,8 @@
   });
 
   function showOnlyTab(toShow) {
+    reset();
+    document.querySelector('input[name="selected_tab"]').value = toShow;
     allTabs.forEach(tabName => {
       [...document.getElementsByClassName(tabName)].forEach(el => {
         el.classList.toggle('display-none', toShow !== tabName);
@@ -127,7 +130,6 @@
       event.stopPropagation();
       reset();
       const tabName = event.currentTarget.dataset.tab;
-      document.querySelector('input[name="selected_tab"]').value = tabName;
       tabs.forEach(tabToSelect => {
         const isCurrent = tabToSelect.dataset.tab === tabName;
         tabToSelect.classList.toggle('intake-tabbed-current', isCurrent);

--- a/crt_portal/static/js/form_letter.js
+++ b/crt_portal/static/js/form_letter.js
@@ -68,40 +68,72 @@
   };
 
   const description = document.getElementById('intake_description');
-  const options = document.getElementById('intake_select');
+  const selects = document.querySelectorAll('.intake-select');
   const reportId = document.getElementById('template-report-id').value;
-  options.addEventListener('change', function(event) {
-    event.preventDefault();
-    const index = event.target.selectedIndex;
-    const option = event.target.options[index];
-    const value = event.target.value;
-    window
-      .fetch('/api/responses/' + value + '/?report_id=' + reportId)
-      .then(function(response) {
-        return response.json();
-      })
-      .then(function(data) {
-        description.innerHTML = data.subject || '(select a response template)';
-        if (data.is_html) {
-          letter.hidden = true;
-          letter_html.hidden = false;
-          letter_html.innerHTML = marked.parse(data.body || '');
-        } else {
-          letter_html.hidden = true;
-          letter.hidden = false;
-          letter.innerHTML = data.body || '';
+  selects.forEach(select =>
+    select.addEventListener('change', function(event) {
+      event.preventDefault();
+      const index = event.target.selectedIndex;
+      const option = event.target.options[index];
+      const value = event.target.value;
+      window
+        .fetch('/api/responses/' + value + '/?report_id=' + reportId)
+        .then(function(response) {
+          return response.json();
+        })
+        .then(function(data) {
+          description.innerHTML = data.subject || '(select a response template)';
+          if (data.is_html) {
+            letter.hidden = true;
+            letter_html.hidden = false;
+            letter_html.innerHTML = marked.parse(data.body || '');
+          } else {
+            letter_html.hidden = true;
+            letter.hidden = false;
+            letter.innerHTML = data.body || '';
+          }
+          addReferralAddress(data.referral_contact);
+        });
+      if (index >= 1) {
+        copy.removeAttribute('disabled');
+        print.removeAttribute('disabled');
+        if (email_enabled && has_contact_email) {
+          send_email.removeAttribute('disabled');
         }
-        addReferralAddress(data.referral_contact);
-      });
-    if (index >= 1) {
-      copy.removeAttribute('disabled');
-      print.removeAttribute('disabled');
-      if (email_enabled && has_contact_email) {
-        send_email.removeAttribute('disabled');
+      } else {
+        reset();
       }
-    } else {
+    })
+  );
+
+  const allTabs = [...document.querySelectorAll('a.intake-tabbed-nav-link')].map(tab => {
+    return tab.dataset.tab;
+  });
+
+  function showOnlyTab(toShow) {
+    allTabs.forEach(tabName => {
+      [...document.getElementsByClassName(tabName)].forEach(el => {
+        el.classList.toggle('display-none', toShow !== tabName);
+      });
+    });
+  }
+
+  showOnlyTab(allTabs[0]);
+
+  const tabs = [...document.querySelectorAll('a.intake-tabbed-nav-link')];
+  tabs.forEach(tab => {
+    tab.addEventListener('click', function(event) {
+      event.preventDefault();
+      event.stopPropagation();
       reset();
-    }
+      const tabName = event.currentTarget.dataset.tab;
+      document.querySelector('input[name="selected_tab"]').value = tabName;
+      tabs.forEach(tabToSelect => {
+        const isCurrent = tabToSelect.dataset.tab === tabName;
+        tabToSelect.classList.toggle('intake-tabbed-current', isCurrent);
+      });
+      showOnlyTab(tabName);
+    });
   });
 
   var setLanguageCookie = function(lang) {
@@ -125,11 +157,11 @@
 
     // form letters for languages other than the one selected
     var toHide = document.querySelectorAll(
-      `#intake_select > option.usa-select:not([data-language=${selected_language}])`
+      `.intake-select > option.usa-select:not([data-language=${selected_language}])`
     );
     // form letters for the language that is selected
     var toShow = document.querySelectorAll(
-      `#intake_select > option.usa-select[data-language=${selected_language}]`
+      `.intake-select > option.usa-select[data-language=${selected_language}]`
     );
 
     for (var el of toHide) {
@@ -141,8 +173,9 @@
     }
 
     // the selected language changed, clear the currently selected form letter
-    var intake_select = document.getElementById('intake_select');
-    intake_select.selectedIndex = 0;
+    document.querySelectorAll('.intake-select').forEach(intake_select => {
+      intake_select.selectedIndex = 0;
+    });
     reset();
   };
 

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -392,7 +392,7 @@
 
       span {
         padding-bottom: 11px;
-        border-bottom: 3px solid #162E51;
+        border-bottom: 3px solid #005EA2;
       }
     }
   }

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -298,6 +298,120 @@
   }
 }
 
+#intake_print:not([disabled="disabled"]),#intake_copy:not([disabled="disabled"]) {
+  background-color: #ecf1f7;
+  color: #162e51;
+}
+
+.intake-tabbed-area {
+
+  nav ul {
+    list-style: none;
+
+    li:not(:first-child) {
+      margin-top: 0;
+    }
+
+    margin: 0;
+  }
+
+  .intake-tabbed-header {
+    font-family: Public Sans Web,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+    font-size: 1rem;
+    line-height: 1.6;
+  }
+
+  select.intake-select {
+    margin-bottom: 16px;
+    width: 100%;
+  }
+
+  .intake-tabbed-nav-container {
+    padding: 0;
+    align-items: flex-end;
+    justify-content: space-between;
+    display: flex;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 64rem;
+  }
+
+  .intake-tabbed-nav {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    float: right;
+    font-family: Public Sans Web,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+    font-size: 1rem;
+    justify-content: flex-start;
+    line-height: 1;
+    padding: 0;
+    position: relative;
+    width: 100%;
+  }
+
+  .intake-tabbed-nav__primary intake-tabbed-accordion {
+    color: #2e2e2a;
+    font-family: Public Sans Web,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+    font-size: 1rem;
+    line-height: 1;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .intake-tabbed-nav__primary {
+    width: auto;
+    display: flex;
+  }
+
+  .intake-tabbed-header--basic .intake-tabbed-nav__link:hover::after, .intake-tabbed-header--basic .intake-tabbed-nav__primary-item>.intake-tabbed-current::after {
+    bottom: 0;
+  }
+
+  .intake-tabbed-nav__primary-item {
+    font-size: .88rem;
+    line-height: 1;
+
+    &:has(.intake-tabbed-current) {
+      background-color: #ECF1F7;
+    }
+  }
+
+  a.intake-tabbed-nav-link {
+    line-height: 1;
+    padding: 1rem;
+    color: #162e51;
+    display: block;
+    font-weight: 700;
+    text-decoration: none;
+
+    &.intake-tabbed-current {
+      background-color: #ECF1F7;
+      position: relative;
+
+      span {
+        padding-bottom: 11px;
+        border-bottom: 3px solid #162E51;
+      }
+    }
+  }
+
+  .intake-tab-content {
+    background-color: #ECF1F7;
+    padding: 16px;
+    margin-bottom:16px;
+  }
+
+  textarea {
+    background-color: white;
+  }
+
+  #intake_letter_html {
+    background-color: white;
+  }
+}
+
 .usa-select {
   @include u-border(1px, $theme-color-primary-darker);
   border-radius: 3px;

--- a/crt_portal/static/sass/custom/modal.scss
+++ b/crt_portal/static/sass/custom/modal.scss
@@ -130,7 +130,7 @@ body.is-modal {
     margin-bottom: 1rem;
   }
 
-  #intake_select {
+  .intake-select {
     width: 50%;
     margin-bottom: 1rem;
   }


### PR DESCRIPTION
## What does this change?

- 🌎 The template selection modal shows all templates in one place.
- ⛔ This isn't great because there are a lot of templates.
- ✅ This commit splits out referrals from "normal" templates.

## Screenshots (for front-end PR):

![templates](https://user-images.githubusercontent.com/15126660/230963540-3848de8d-e4a6-40c2-8744-69b5442f0f3e.gif)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
