### PR TITLE
Make grouping query more efficient, fix bulk actions bug

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -90,8 +90,7 @@ def report_grouping(querydict):
     summaries = []
     for group in groups:
         description = group['violation_summary']
-        qs = all_qs.filter(violation_summary=description)
-        if qs.count() <= 1:
+        if description == "":
             continue
         summaries.append(description)
         group_queries.append({

--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -84,10 +84,10 @@ def _get_date_field_from_param(field):
 
 
 def report_grouping(querydict):
-    groups = Report.objects.values('violation_summary').annotate(total=Count('violation_summary')).filter(total__gt=1).order_by('-total')
+    all_qs, filters = report_filter(querydict)
+    groups = all_qs.values('violation_summary').annotate(total=Count('violation_summary')).filter(total__gt=1).order_by('-total')
     group_queries = []
     summaries = []
-    all_qs, filters = report_filter(querydict)
     for group in groups:
         description = group['violation_summary']
         qs = all_qs.filter(violation_summary=description)

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_actions.html
@@ -19,6 +19,7 @@
       <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
       <input type="hidden" value="{{ ids }}" name="ids" id="ids" />
       <input type="hidden" value="{{ selected_all }}" name="all" id="all" />
+      <input type="hidden" value="{{ query_string }}" name="query_string" id="query_string" />
 
       <div id="bulk_actions_section">
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -765,10 +765,7 @@ class ActionsView(LoginRequiredMixin, FormView):
         selected_all = request.POST.get('all', '') == 'all'
         confirm_all = request.POST.get('confirm_all', '') == 'confirm_all'
         ids = request.POST.get('ids', '').split(',')
-        query_string = request.POST.get('query_string', None)
-
-        if query_string is None:
-            query_string = return_url_args
+        query_string = request.POST.get('query_string', return_url_args)
 
         if confirm_all:
             requested_query = reconstruct_query(query_string)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -756,6 +756,7 @@ class ActionsView(LoginRequiredMixin, FormView):
             'print_reports': requested_query,
             'print_options': PrintActions(),
             'questions': Review.question_text,
+            'query_string': query_string,
         }
         return render(request, 'forms/complaint_view/actions/index.html', output)
 
@@ -764,9 +765,13 @@ class ActionsView(LoginRequiredMixin, FormView):
         selected_all = request.POST.get('all', '') == 'all'
         confirm_all = request.POST.get('confirm_all', '') == 'confirm_all'
         ids = request.POST.get('ids', '').split(',')
+        query_string = request.POST.get('query_string', None)
+
+        if query_string is None:
+            query_string = return_url_args
 
         if confirm_all:
-            requested_query = reconstruct_query(return_url_args)
+            requested_query = reconstruct_query(query_string)
         else:
             requested_query = Report.objects.filter(pk__in=ids)
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -244,7 +244,7 @@ def render_group_view(request, profile_form, selected_assignee_id, selected_camp
             })
     else:
         updated_group_params = group_params
-    final_data = get_group_view_data(request, updated_group_queries[0]["qs"], filters, grouping, updated_group_params[0], 'All other reports')
+    final_data = group_view_data[len(group_view_data) - 1]["data"]
     final_data['return_url_args'] = urllib.parse.quote(f"{final_data['page_args']}&group_params={updated_group_params}")
     final_data.update({
         'profile_form': profile_form,

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -244,7 +244,7 @@ def render_group_view(request, profile_form, selected_assignee_id, selected_camp
             })
     else:
         updated_group_params = group_params
-    final_data = group_view_data[len(group_view_data) - 1]["data"]
+    final_data = group_view_data[-1]["data"]
     final_data['return_url_args'] = urllib.parse.quote(f"{final_data['page_args']}&group_params={updated_group_params}")
     final_data.update({
         'profile_form': profile_form,


### PR DESCRIPTION
[Issue #1527](https://github.com/usdoj-crt/crt-portal-management/issues/1527)
[Issue #1524](https://github.com/usdoj-crt/crt-portal-management/issues/1524)
[Issue #1528](https://github.com/usdoj-crt/crt-portal-management/issues/1528)

## What does this change?
This updates the grouping query to make it more efficient in the following ways:
1. Removing the count() query for each group
2. Applying the filters before grouping to reduce the number of reports to group
3. Removing an extra unnecessary grouping query

It also fixes the bulk actions in groups so they only apply to members of the group.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
