### PR TITLE
Add a script to unlock stalled deployments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,8 @@ We are using the defaults, so you can press enter for all the set up options. Yo
 ### Deployment for each environment
 * The app will deploy to **dev** when the tests pass and a PR is merged into `develop`. You should do this in GitHub.
 
+NOTE: If this deployment fails, you'll need to unlock the deployment and either merge again or re-run the build-test-deploy workflow in CircleCI. Run `./unlock_deployment.sh --help` for details.
+
 * The app will deploy to **stage** when the tests pass and when we make or update a branch that starts with `release/`.
     * Make sure the develop branch is approved for deploy by the product owner
     * Look at ZenHub and see if there is anything in "Dev done" flag that for approval so those issues are in "Ready for UAT" when you make the release

--- a/unlock_deployment.sh
+++ b/unlock_deployment.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+circleci_url='https://app.circleci.com/pipelines/github/usdoj-crt/crt-portal?branch=develop'
+
+read -r -d '' usage <<EOF
+Unlocks CircleCI when deployments are stuck because of a failed deployment.
+
+Once unlocked, deployments will need to be restarted by merging a new branch into develop or by re-running the stalled build-and-test from CircleCI at:
+
+$circleci_url
+
+Make sure to log in (by running 'cf login --sso') prior to running this script
+
+Note: This script will change the current 'cf target' to dev.
+
+Usage:
+
+  $0
+
+EOF
+
+if [ "$#" -gt 0 ]; then
+  echo "$usage"
+  exit 1
+fi
+
+echo "Making sure we're in dev: "
+echo ""
+cf target -o 'doj-crtportal' -s 'dev'
+if [ $? -ne 0 ]; then
+  echo 'Failed to change cf target to dev.'
+  echo ''
+  echo "Please make sure you're logged in to cloud.gov"
+  exit 1
+fi
+
+. env-helpers.sh crt-portal-django
+
+next="$(cf_get_env CCI_NEXT_TICKET)"
+serving="$(cf_get_env CCI_SERVING_TICKET)"
+
+# If next or serving are unset, we're in a bad state.
+if [ -z "$next" ] || [ -z "$serving" ]; then
+  echo 'One or both of the deployment variables are unset.'
+  echo ''
+  echo "Please make sure you're logged in to cloud.gov"
+  exit 1
+fi
+
+cat <<EOF
+
+================================================================================
+⚠️ WARNING:
+
+This will skip any pending deployments. They will need to be cancelled and re-run.
+
+If you're not sure that you want to do this, please exit now.
+
+The current serving ticket is: $serving
+The current pending ticket is: $next
+
+This will set the serving ticket to: $next
+================================================================================
+
+EOF
+
+read -p 'Reset the deployment variables [y/N]? '
+if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
+  echo 'Okay - canceled!'
+  exit 1
+fi
+
+cf set-env crt-portal-django CCI_SERVING_TICKET "$next" 1>/dev/null
+if [ $? -ne 0 ]; then
+  echo 'Failed to set CCI_SERVING_TICKET.'
+  exit 1
+fi
+
+new_next="$(cf_get_env CCI_NEXT_TICKET)"
+new_serving="$(cf_get_env CCI_SERVING_TICKET)"
+cat <<EOF
+
+================================================================================
+🔓 Unlocked!
+
+The new serving ticket is: $new_serving
+The new pending ticket is: $new_next
+
+You may now retry the failed / locked deployment. To do this, find the stalled workflow in Circle CI and choose "Rerun" -> "Rerun workflow from start"
+
+$circleci_url
+================================================================================
+
+EOF
+


### PR DESCRIPTION
## What does this change?

- 🌎 When deployments fail, our env variables get stuck, and future deployments can't continue.
- ⛔ To unlock this right now, we need to manually set env variables (and remember what to set them to)
- ✅ This commit aims to reduce human error in doing so by adding a unlock_deployment script.

## Screenshots (for front-end PR):

n/a

## Checklist:

- [ ] Run `./unlock_deployment.sh --help`, and follow the instructions.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

Note: I've tested this as much as I can without actually having a failed deployment to play with 😅 - we'll be able to truly verify the process with the next stalled deployment.

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
