### PR TITLE
Add a district number filter

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -47,6 +47,7 @@ filter_options = {
     'modified_date_end': '__lte',  # not in filter controls?
 
     'primary_statute': '__in',  # aka "Classification"
+    'district': '__in',
     'primary_complaint': '__in',  # aka "Primary issue"
     'dj_number': 'dj_number',
     'reported_reason': 'reported_reason',

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1130,6 +1130,16 @@ class Filters(ModelForm):
             'name': 'location_state',
         }),
     )
+    district = ChoiceField(
+        required=False,
+        label=_("District number"),
+        choices=add_empty_choice(DISTRICT_CHOICES),
+        widget=Select(attrs={
+            'name': 'district',
+            'class': 'usa-select',
+            'aria-label': 'District Number'
+        })
+    )
     primary_statute = ChoiceField(
         required=False,
         label=_("Primary classification"),  # This is overridden in templates to the shorter "Classification"
@@ -1296,6 +1306,7 @@ class Filters(ModelForm):
             'assigned_to',
             'public_id',
             'primary_statute',
+            'district',
             'violation_summary',
             'primary_complaint',
             'contact_phone',

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -23,6 +23,7 @@
       {% include 'forms/complaint_view/index/filters/contact_email.html' %}
       {% include 'forms/complaint_view/index/filters/contact_phone_number_filter.html' %} <!-- CRT summary -->
       {% include 'forms/complaint_view/index/filters/date.html' %}
+      {% include 'forms/complaint_view/index/filters/district_number_filter.html' %}
       {% include 'forms/complaint_view/index/filters/primary_statute_filter.html' %} <!-- Classification -->
       {% include 'forms/complaint_view/index/filters/primary_issue.html' %}
       {% include 'forms/complaint_view/index/filters/reported_reason.html' %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/district_number_filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/district_number_filter.html
@@ -1,0 +1,11 @@
+{% extends "forms/complaint_view/index/filter.html" %}
+
+{% block controls %}district{% endblock %}
+{% block label %}District Number{% endblock %}
+{% block id %}district{% endblock %}
+
+{% block content %}
+  <div id="district-filter">
+    {{ form.district }}
+  </div>
+{% endblock %}

--- a/crt_portal/cts_forms/templatetags/get_field_label.py
+++ b/crt_portal/cts_forms/templatetags/get_field_label.py
@@ -16,6 +16,7 @@ variable_rename = {
     'origination_utm_campaign': 'Campaign',
     'public_id': 'Complaint ID',
     'primary_statute': 'Classification',
+    'district': 'District number',
     'violation_summary': 'Personal description',
     'primary_complaint': 'Primary issue',
     'servicemember': 'Servicemember',

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -140,6 +140,7 @@
     dj_number: '',
     public_id: '',
     primary_statute: '',
+    district: '',
     reported_reason: [],
     commercial_or_public_place: [],
     intake_format: [],
@@ -405,6 +406,7 @@
     var djNumberEl = formEl.querySelectorAll('.crt-dj-number input');
     var complaintIDEl = formEl.querySelector('input[name="public_id"]');
     var statuteEl = formEl.querySelector('select[name="primary_statute"]');
+    var districtEl = formEl.querySelector('select[name="district"]');
     var perPageEl = dom.getElementsByName('per_page');
     var groupingEl = dom.querySelector('select[name="grouping"]');
     var personalDescriptionEl = formEl.querySelector('textarea[name="violation_summary"]');
@@ -532,6 +534,10 @@
     textInputView({
       el: statuteEl,
       name: 'primary_statute'
+    });
+    textInputView({
+      el: districtEl,
+      name: 'district'
     });
     textInputsView({
       el: perPageEl,


### PR DESCRIPTION
## What does this change?

- 🌎 Users can't filter by district number.
- ⛔ They want to - and we have district number on the report
- ✅ This commit adds a district number filter to the report page.

## Screenshots (for front-end PR):

![demo](https://github.com/usdoj-crt/crt-portal/assets/15126660/a98c5852-3ad0-447d-9fa6-e77c39046165)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
