### PR TITLE
Fix back to all stripping params

### DIFF
--- a/crt_portal/cts_forms/templatetags/back_to_all.py
+++ b/crt_portal/cts_forms/templatetags/back_to_all.py
@@ -14,6 +14,5 @@ def back_to_all(return_url_args=''):
         return return_url_args
     violation_summary = querydict.get('violation_summary', '')
     if violation_summary.startswith('^') and violation_summary.endswith('$'):
-        querydict.pop('violation_summary')
-        return_url_args = urllib.parse.urlencode(querydict).replace('%3F', '?')
+        return_url_args = parsed_args.replace('&violation_summary=' + violation_summary, '')
     return return_url_args


### PR DESCRIPTION
## What does this change?

Currently there is a bug with the back to all url builder logic on the individual report pages that strips duplicate parameters so if the user has selected "status=open" and "status=new" only one is retained. This PR updates the logic to retain all params including duplicates.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
