### PR TITLE
Response letter var bug

### DIFF
--- a/crt_portal/static/js/response_template_preview.js
+++ b/crt_portal/static/js/response_template_preview.js
@@ -41,6 +41,9 @@
         .replaceAll(aTag['href'], newHref)
         .replaceAll(aTag.innerText, newLinkText);
     });
+    pastedHtml = pastedHtml
+      .replaceAll('date_of_intake', 'date(UNDERSCORE)of(UNDERSCORE)intake')
+      .replaceAll('record_locator', 'record(UNDERSCORE)locator');
     const markdown = turndown.turndown(pastedHtml);
     // Word sometimes includes comments in its HTML, so strip them:
     const sanitized = markdown.replace(/<!--(?!>)[\S\s]*?-->/g, '').replaceAll('(UNDERSCORE)', '_');


### PR DESCRIPTION
[Issue 1536](https://github.com/usdoj-crt/crt-portal-management/issues/1536)

## What does this change?

This PR fixes a bug where underscores in variables are escaped with a backslash when they are pasted into the admin page.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
