### PR TITLE
Add "soft validation" to the report detail page

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1926,7 +1926,7 @@ class ReportEditForm(ProForm, ActivityStreamUpdater):
     trafficking = BooleanField(required=False, widget=CheckboxInput(attrs={'class': 'usa-checkbox__input'}))
 
     # Summary fields
-    summary = CharField(required=False, strip=True, widget=Textarea(attrs={'class': 'usa-textarea'}))
+    summary = CharField(required=False, strip=True, widget=Textarea(attrs={'class': 'usa-textarea', 'data-soft-valid': 'true', 'data-soft-maxlength': 7000}))
     summary_id = IntegerField(required=False, widget=HiddenInput())
 
     class Meta(ProForm.Meta):

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -97,6 +97,7 @@
 <script src="{% static 'js/modal.min.js' %}"></script>
 <script src="{% static 'js/form_letter.min.js' %}"></script>
 <script src="{% static 'js/restrict_field.min.js' %}"></script>
+<script src="{% static 'js/soft_validation.min.js' %}"></script>
 <script src="{% static 'js/paste_dj_field.min.js' %}"></script>
 <script src="{% static 'js/print_report.min.js' %}"></script>
 <script src="{% static 'js/attachments.min.js' %}"></script>

--- a/crt_portal/static/js/soft_validation.js
+++ b/crt_portal/static/js/soft_validation.js
@@ -1,0 +1,81 @@
+/**
+ * Unlike USWDS's builtin validation, does not restrict input.
+ *
+ * This can be useful for fields where users may want to paste a large value,
+ * then trim it down before submission.
+ *
+ * For the list of supported value names, see:
+ *   https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation#using_built-in_form_validation
+ *
+ * To use them without conflicting with builtin validation, use a "data-soft-"
+ * attribute. For example:
+ *
+ * <textarea data-soft-valid data-soft-maxlength="5"></textarea>
+ *
+ */
+(function(root, dom) {
+  function markValid(element) {
+    element.classList.remove('usa-input--error');
+    element.dataset.softValid = true;
+    if (element.nextElementSibling.classList.contains('soft-valid-message')) {
+      element.nextElementSibling.remove();
+    }
+
+    if (!element.form?.querySelector('[data-soft-valid="false"]')) {
+      element.form.querySelector('[type="submit"]').disabled = false;
+    }
+  }
+
+  function markInvalid(element, clone) {
+    element.classList.add('usa-input--error');
+    element.dataset.softValid = false;
+    element.setCustomValidity(clone.validationMessage);
+    if (element.nextElementSibling.classList.contains('soft-valid-message')) {
+      element.nextElementSibling.remove();
+    }
+
+    const message = document.createElement('span');
+    message.classList.add('usa-error-message', 'soft-valid-message');
+    message.textContent = clone.validationMessage;
+    element.parentNode.insertBefore(message, element.nextElementSibling);
+
+    if (element.form?.querySelector('[data-soft-valid="false"]')) {
+      element.form.querySelector('[type="submit"]').disabled = true;
+    }
+  }
+
+  function validate(event) {
+    const element = event.currentTarget;
+    const attrs = Object.entries(element.dataset)
+      .filter(([name, data]) => {
+        return name.startsWith('soft');
+      })
+      .map(([name, data]) => {
+        return [name.replace('soft', '').toLowerCase(), data];
+      });
+
+    if (!attrs.length) return;
+
+    const clone = element.cloneNode(true);
+    attrs.forEach(([attr, data]) => {
+      clone.setAttribute(attr, data);
+    });
+    if (clone.checkValidity()) {
+      markValid(element);
+    } else {
+      markInvalid(element, clone);
+    }
+    clone.remove();
+  }
+
+  function listenForValidity(target) {
+    target.addEventListener('input', validate);
+    target.addEventListener('change', validate);
+  }
+
+  function addListeners() {
+    dom.querySelectorAll('[data-soft-valid]').forEach(listenForValidity);
+  }
+
+  root.addEventListener('load', addListeners);
+})(window, document);

--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -164,6 +164,10 @@ form#cts-forms-profile {
       background-color: color($theme-link-hover-color);
     }
 
+    &:disabled:hover {
+      background-color: #c9c9c9;
+    }
+
     @media (min-width: 30em) {
       margin-top: 0;
     }


### PR DESCRIPTION
## What does this change?

- 🌎 HTML supports field validation.
- ⛔ Right now, our site is configured to cut fields off / prevent entry if that validation is triggered. For the summary field specifically, there is _no_ validation until you click submit, where you're directed to an error message.
- ✅ This commit adds a "soft validation", which leverages that same HTML validation to add soft warnings when fields are at the limit. This supports the use-case of pasting a large value into a field, and then trimming it down to size.
- 🔮 Future commits could style this a bit fancier, and apply this to other fields, such as the DJ number.

## Screenshots (for front-end PR):

![validation](https://user-images.githubusercontent.com/15126660/235725289-5d6b4569-771b-4d00-ae4f-f762804489cc.gif)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
