### PR TITLE
Fix cachebusting on Localstack

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -499,7 +499,7 @@ ENABLE_LOCAL_ATTACHMENT_STORAGE = False
 if USE_LOCALSTACK == 'True':
     from .localstack_settings import *  # noqa: F401,F403
 elif environment == 'LOCAL':
-    ENABLE_LOCAL_ATTACHMENT_STORAGE = False
+    ENABLE_LOCAL_ATTACHMENT_STORAGE = True
 
 if environment == 'LOCAL':
     from .local_settings import *  # noqa: F401,F403

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -496,12 +496,10 @@ AV_SCAN_URL = os.getenv('AV_SCAN_URL')
 AV_SCAN_MAX_ATTEMPTS = 10
 
 ENABLE_LOCAL_ATTACHMENT_STORAGE = False
-USE_STATIC_CACHEBUSTER = True
 if USE_LOCALSTACK == 'True':
     from .localstack_settings import *  # noqa: F401,F403
 elif environment == 'LOCAL':
     ENABLE_LOCAL_ATTACHMENT_STORAGE = False
-    USE_STATIC_CACHEBUSTER = False
 
 if environment == 'LOCAL':
     from .local_settings import *  # noqa: F401,F403

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -496,10 +496,12 @@ AV_SCAN_URL = os.getenv('AV_SCAN_URL')
 AV_SCAN_MAX_ATTEMPTS = 10
 
 ENABLE_LOCAL_ATTACHMENT_STORAGE = False
+USE_STATIC_CACHEBUSTER = True
 if USE_LOCALSTACK == 'True':
     from .localstack_settings import *  # noqa: F401,F403
 elif environment == 'LOCAL':
-    ENABLE_LOCAL_ATTACHMENT_STORAGE = True
+    ENABLE_LOCAL_ATTACHMENT_STORAGE = False
+    USE_STATIC_CACHEBUSTER = False
 
 if environment == 'LOCAL':
     from .local_settings import *  # noqa: F401,F403

--- a/crt_portal/cts_forms/templatetags/static_refresh.py
+++ b/crt_portal/cts_forms/templatetags/static_refresh.py
@@ -1,6 +1,7 @@
 import os
 
 from django import template
+from django.conf import settings
 from django.templatetags.static import StaticNode
 
 register = template.Library()
@@ -13,6 +14,8 @@ class TimestampedStaticNode(StaticNode):
 
     def url(self, *args, **kwargs):
         url = super().url(*args, **kwargs)
+        if settings.USE_STATIC_CACHEBUSTER:
+            return url
         return f'{url}?v={self.timestamp}'
 
 


### PR DESCRIPTION
Thanks @kewitham for calling this out.

## What does this change?

- 🌎 Our new cachebusting uses query params to defeat the cache while still serving the same file.  The previous version of this code assumed that no query parameters were added to static URLs.
- ⛔ Localstack adds a bunch of params, which causes the url to be malformed.
- ✅ This commit joins params instead of adding a new one, so the URL
  is: /asset.js?foo=bar&v=1235 instead of /assets.js?foo=bar?v=1235

## Screenshots (for front-end PR):

<img width="655" alt="image" src="https://user-images.githubusercontent.com/15126660/236042774-b5e95983-3081-491b-af47-c636ca1ac27c.png">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
