### PR TITLE
Grouping Feature: Fix back to all

### DIFF
--- a/crt_portal/cts_forms/templatetags/back_to_all.py
+++ b/crt_portal/cts_forms/templatetags/back_to_all.py
@@ -15,5 +15,5 @@ def back_to_all(return_url_args=''):
     violation_summary = querydict.get('violation_summary', '')
     if violation_summary.startswith('^') and violation_summary.endswith('$'):
         querydict.pop('violation_summary')
-        return_url_args = urllib.parse.urlencode(querydict)
+        return_url_args = urllib.parse.urlencode(querydict).replace('%3F', '?')
     return return_url_args


### PR DESCRIPTION
[Issue #1514](https://github.com/usdoj-crt/crt-portal-management/issues/1514)

## What does this change?

This PR fixes an issue where when the user clicks on an individual report in a group and then the Back to all button it 404s.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
