### PR TITLE
Add tabs and filters for new team management view

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -17,7 +17,7 @@ from django.conf import settings
 
 from features.models import Feature
 
-from .model_variables import (COMMERCIAL_OR_PUBLIC_ERROR,
+from .model_variables import (ACTION_CHOICES, COMMERCIAL_OR_PUBLIC_ERROR,
                               COMMERCIAL_OR_PUBLIC_PLACE_CHOICES,
                               COMMERCIAL_OR_PUBLIC_PLACE_HELP_TEXT,
                               CONTACT_PHONE_INVALID_MESSAGE,
@@ -1114,7 +1114,14 @@ class Filters(ModelForm):
                 'class': 'usa-input usa-select',
             })
         )
-
+    actions = MultipleChoiceField(
+        required=False,
+        label='Action taken',
+        choices=ACTION_CHOICES,
+        widget=UsaCheckboxSelectMultiple(attrs={
+            'name': 'actions',
+        }),
+    )
     status = MultipleChoiceField(
         initial=(('new', 'New'), ('open', 'Open')),
         required=False,

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -668,6 +668,19 @@ CONTACT_PHONE_INVALID_MESSAGE = _('If you submit a phone number, please make sur
 
 DJ_NUMBER_INVALID_MESSAGE = 'Please double check the DJ Number. It should consist of a classification and Judicial district, separated by "-".'
 
+ACTION_CHOICES = (
+    ('Attached file:', 'Attached file'),
+    ('Contacted complainant:', 'Contacted complainant'),
+    ('Report viewed:', 'Report viewed'),
+    ('Assigned section:', 'Assigned section'),
+    ('Added comment:', 'Added comment'),
+    ('ICM DJ Number:', 'ICM DJ Number'),
+    ('Secondary review:', 'Secondary review'),
+    ('Contact state:', 'Contact state'),
+    ('District:', 'District'),
+    ('Added summary:', 'Added summary'),
+)
+
 PRINT_CHOICES = (
     ('correspondent', 'Correspondent Information'),
     ('issue', 'Reported Issue'),

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-filter-controls.html
@@ -1,13 +1,15 @@
 <form
   id="filters-form"
   method="GET"
-  action="/form/dashboard"
+  action="/form/dashboard/activity"
   novalidate
 >
   <div class="usa-form">
     <div class="intake-filters">
       {% include 'forms/complaint_view/dashboard/filters/assignee.html' %}
       {% include 'forms/complaint_view/index/filters/date.html' %}
+      {% include 'forms/complaint_view/dashboard/filters/action.html' %}
+      {% include 'forms/complaint_view/index/filters/public_id_filter.html' %}
     </div>
 
     <div class="text-right">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log-header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log-header.html
@@ -1,0 +1,5 @@
+<header class="dashboard-header">
+    <div class="title">
+      {% include 'forms/complaint_view/dashboard/dashboard_header_title.html' with page='activity-log' %}
+    </div>
+  </header>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
@@ -4,6 +4,7 @@
 {% include 'forms/complaint_view/dashboard/header.html' %}
 {% endblock %}
 {% block content %}
+{% include 'forms/complaint_view/dashboard/team-management-header.html' %}
 {% include 'forms/complaint_view/dashboard/activity-log-header.html' %}
 <div class="intake-content">
   <div id="status-update" class="grid-col-auto">
@@ -16,7 +17,7 @@
   <div class="grid-col-auto">
     <div class="intake-table">
       <div class="intake-table-header">
-        <h2 class="intake-section-title">Activity log</h2>
+        <h3 class="intake-section-title">Activity log</h3>
       </div>
       {% include "forms/complaint_view/dashboard/activity_table.html" with page_format=page_format sort_state=sort_state filter_state=filter_state %}
     </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
@@ -3,26 +3,24 @@
 {% block page_header %}
 {% include 'forms/complaint_view/dashboard/header.html' %}
 {% endblock %}
-
 {% block content %}
-{% include 'forms/complaint_view/dashboard/reports-touched-header.html' %}
+{% include 'forms/complaint_view/dashboard/activity-log-header.html' %}
 <div class="intake-content">
   <div id="status-update" class="grid-col-auto">
     {% include 'partials/messages.html' %}
   </div>
-  {% include "forms/complaint_view/dashboard/filter-controls.html" with filters=filters form=form %}
+  {% include "forms/complaint_view/dashboard/activity-filter-controls.html" with filters=filters form=form %}
   <div class="display-flex margin-top-8">
     {% include "forms/complaint_view/dashboard/active-filters.html" %}
   </div>
   <div class="grid-col-auto">
     <div class="intake-table">
       <div class="intake-table-header">
-        <h2 class="intake-section-title">Reports touched</h2>
+        <h2 class="intake-section-title">Activity log</h2>
       </div>
-      {% include "forms/complaint_view/dashboard/complaints_table.html" with page_format=page_format sort_state=sort_state filter_state=filter_state %}
+      {% include "forms/complaint_view/dashboard/activity_table.html" with page_format=page_format sort_state=sort_state filter_state=filter_state %}
     </div>
   </div>
-  {% include "forms/complaint_view/dashboard/analytics.html" with embeds=embeds %}
 </div>
 {% endblock %}
 {% block page_js %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity_table.html
@@ -1,0 +1,51 @@
+{% load sortable_table_heading %}
+<form class="usa-form"
+      method="get"
+      action="{% url 'crt_forms:crt-forms-actions' %}"
+      novalidate
+>
+  <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
+
+  <div>
+    {% if selected_actor %}
+    <table class="usa-table crt-table dashboard-table">
+      <thead>
+        <tr>
+          {% render_sortable_heading 'Timestamp' sort_state filter_state %}
+          {% render_sortable_heading 'User' sort_state filter_state %}
+          {% render_sortable_heading 'Action' sort_state filter_state nowrap=True %}
+          {% render_sortable_heading 'Detail' sort_state filter_state nowrap=True %}
+          {% render_sortable_heading 'Complaint ID' sort_state filter_state %}
+        </tr>
+      </thead>
+      {% if data %}
+        <tbody>
+          {% for datum in data %}
+            <tr class="tr-status-{{ datum.report.status }} tr--hover{% cycle ' stripe' '' %}">
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.timestamp }}</a></td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ selected_actor }}</a></td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.action }}</a></td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.detail }}</a></td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.reportid }}</a></td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      {% endif %}
+    </table>
+    {% endif %}
+  </div>
+</form>
+
+{% if not selected_actor %}
+  <div class="crt-portal-card table-message">
+    <div class="crt-portal-card__content">
+      <div class="grid-container padding-bottom-2">
+        <div class="align-center">
+          <img alt="filter icon" src="{% static 'img/filters.svg' %}" class="margin-top-1" />
+          <p class="margin-bottom-1 margin-top-1" role="status"><b>Select intake specialist</b></p>
+          <em>Please select an intake specialist to see activity log data</em>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/analytics.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/analytics.html
@@ -1,5 +1,5 @@
 {% if embeds %}
-<h2 style="margin-top: 2em" class="intake-section-title">Analytics</h2>
+<h3 style="margin-top: 2em" class="intake-section-title">Analytics</h3>
 <div class="margin-bottom-2">Take a high-level look at report data.</div>
 
 {% for embed in embeds %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/dashboard_header_title.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/dashboard_header_title.html
@@ -1,0 +1,14 @@
+<div class="title">
+    <ul class="usa-nav__primary usa-accordion">
+      <li class="usa-nav__primary-item">
+        <a class="text-semibold text-base-dark crt-landing--menu_link reporting-header {% if page == 'team-management' %} selected {% endif %}" href="/form/dashboard">
+          Reports touched
+        </a>
+      </li>
+      <li class="usa-nav__primary-item">
+        <a class="text-semibold text-base-dark crt-landing--menu_link reporting-header {% if page == 'activity-log' %} selected {% endif %}" href="/form/dashboard/activity">
+          Activity log
+        </a>
+      </li>
+    </ul>
+  </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filters/action.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filters/action.html
@@ -1,0 +1,12 @@
+{% extends "forms/complaint_view/index/filter.html" %}
+
+{% block classes %}actions{% endblock %}
+{% block controls %}actions{% endblock %}
+{% block label %}{{ form.actions.label }}{% endblock %}
+{% block id %}actions{% endblock %}
+
+{% block content %}
+  <div id="actions-filter" class="multicheckboxes-container">
+    {{ form.actions }}
+  </div>
+{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/index.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block content %}
+{% include 'forms/complaint_view/dashboard/team-management-header.html' %}
 {% include 'forms/complaint_view/dashboard/reports-touched-header.html' %}
 <div class="intake-content">
   <div id="status-update" class="grid-col-auto">
@@ -17,7 +18,7 @@
   <div class="grid-col-auto">
     <div class="intake-table">
       <div class="intake-table-header">
-        <h2 class="intake-section-title">Reports touched</h2>
+        <h3 class="intake-section-title">Reports touched</h3>
       </div>
       {% include "forms/complaint_view/dashboard/complaints_table.html" with page_format=page_format sort_state=sort_state filter_state=filter_state %}
     </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/reports-touched-header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/reports-touched-header.html
@@ -1,0 +1,6 @@
+<header class="dashboard-header">
+    <div class="title">
+      {% include 'forms/complaint_view/dashboard/dashboard_header_title.html' with page='team-management' %}
+    </div>
+  </header>
+  

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/team-management-header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/team-management-header.html
@@ -1,0 +1,4 @@
+<div class="margin-left-4 padding-left-2">
+    <h2 class="intake-section-title padding-bottom-2">Team Management</h2>
+    <div class="margin-bottom-2">Review the activity log of intake specialists, including reports touched and actions taken.</div>
+</div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -1,4 +1,4 @@
-<h2 class="intake-section-title margin-bottom-105">Report Records</h2>
+<h2 class="intake-section-title margin-bottom-105 padding-bottom-2">Report Records</h2>
 <span>Find specific CRT Report Records by using the filter options below.</span>
 <form
   id="filters-form"

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -28,7 +28,7 @@
   <div class="grid-col-auto">
     <div class="intake-table">
       <div class="intake-table-header">
-        <h2 class="intake-section-title">Incoming records</h2>
+        <h3 class="intake-section-title">Incoming records</h3>
         <div class="margin-left-auto">
           {% include "forms/snippets/pagination.html" with page_format=page_format page_args=page_args placement="top" %}
         </div>

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import (ActionsView, index_view, dashboard_view, RoutingGuideView, ShowView, ProFormView,
+from .views import (ActionsView, index_view, dashboard_view, dashboard_activity_log_view, RoutingGuideView, ShowView, ProFormView,
                     SaveCommentView, TrendView, ResponseView, SearchHelperView,
                     PrintView, ProfileView, ReportAttachmentView, ReportDataView, DataExport, RemoveReportAttachmentView)
 from .forms import ProForm
@@ -26,5 +26,6 @@ urlpatterns = [
     path('attachment/report/<int:report_id>/', ReportAttachmentView.as_view(), name='save-report-attachment'),
     path('attachment/<int:attachment_id>/', RemoveReportAttachmentView.as_view(), name='remove-report-attachment'),
     path('trends/', TrendView.as_view(), name='trends'),
-    path('dashboard/', dashboard_view, name='dashboard')
+    path('dashboard/', dashboard_view, name='dashboard'),
+    path('dashboard/activity', dashboard_activity_log_view, name='activity-log')
 ]

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -436,6 +436,18 @@ def process_intake_filters(request):
     }
 
 
+def process_activity_filters(request):
+    selected_actor = request.GET.get("assigned_to", "")
+    selected_actor_object = User.objects.filter(username=selected_actor).first()
+    selected_actor_id = selected_actor_object.pk if selected_actor_object else ''
+
+    return {
+        'form': Filters(request.GET),
+        'selected_actor': selected_actor,
+        'selected_actor_id': selected_actor_id,
+    }
+
+
 @login_required
 def dashboard_view(request):
     embeds = [model_to_dict(e) for e in DashboardEmbed.objects.all()]
@@ -446,6 +458,17 @@ def dashboard_view(request):
         {
             **process_intake_filters(request),
             'embeds': embeds,
+        })
+
+
+@login_required
+def dashboard_activity_log_view(request):
+
+    return render(
+        request,
+        'forms/complaint_view/dashboard/activity-log.html',
+        {
+            **process_activity_filters(request),
         })
 
 

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -36,6 +36,12 @@
       }
     }
   }
+
+  .intake-table-header {
+    .intake-section-title {
+      font-size: 22px;
+    }
+  }
 }
 
 .intake-header {
@@ -792,7 +798,7 @@ form#cts-forms-profile {
   align-items: center;
   display: flex;
   border-radius: 5px 5px;
-  min-height: 5rem;
+  min-height: 3rem;
   padding-bottom: 1.2rem;
   padding-left: 1.3rem;
   padding-right: 2rem;

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -86,6 +86,7 @@
     font-weight: 500;
     &:hover {
       color: #fff;
+      background-color: transparent;
       border-bottom: 3px solid color('white');
     }
 
@@ -112,6 +113,40 @@
         background: color($theme-color-warning-light) !important;
       }
     }
+  }
+}
+
+.dashboard-header {
+  @include u-padding-x(4);
+  @include flex-container();
+  justify-content: space-between;
+  margin-bottom: 4rem;
+
+  .title {
+    @include flex-container();
+
+    .usa-nav__primary {
+      display: flex;
+      margin-top: 0;
+      .usa-nav__primary-item {
+        border-top: none;
+      }
+
+    }
+
+  }
+  .crt-landing--menu_link.reporting-header {
+    border: none;
+    margin: 0 1rem;
+    padding: 1rem 0;
+  }
+
+  .crt-landing--menu_link.reporting-header.selected {
+    border-bottom: 3px solid #005EA2;
+  }
+  .usa-nav__primary a:not(.usa-button):hover {
+    background-color: transparent;
+    border-bottom: 3px solid #005EA2;
   }
 }
 


### PR DESCRIPTION
[Issue 1558](https://github.com/usdoj-crt/crt-portal-management/issues/1558)

## What does this change?

This PR adds the tabs and filters for the new team management activity view. Filtering functionality and results will be added in another PR.

Navigate to /form/dashboard to see the tabbing functionality at the top of the page.
Click on the Activity log tab to see the new page.
Click on the filters to see the options.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
