### PR TITLE
Prevent duplicate submission of forms.

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -98,6 +98,7 @@
 <script src="{% static 'js/restrict_field.min.js' %}"></script>
 <script src="{% static 'js/soft_validation.min.js' %}"></script>
 <script src="{% static 'js/paste_dj_field.min.js' %}"></script>
+<script src="{% static 'js/disable_submit_button.min.js' %}"></script>
 <script src="{% static 'js/print_report.min.js' %}"></script>
 <script src="{% static 'js/attachments.min.js' %}"></script>
 <script src="{% static 'js/show_count.min.js'%}"></script>

--- a/crt_portal/static/js/disable_submit_button.js
+++ b/crt_portal/static/js/disable_submit_button.js
@@ -1,13 +1,28 @@
+/** Used by public and internal-facing forms to prevent duplicate submission. */
 (function(root) {
-  document.getElementById('report-form').addEventListener('submit', disableSubmitButton);
-  function disableSubmitButton() {
-    const submitNextButton = document.getElementById('submit-next');
-    const submitNextTopButton = document.getElementById('submit-next-top');
-    const submitNextBottomButton = document.getElementById('submit-next-bottom');
-    const submitButton = document.getElementById('submit');
-    if (submitNextButton) submitNextButton.disabled = true;
-    if (submitNextTopButton) submitNextTopButton.disabled = true;
-    if (submitNextBottomButton) submitNextBottomButton.disabled = true;
-    if (submitButton) submitButton.disabled = true;
+  function disableButtons(form) {
+    // Use setTimeout to detach from the submission thread, ensuring the form is
+    // submitted before we disable the buttons.
+    const submitButtons = form.querySelectorAll('[type="submit"]');
+    setTimeout(() => {
+      submitButtons.forEach(button => {
+        button.disabled = true;
+      });
+    }, 0);
   }
+
+  root.addEventListener('load', () => {
+    Array.from(document.forms).forEach(form => {
+      form.addEventListener('submit', event => {
+        if (form.classList.contains('is-submitting')) {
+          console.warn('Preventing duplicate submission');
+          event.preventDefault();
+          return false;
+        }
+        form.classList.add('is-submitting');
+        disableButtons(form);
+        return true;
+      });
+    });
+  });
 })(window);


### PR DESCRIPTION
## What does this change?

- 🌎 Our site is controlled mostly by django forms.
- ⛔ There have been a few instances of forms being submitted twice accidentally - these all seem to be because users accidentally click submit multiple times.
- ✅ This commit updates our duplicate prevention script to:
  - Apply to all forms on the site
  - Prevent duplicate form submission explicitly
  - Disable submit buttons to indicate that the form can't be resubmitted

Note that the previous way of disabling the buttons only worked if the submit button didn't have a value; when the button is disabled, its value isn't included in the submit. This approach ensures the form is submitted by running the disable on another thread.

## Screenshots (for front-end PR):

![submit-form](https://user-images.githubusercontent.com/15126660/235940195-38a1f25e-57b0-443f-8531-7027da6bb1e5.gif)

Note that, on each step, the buttons are disabled after click:

![report](https://user-images.githubusercontent.com/15126660/235940214-afb7f3cb-e98b-4629-8317-1ed2d9faeef3.gif)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
