### PR TITLE
Response template link issue fix

### DIFF
--- a/crt_portal/cts_forms/response_templates/hce_form_letter_ko.md
+++ b/crt_portal/cts_forms/response_templates/hce_form_letter_ko.md
@@ -24,7 +24,7 @@ HUD는 주거 차별에 대한 개별 클레임을 조사합니다. 여기에는
 
 또한 여성폭력방지법(VAWA)에 따른 주거권이 침해되었다고 판단되는 경우 HUD에 민원을 제기하실 수 있습니다. HUD는https://www.hud.gov/program_offices/fair_housing_equal_opp/VAWA에서 VAWA의 주택 보호에 대한 정보를 제공했습니다.
 
-[www.hud.gov/program_offices/fair_‌housing_‌equal_‌‌opp/online-complaint](http://www.hud.gov/program_offices/fair_‌housing_‌equal_opp/online-complaint)를 통해 온라인으로 또는1-800-669-9777에 전화로, 또는 1-800-877-8339에 문자전화로 민원을 제기하실 수 있습니다.  
+[www.hud.gov/program_offices/fair_‌housing_‌equal_‌‌opp/online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint)를 통해 온라인으로 또는1-800-669-9777에 전화로, 또는 1-800-877-8339에 문자전화로 민원을 제기하실 수 있습니다.  
 
 차별 또는 위반 발생일로부터 1년 내에 HUD에 신고 하지 않으면 HUD는 귀하의 제보를 검토하지 않을 것입니다.
 
@@ -34,7 +34,7 @@ CFPB는 [www.consumerfinance.gov/coronavirus/mortgage-and-housing-assistance/‌
 
 **대출 또는 신용에서 차별을 경험하는 경우:**
 
-HUD에 [www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint) 로 또는 CFPB에 [www.consumerfinance.gov/complaint](http://www.consumerfinance.gov/complaint/)로 민원을 제기할 수 있습니다.
+HUD에 [www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint) 로 또는 CFPB에 [www.consumerfinance.gov/complaint](http://www.consumerfinance.gov/complaint/)로 민원을 제기할 수 있습니다.
 
 **변호사를 고용하고 싶다면:**
 

--- a/crt_portal/cts_forms/response_templates/hce_form_letter_vi.md
+++ b/crt_portal/cts_forms/response_templates/hce_form_letter_vi.md
@@ -24,7 +24,7 @@ HUD điều tra những khiếu nại của cá nhân về phân biệt đ
 
 Quý vị cũng có thể nộp đơn khiếu nại lên HUD nếu tin rằng những quyền lợi về nhà ở của mình chiếu theo Đạo Luật Chống Bạo Hành Phụ Nữ (Violence Against Women Act, VAWA) đã bị vi phạm. HUD cung cấp thông tin về sự bảo vệ về nhà ở của VAWA tại trang mạng [https://www.hud.gov/program_offices/fair_housing_equal_opp/VAWA](https://www.hud.gov/program_offices/fair_housing_equal_opp/VAWA).
 
-Quý vị có thể nộp thư khiếu nại trực tuyến lên HUD tại trang mạng [www.hud.gov/program_offices/fair_‌housing_‌equal_‌‌opp/online-complaint](http://www.hud.gov/program_offices/fair_‌housing_‌equal_opp/online-complaint), hoặc gọi 1-800-669-9777 hay TTY: 1-800-877-8339.
+Quý vị có thể nộp thư khiếu nại trực tuyến lên HUD tại trang mạng [www.hud.gov/program_offices/fair_‌housing_‌equal_‌‌opp/online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint), hoặc gọi 1-800-669-9777 hay TTY: 1-800-877-8339.
 
 Quý vị có được một năm, tính từ ngày quý vị gặp phải nạn phân biệt đối xử, để nộp đơn khiếu nại lên HUD, nếu không, họ sẽ không duyệt xét thư khiếu nại của quý vị.
 
@@ -34,7 +34,7 @@ CFPB có thể giúp quý vị tìm thấy những nguồn hỗ trợ 
 
 **Nếu quý vị bị phân biệt đối xử trong việc vay tiền hay vấn đề tín dụng:**
 
-Quý vị có thể gửi đơn khiếu nại lên HUD tại trang mạng [www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint) và khiếu nại lên CFPB tại trang mạng [www.consumerfinance.gov/complaint](http://www.consumerfinance.gov/complaint/).
+Quý vị có thể gửi đơn khiếu nại lên HUD tại trang mạng [www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint) và khiếu nại lên CFPB tại trang mạng [www.consumerfinance.gov/complaint](http://www.consumerfinance.gov/complaint/).
 
 **Nếu quý vị muốn thuê luật sư:**
 

--- a/crt_portal/cts_forms/response_templates/hce_form_letter_vi.md
+++ b/crt_portal/cts_forms/response_templates/hce_form_letter_vi.md
@@ -24,7 +24,7 @@ HUD điều tra những khiếu nại của cá nhân về phân biệt đ
 
 Quý vị cũng có thể nộp đơn khiếu nại lên HUD nếu tin rằng những quyền lợi về nhà ở của mình chiếu theo Đạo Luật Chống Bạo Hành Phụ Nữ (Violence Against Women Act, VAWA) đã bị vi phạm. HUD cung cấp thông tin về sự bảo vệ về nhà ở của VAWA tại trang mạng [https://www.hud.gov/program_offices/fair_housing_equal_opp/VAWA](https://www.hud.gov/program_offices/fair_housing_equal_opp/VAWA).
 
-Quý vị có thể nộp thư khiếu nại trực tuyến lên HUD tại trang mạng [www.hud.gov/program_offices/fair_‌housing_‌equal_‌‌opp/online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint), hoặc gọi 1-800-669-9777 hay TTY: 1-800-877-8339.
+Quý vị có thể nộp thư khiếu nại trực tuyến lên HUD tại trang mạng [www.hud.gov/program_offices/fair_‌housing_‌equal_‌‌opp/online-complaint](https://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint), hoặc gọi 1-800-669-9777 hay TTY: 1-800-877-8339.
 
 Quý vị có được một năm, tính từ ngày quý vị gặp phải nạn phân biệt đối xử, để nộp đơn khiếu nại lên HUD, nếu không, họ sẽ không duyệt xét thư khiếu nại của quý vị.
 
@@ -34,7 +34,7 @@ CFPB có thể giúp quý vị tìm thấy những nguồn hỗ trợ 
 
 **Nếu quý vị bị phân biệt đối xử trong việc vay tiền hay vấn đề tín dụng:**
 
-Quý vị có thể gửi đơn khiếu nại lên HUD tại trang mạng [www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint) và khiếu nại lên CFPB tại trang mạng [www.consumerfinance.gov/complaint](http://www.consumerfinance.gov/complaint/).
+Quý vị có thể gửi đơn khiếu nại lên HUD tại trang mạng [www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint](https://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint) và khiếu nại lên CFPB tại trang mạng [www.consumerfinance.gov/complaint](http://www.consumerfinance.gov/complaint/).
 
 **Nếu quý vị muốn thuê luật sư:**
 

--- a/crt_portal/cts_forms/response_templates/hce_form_letter_zh-hans.md
+++ b/crt_portal/cts_forms/response_templates/hce_form_letter_zh-hans.md
@@ -38,9 +38,9 @@ is_html: true
 
 如果您想聘请律师：
 
-您可能希望与私人律师磋商看您是否享有其他联邦和州法律下的任何权利，如果您没有律师，您所在州的律师协会或当地法律援助机构或许可以为您提供援助，您可以从 www.americanbar.org/groups/legal_services/flh-home 或 www.lsc.gov/find-legal-aid寻找当地律师。
+您可能希望与私人律师磋商看您是否享有其他联邦和州法律下的任何权利，如果您没有律师，您所在州的律师协会或当地法律援助机构或许可以为您提供援助，您可以从 www.americanbar.org/groups/legal_services/flh-home 或 www.lsc.gov/find-legal-aid 寻找当地律师。
 
-有关信贷、残疾权利和住房权利的更多信息，请访问我们的住房资源页面https://civilrights.justice.gov/housing-resources。
+有关信贷、残疾权利和住房权利的更多信息，请访问我们的住房资源页面https://civilrights.justice.gov/housing-resources 。
 
 
 此致

--- a/crt_portal/cts_forms/response_templates/hce_form_letter_zh-hant.md
+++ b/crt_portal/cts_forms/response_templates/hce_form_letter_zh-hant.md
@@ -24,7 +24,7 @@ is_html: true
 
 如果您認為您在《暴力侵害婦女法》下應享有的住房權利受到侵犯，您也可以向房屋和城市發展部投訴。房屋和城市發展部在網上提供了有關《暴力侵害婦女法》住房保護的信息[https://www.hud.gov/program_offices/fair_housing_equal_opp/VAWA](https://www.hud.gov/program_offices/fair_housing_equal_opp/VAWA)。
 
-您可以在網上 [www.hud.gov/program_offices/fair_‌housing_‌equal_‌‌opp/online-complaint](http://www.hud.gov/program_offices/fair_‌housing_‌equal_opp/online-complaint) 或致電 1-800-669-9777 或 電傳打字1-800-877-8339向房屋和城市發展部投訴。
+您可以在網上 [www.hud.gov/program_offices/fair_‌housing_‌equal_‌‌opp/online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint) 或致電 1-800-669-9777 或 電傳打字1-800-877-8339向房屋和城市發展部投訴。
 
 您有一年時間從受到歧視或違規之日起向房屋和城市發展部提出投訴，否則他們不會受理您的投訴。
 
@@ -34,7 +34,7 @@ is_html: true
 
 **如果您在貸款或信貸方面受到歧視：**
 
-您可以向房屋和城市發展部[www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint) 和消費者金融保護局[www.consumerfinance.gov/complaint](http://www.consumerfinance.gov/complaint/) 提出投訴。
+您可以向房屋和城市發展部[www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint) 和消費者金融保護局[www.consumerfinance.gov/complaint](http://www.consumerfinance.gov/complaint/) 提出投訴。
 
 **如果您想聘請律師：**
 

--- a/crt_portal/cts_forms/response_templates/hce_form_letter_zh-hant.md
+++ b/crt_portal/cts_forms/response_templates/hce_form_letter_zh-hant.md
@@ -24,7 +24,7 @@ is_html: true
 
 如果您認為您在《暴力侵害婦女法》下應享有的住房權利受到侵犯，您也可以向房屋和城市發展部投訴。房屋和城市發展部在網上提供了有關《暴力侵害婦女法》住房保護的信息[https://www.hud.gov/program_offices/fair_housing_equal_opp/VAWA](https://www.hud.gov/program_offices/fair_housing_equal_opp/VAWA)。
 
-您可以在網上 [www.hud.gov/program_offices/fair_‌housing_‌equal_‌‌opp/online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint) 或致電 1-800-669-9777 或 電傳打字1-800-877-8339向房屋和城市發展部投訴。
+您可以在網上 [www.hud.gov/program_offices/fair_‌housing_‌equal_‌‌opp/online-complaint](https://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint) 或致電 1-800-669-9777 或 電傳打字1-800-877-8339向房屋和城市發展部投訴。
 
 您有一年時間從受到歧視或違規之日起向房屋和城市發展部提出投訴，否則他們不會受理您的投訴。
 
@@ -34,7 +34,7 @@ is_html: true
 
 **如果您在貸款或信貸方面受到歧視：**
 
-您可以向房屋和城市發展部[www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint](http://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint) 和消費者金融保護局[www.consumerfinance.gov/complaint](http://www.consumerfinance.gov/complaint/) 提出投訴。
+您可以向房屋和城市發展部[www.hud.gov/program_offices/fair_housing_equal_opp/‌online-complaint](https://www.hud.gov/program_offices/fair_housing_equal_opp/online-complaint) 和消費者金融保護局[www.consumerfinance.gov/complaint](http://www.consumerfinance.gov/complaint/) 提出投訴。
 
 **如果您想聘請律師：**
 

--- a/crt_portal/static/js/response_template_preview.js
+++ b/crt_portal/static/js/response_template_preview.js
@@ -35,8 +35,9 @@
     const htmlDoc = parser.parseFromString(pastedHtml, 'text/html');
     const aTags = Array.from(htmlDoc.getElementsByTagName('a'));
     aTags.forEach(aTag => {
-      const newhref = aTag['href'].replaceAll('_', '(UNDERSCORE)');
-      pastedHtml = pastedHtml.replaceAll(aTag['href'], newhref);
+      const newHref = aTag['href'].replaceAll('_', '(UNDERSCORE)');
+      const newLinkText = aTag.innerText.replaceAll('_', '(UNDERSCORE)');
+      pastedHtml = pastedHtml.replaceAll(aTag['href'], newHref).replaceAll(aTag.innerText, newLinkText);
     });
     const markdown = turndown.turndown(pastedHtml);
     // Word sometimes includes comments in its HTML, so strip them:

--- a/crt_portal/static/js/response_template_preview.js
+++ b/crt_portal/static/js/response_template_preview.js
@@ -37,7 +37,9 @@
     aTags.forEach(aTag => {
       const newHref = aTag['href'].replaceAll('_', '(UNDERSCORE)');
       const newLinkText = aTag.innerText.replaceAll('_', '(UNDERSCORE)');
-      pastedHtml = pastedHtml.replaceAll(aTag['href'], newHref).replaceAll(aTag.innerText, newLinkText);
+      pastedHtml = pastedHtml
+        .replaceAll(aTag['href'], newHref)
+        .replaceAll(aTag.innerText, newLinkText);
     });
     const markdown = turndown.turndown(pastedHtml);
     // Word sometimes includes comments in its HTML, so strip them:


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

This PR updates the backslashes and underscores in response template links to unbreak them and adds logic to identify and replace underscores in link text.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
