### PR TITLE
Ignore browser cache when static files have changed

### DIFF
--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -133,7 +133,6 @@ class ResponseTemplatePreviewBase:
 
     def _add_css(self, body):
         return body + mark_safe(
-            '{% load static %}'
             '<link rel="stylesheet" href="{% static "css/compiled/template-preview.css" %}">'
         )
 

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -143,6 +143,7 @@ TEMPLATES = [
             'builtins': [
                 'cts_forms.templatetags.with_input_error',
                 'features.templatetags.feature_script',
+                'cts_forms.templatetags.static_refresh',
             ],
             'context_processors': [
                 'django.template.context_processors.debug',

--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load i18n %}
 {% load get_env %}
 {% load get_voting_mode %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_actions.html
@@ -1,7 +1,6 @@
 {% extends "forms/complaint_view/show/card.html" %}
 
 {% load i18n %}
-{% load static %}
 
 {% block title %}Update multiple records{% endblock %}
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_print.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_print.html
@@ -1,4 +1,3 @@
-{% load static %}
 
 <span>
   <a href="#" id="printout_report" class="bulk-print-link">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -1,6 +1,5 @@
 {% extends "forms/complaint_view/intake_base.html" %}
 
-{% load static %}
 
 {% block page_title %}
   <title>CRT Complaint Records - Update multiple records</title>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/active-filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/active-filters.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load get_field_label %}
 
 <div id="active-filters" data-active-filters>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/analytics.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/analytics.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% if embeds %}
 <h2 style="margin-top: 2em" class="intake-section-title">Analytics</h2>
 <div class="margin-bottom-2">Take a high-level look at report data.</div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/complaints_table.html
@@ -1,5 +1,4 @@
 {% load sortable_table_heading %}
-{% load static %}
 <form class="usa-form"
       method="get"
       action="{% url 'crt_forms:crt-forms-actions' %}"

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filter-controls.html
@@ -1,4 +1,3 @@
-{% load static %}
 <h2 class="intake-section-title">Team Management</h2>
 <div class="margin-bottom-2">Review the activity log of intake specialists by selecting their name(s) and dates in the filter options below.</div>
 <form

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filter-no-dropdown.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filter-no-dropdown.html
@@ -1,4 +1,3 @@
-{% load static %}
 <div class="crt-textbox {% block classes %}{% endblock %}">
   <div class="content" id="{%block id %}{% endblock %}">
     {% block content %}{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/header.html
@@ -1,4 +1,3 @@
-{% load static %}
 <header class="intake-header">
   <div class="title">
     {% include 'forms/complaint_view/header_title.html' with page='team_management' %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/index.html
@@ -1,5 +1,4 @@
 {% extends "forms/complaint_view/intake_base.html" %}
-{% load static %}
 
 {% block page_header %}
 {% include 'forms/complaint_view/dashboard/header.html' %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/header_title.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/header_title.html
@@ -1,4 +1,3 @@
-{% load static %}
 <div class="title">
   <div class="title-icon">
     <img src="{% static 'img/intake-icons/ic_home.svg' %}" alt="" class="icon" />

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/active-filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/active-filters.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load get_field_label %}
 
 <div id="active-filters" data-active-filters>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -1,5 +1,4 @@
 {% load sortable_table_heading %}
-{% load static %}
 
 <form class="usa-form"
       method="get"

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -1,4 +1,3 @@
-{% load static %}
 <h2 class="intake-section-title margin-bottom-105">Report Records</h2>
 <span>Find specific CRT Report Records by using the filter options below.</span>
 <form

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-no-dropdown.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-no-dropdown.html
@@ -1,4 +1,3 @@
-{% load static %}
 <div class="crt-textbox {% block classes %}{% endblock %}">
   <div class="content" id="{%block id %}{% endblock %}">
     {% block content %}{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter.html
@@ -1,4 +1,3 @@
-{% load static %}
 <div class="crt-dropdown {% block classes %}{% endblock %}" data-crt-dropdown>
   <button
     class="crt-dropdown__title"

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/checkbox_section_filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/checkbox_section_filter.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load multiselect_summary %}
 {% block content %}
 <form id="cts-forms-profile" class="usa-form" method="post" action="{% url 'crt_forms:cts-forms-profile' %}" novalidate>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/checkbox_status_filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/checkbox_status_filter.html
@@ -1,4 +1,3 @@
-{% load static %}
 
 {% block content %}
   {{ form.status }}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/grouped_index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/grouped_index.html
@@ -1,5 +1,4 @@
 {% extends "forms/complaint_view/intake_base.html" %}
-{% load static %}
 
 {% block page_header %}
 {% include 'forms/complaint_view/intake_filters_header.html' with title_text="Reporting Portal" profile_form=profile_form  %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -1,5 +1,4 @@
 {% extends "forms/complaint_view/intake_base.html" %}
-{% load static %}
 
 {% block page_header %}
 {% include 'forms/complaint_view/intake_filters_header.html' with title_text="Reporting Portal" profile_form=profile_form  %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load static %}
 {% block ga_tagmanager_head %}{% endblock %}
 {% block ga_tagmanager_body %}{% endblock %}
 {% block meta_analytics %}{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/intake_filters_header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/intake_filters_header.html
@@ -1,4 +1,3 @@
-{% load static %}
 <header class="intake-header grid-row">
   {% include 'forms/complaint_view/header_title.html' with page="report_records" %}
   <div class="intake-actions">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/intake_header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/intake_header.html
@@ -1,4 +1,3 @@
-{% load static %}
 <header class="intake-header">
   <div class="title">
     {% include 'forms/complaint_view/header_title.html' with page="report_records" %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/form_letter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/form_letter.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load i18n %}
 
 <div id="form-letterhead" hidden>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/routing_guide.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/routing_guide.html
@@ -1,5 +1,4 @@
 {% extends "forms/complaint_view/intake_base.html" %}
-{% load static %}
 {% block page_header %}
 {% include 'forms/complaint_view/routing_guide_header.html' %}
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/routing_guide_header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/routing_guide_header.html
@@ -1,4 +1,3 @@
-{% load static %}
 <header class="intake-header">
   <div class="title">
     {% include 'forms/complaint_view/header_title.html' %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/search_help.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/search_help.html
@@ -1,6 +1,5 @@
 {% extends "forms/complaint_view/intake_base.html" %}
 
-{% load static %}
 
 {% block page_title %}
   <title>CRT Complaint Records - Search help</title>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -1,5 +1,4 @@
 {% extends "forms/complaint_view/show/card.html" %}
-{% load static %}
 {% block title %}{{title}}{% endblock %}
 {% block extra_classes %}crt-action-card{% endblock %}
 {% block icon %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
@@ -1,5 +1,4 @@
 {% extends "forms/complaint_view/show/card.html" %}
-{% load static %}
 {% block title %}{{title}}{% endblock %}
 {% block icon %}
   <img src="{% static icon %}" alt="" class="icon" />

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/attachments.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/attachments.html
@@ -1,5 +1,4 @@
 {% extends "forms/complaint_view/show/card.html" %}
-{% load static %}
 {% block title %}{{title}}{% endblock %}
 {% block extra_classes %}crt-action-card{% endblock %}
 {% block icon %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -2,7 +2,6 @@
 {% load commercial_public_space_view %}
 {% load correctional_facility_view %}
 {% load employer_info_view %}
-{% load static %}
 
 {% block title %}Reported complaint{% endblock %}
 {% block extra_title %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/correspondent_info.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/correspondent_info.html
@@ -1,5 +1,4 @@
 {% extends "forms/complaint_view/show/card.html" %}
-{% load static %}
 {% load all_sections %}
 
 {% block title %}Correspondent information{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/header.html
@@ -1,4 +1,3 @@
-{% load static %}
 
 <div class="display-flex flex-align-center details-id">
   <h2 class="margin-right-205 margin-top-0 margin-bottom-0 backend-blue">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -1,6 +1,5 @@
 {% extends "forms/complaint_view/intake_base.html" %}
 {% load back_to_all %}
-{% load static %}
 
 {% block page_title %}
  <title>CRT Complaint Records{% for message in messages %} - {{ message }}{% endfor %}</title>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/print_report.html
@@ -1,4 +1,3 @@
-{% load static %}
 
 <form class="usa-form"
       method="post"

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/related_reports.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/related_reports.html
@@ -1,5 +1,4 @@
 {% extends "forms/complaint_view/show/card.html" %}
-{% load static %}
 {% load all_sections %}
 
 {% block title %}{{title}}{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/response_template.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load static %}
 
 {% get_available_languages as LANGUAGES %}
 {% get_language_info_list for LANGUAGES as languages %}

--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load static %}
 {% get_current_language as LANGUAGE_CODE %}
 
 

--- a/crt_portal/cts_forms/templates/forms/data_export.html
+++ b/crt_portal/cts_forms/templates/forms/data_export.html
@@ -1,5 +1,4 @@
 {% extends "forms/complaint_view/intake_base.html" %}
-{% load static %}
 
 {% block page_title %}
  <title>CRT Complaint Records{% for message in messages %} - {{ message }}{% endfor %}</title>

--- a/crt_portal/cts_forms/templates/forms/errors.html
+++ b/crt_portal/cts_forms/templates/forms/errors.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load static %}
 
 {% block page_header %}
 <header class="confirmation-header crt-landing--blue padding-bottom-10">

--- a/crt_portal/cts_forms/templates/forms/errors_heading.html
+++ b/crt_portal/cts_forms/templates/forms/errors_heading.html
@@ -1,6 +1,5 @@
 {% extends "forms/errors.html" %}
 {% load i18n %}
-{% load static %}
 
 {% block error_heading %}{{ status }}{% endblock %}
 {% block error_message %}{{ message }}{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/portal/header.html
+++ b/crt_portal/cts_forms/templates/forms/portal/header.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load i18n %}
 {% trans "United States Department of Justice" as DOJ %}
 

--- a/crt_portal/cts_forms/templates/forms/portal/progress-bar.html
+++ b/crt_portal/cts_forms/templates/forms/portal/progress-bar.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load i18n %}
 {# Progress text for screen reader. #}
 <div class="grid-row grid-gap progress-bar">

--- a/crt_portal/cts_forms/templates/forms/pro_template.html
+++ b/crt_portal/cts_forms/templates/forms/pro_template.html
@@ -1,6 +1,5 @@
 {# not on public pages #}
 {% extends "forms/report_base.html" %}
-{% load static %}
 {{ super }}
 
 {% block page_header %}

--- a/crt_portal/cts_forms/templates/forms/question_cards/commercial_public_location.html
+++ b/crt_portal/cts_forms/templates/forms/question_cards/commercial_public_location.html
@@ -1,4 +1,4 @@
-{% load i18n %} {% load static %}
+{% load i18n %}
 
 <fieldset class="usa-fieldset margin-bottom-4">
   <legend class="question--header">

--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load static %}
 
 {% block page_title %}
   {% if wizard.steps.step1 and current_step_name %}

--- a/crt_portal/cts_forms/templates/forms/report_class.html
+++ b/crt_portal/cts_forms/templates/forms/report_class.html
@@ -1,6 +1,5 @@
 {% extends "forms/report_base.html" %}
 {% load i18n %}
-{% load static %}
 
 
 {% block form_questions %}

--- a/crt_portal/cts_forms/templates/forms/report_contact_info.html
+++ b/crt_portal/cts_forms/templates/forms/report_contact_info.html
@@ -1,6 +1,5 @@
 {% extends "forms/report_base.html" %}
 {% load i18n %}
-{% load static %}
 
 {% block page_info_card %}
   <div class="crt-portal-card crt-portal-card">

--- a/crt_portal/cts_forms/templates/forms/report_location.html
+++ b/crt_portal/cts_forms/templates/forms/report_location.html
@@ -1,5 +1,4 @@
 {% extends "forms/report_base.html" %}
-{% load static %}
 {% load i18n %}
 
 

--- a/crt_portal/cts_forms/templates/forms/report_maintenance.html
+++ b/crt_portal/cts_forms/templates/forms/report_maintenance.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load static %}
 
 {% block page_header %}
 <header class="confirmation-header crt-landing--blue padding-bottom-10">

--- a/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
+++ b/crt_portal/cts_forms/templates/forms/report_primary_complaint.html
@@ -1,5 +1,4 @@
 {% extends "forms/report_base.html" %}
-{% load static %}
 {% load i18n %}
 
 {% block form_questions %}

--- a/crt_portal/cts_forms/templates/forms/report_review.html
+++ b/crt_portal/cts_forms/templates/forms/report_review.html
@@ -1,6 +1,5 @@
 {% extends "forms/report_base.html" %}
 {% load i18n %}
-{% load static %}
 
 {% block form_questions %}
  <div class="crt-portal-card">

--- a/crt_portal/cts_forms/templates/forms/snippets/group_pagination.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/group_pagination.html
@@ -1,7 +1,6 @@
 {# not on public pages #}
 {% load grouping_page %}
 
-{% load static %}
 <section class="usa-pagination-wrapper">
   <nav class="usa-pagination view-all-pagination" aria-label="pagination">
     <span class="usa-sr-only">Pagination: Current page, page {{ page_format.page }}.</span>

--- a/crt_portal/cts_forms/templates/forms/snippets/pagination.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/pagination.html
@@ -1,6 +1,5 @@
 {# not on public pages #}
 
-{% load static %}
 <section class="usa-pagination-wrapper">
   <nav class="usa-pagination view-all-pagination" aria-label="pagination">
     <span class="usa-sr-only">Pagination: Current page, page {{ page_format.page }}.</span>

--- a/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
+++ b/crt_portal/cts_forms/templates/forms/snippets/sortable_table_heading.html
@@ -1,6 +1,5 @@
 {# not on public pages #}
 
-{% load static %}
 
 <th scope="col" class="{% if sort_url %}sort-cell{% endif %}" {% if nowrap %}nowrap{% endif %}>
   {% if sort_url %}

--- a/crt_portal/cts_forms/templates/hate_crime_human_trafficking.html
+++ b/crt_portal/cts_forms/templates/hate_crime_human_trafficking.html
@@ -1,6 +1,5 @@
 {% extends "landing.html" %}
 
-{% load static %}
 {% load i18n %}
 
 {% block meta_title %}
@@ -72,7 +71,7 @@
               {% trans "Get help from the National Human Trafficking Hotline" %}
             </a>
           </p>
-        </section>        
+        </section>
       </div>
     </div>
   </div>

--- a/crt_portal/cts_forms/templates/hce_resources.html
+++ b/crt_portal/cts_forms/templates/hce_resources.html
@@ -1,6 +1,5 @@
 {% extends "landing.html" %}
 
-{% load static %}
 {% load i18n %}
 
 {% block meta_title %}

--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 
-{% load static %}
 {% load i18n %}
 {% load get_voting_mode %}
 

--- a/crt_portal/cts_forms/templates/partials/banner/usa_banner.html
+++ b/crt_portal/cts_forms/templates/partials/banner/usa_banner.html
@@ -1,4 +1,3 @@
-{% load static %}
 <section class="usa-banner" aria-label="Official government website,,">
   <div class="usa-accordion">
     {% include "partials/banner/usa_banner_header.html" %}

--- a/crt_portal/cts_forms/templates/partials/banner/usa_banner_content.html
+++ b/crt_portal/cts_forms/templates/partials/banner/usa_banner_content.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load i18n %}
 <div class="usa-banner__guidance tablet:grid-col-6">
   <img class="usa-banner__icon usa-media-block__img" src="{% static "img/icon-dot-gov.svg" %}" role="img" alt="" aria-hidden="true">

--- a/crt_portal/cts_forms/templates/partials/banner/usa_banner_header.html
+++ b/crt_portal/cts_forms/templates/partials/banner/usa_banner_header.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load i18n %}
 <header class="usa-banner__header">
   <div class="usa-banner__inner">

--- a/crt_portal/cts_forms/templates/partials/banner/usa_banner_language_selection.html
+++ b/crt_portal/cts_forms/templates/partials/banner/usa_banner_language_selection.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load static %}
 
 {% get_current_language as LANGUAGE_CODE %}
 {% get_available_languages as LANGUAGES %}
@@ -17,5 +16,5 @@
         {% endfor %}
       </form>
     </div>
-    
+
 </div>

--- a/crt_portal/cts_forms/templates/partials/footer.html
+++ b/crt_portal/cts_forms/templates/partials/footer.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load static %}
 
 <div class="grid-container">
   <div class="grid-row">

--- a/crt_portal/cts_forms/templates/partials/menu_language_selection.html
+++ b/crt_portal/cts_forms/templates/partials/menu_language_selection.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load i18n %}
 
 {% get_current_language as LANGUAGE_CODE %}

--- a/crt_portal/cts_forms/templates/partials/unsupported-browser-modal.html
+++ b/crt_portal/cts_forms/templates/partials/unsupported-browser-modal.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load static %}
 
 <div id="unsupported_browser_modal" hidden>
   <div class="modal-wrapper" role="dialog" aria-modal="true" aria-describedby="modal_dialog_header">

--- a/crt_portal/cts_forms/templates/privacy.html
+++ b/crt_portal/cts_forms/templates/privacy.html
@@ -1,6 +1,5 @@
 {% extends "landing.html" %}
 
-{% load static %}
 {% load i18n %}
 
 {% block meta_title %}

--- a/crt_portal/cts_forms/templates/vot_resources.html
+++ b/crt_portal/cts_forms/templates/vot_resources.html
@@ -1,6 +1,5 @@
 {% extends "landing.html" %}
 
-{% load static %}
 {% load i18n %}
 
 {% block meta_title %}

--- a/crt_portal/cts_forms/templatetags/static_refresh.py
+++ b/crt_portal/cts_forms/templatetags/static_refresh.py
@@ -9,7 +9,7 @@ register = template.Library()
 class TimestampedStaticNode(StaticNode):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.timestamp = str(int(os.path.getmtime('/code/package.json')))
+        self.timestamp = str(int(os.path.getmtime('.')))
 
     def url(self, *args, **kwargs):
         url = super().url(*args, **kwargs)

--- a/crt_portal/cts_forms/templatetags/static_refresh.py
+++ b/crt_portal/cts_forms/templatetags/static_refresh.py
@@ -9,7 +9,7 @@ register = template.Library()
 class TimestampedStaticNode(StaticNode):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.timestamp = str(int(os.path.getmtime('.')))
+        self.timestamp = str(int(os.path.getmtime('/code/package-lock.json')))
 
     def url(self, *args, **kwargs):
         url = super().url(*args, **kwargs)

--- a/crt_portal/cts_forms/templatetags/static_refresh.py
+++ b/crt_portal/cts_forms/templatetags/static_refresh.py
@@ -1,0 +1,21 @@
+import os
+
+from django import template
+from django.templatetags.static import StaticNode
+
+register = template.Library()
+
+
+class TimestampedStaticNode(StaticNode):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.timestamp = str(int(os.path.getmtime('.')))
+
+    def url(self, *args, **kwargs):
+        url = super().url(*args, **kwargs)
+        return f'{url}?v={self.timestamp}'
+
+
+@register.tag('static')
+def do_static(parser, token):
+    return TimestampedStaticNode.handle_token(parser, token)

--- a/crt_portal/cts_forms/templatetags/static_refresh.py
+++ b/crt_portal/cts_forms/templatetags/static_refresh.py
@@ -9,7 +9,7 @@ register = template.Library()
 class TimestampedStaticNode(StaticNode):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.timestamp = str(int(os.path.getmtime('/code/package-lock.json')))
+        self.timestamp = str(int(os.path.getmtime('/code/package.json')))
 
     def url(self, *args, **kwargs):
         url = super().url(*args, **kwargs)

--- a/crt_portal/templates/admin/base_site.html
+++ b/crt_portal/templates/admin/base_site.html
@@ -1,5 +1,4 @@
 {% extends "admin/base_site.html" %}
-{% load static %}
 {% load feature_script %}
 {% block extrahead %}
     <link rel="icon" href="{% static "img/favicon.png" %}">

--- a/crt_portal/templates/email.html
+++ b/crt_portal/templates/email.html
@@ -1,4 +1,3 @@
-{% load static %}
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">


### PR DESCRIPTION
This is a Draft PR as part of the spike to explore how we might handle force-reloading of static files. We'll discuss this approach and modify/merge as appropriate.

## What does this change?

- 🌎 Users aren't refreshing the page, and so are getting cached static files.
- ⛔ This is bad, because our python often depends on our javascript or CSS having the latest versions. When they are out of sync, unexpected behavior can happen.
- ✅ This commit extends the static tag to use the current directory's modified time as a way to indicate when the application was last deployed. This means that the browser will request new versions of files when the application is deployed or restaged (whenever we've stopped just serving the "same" code).

I've also added this new static tag to the builtin template context in settings.py, so we don't need to `{% load static %}` in every file anymore.

## Screenshots (for front-end PR):

Here's the network tab showing the values loading without 

<img width="760" alt="image" src="https://user-images.githubusercontent.com/15126660/235519886-acb078cc-28fa-477d-b24b-be58b958667f.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

To bump the timestamp when testing locally, running `touch .` from the repository root will cause the package-lock's updated time to be changed, simulating the content being re-cloned.

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
