### PR TITLE
Team management pagination and sorting

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -1,5 +1,6 @@
 # Class to handle filtering Reports by supplied query params,
 # provided they are valid filterable model properties.
+import logging
 import re
 import urllib.parse
 from datetime import datetime
@@ -23,7 +24,7 @@ foreign_key_displays = {
 # To add a new filter option for Reports, add the field name and expected filter behavior
 # These filters should match the order they're presented in filter-controls.html
 filter_options = {
-    'actions': '__icontains',
+    'actions': '__in',
     'assigned_section': '__in',
     'status': '__in',
     'contact_first_name': '__icontains',
@@ -213,7 +214,7 @@ def dashboard_filter(querydict):
             filters[field] = querydict.getlist(field)
             if field == 'actions':
                 field_name = 'verb'
-                kwargs[f'{field_name}__icontains'] = querydict.getlist(field)[0]
+                kwargs[f'{field_name}__in'] = querydict.getlist(field)
             if field == 'public_id':
                 field_name ='target_object_id'
                 kwargs[f'{field_name}__icontains'] = querydict.getlist(field)[0]

--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -23,6 +23,7 @@ foreign_key_displays = {
 # To add a new filter option for Reports, add the field name and expected filter behavior
 # These filters should match the order they're presented in filter-controls.html
 filter_options = {
+    'actions': '__icontains',
     'assigned_section': '__in',
     'status': '__in',
     'contact_first_name': '__icontains',
@@ -210,6 +211,12 @@ def dashboard_filter(querydict):
         filter_list = querydict.getlist(field)
         if len(filter_list) > 0:
             filters[field] = querydict.getlist(field)
+            if field == 'actions':
+                field_name = 'verb'
+                kwargs[f'{field_name}__icontains'] = querydict.getlist(field)[0]
+            if field == 'public_id':
+                field_name ='target_object_id'
+                kwargs[f'{field_name}__icontains'] = querydict.getlist(field)[0]
             if 'date' in field:
                 # filters by a start date or an end date expects yyyy-mm-dd
                 field_name = 'timestamp'

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -17,7 +17,7 @@ from django.conf import settings
 
 from features.models import Feature
 
-from .model_variables import (COMMERCIAL_OR_PUBLIC_ERROR,
+from .model_variables import (ACTION_CHOICES, COMMERCIAL_OR_PUBLIC_ERROR,
                               COMMERCIAL_OR_PUBLIC_PLACE_CHOICES,
                               COMMERCIAL_OR_PUBLIC_PLACE_HELP_TEXT,
                               CONTACT_PHONE_INVALID_MESSAGE,
@@ -1114,7 +1114,14 @@ class Filters(ModelForm):
                 'class': 'usa-input usa-select',
             })
         )
-
+    actions = MultipleChoiceField(
+        required=False,
+        label='Action taken',
+        choices=ACTION_CHOICES,
+        widget=UsaCheckboxSelectMultiple(attrs={
+            'name': 'actions',
+        }),
+    )
     status = MultipleChoiceField(
         initial=(('new', 'New'), ('open', 'Open')),
         required=False,

--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -668,6 +668,19 @@ CONTACT_PHONE_INVALID_MESSAGE = _('If you submit a phone number, please make sur
 
 DJ_NUMBER_INVALID_MESSAGE = 'Please double check the DJ Number. It should consist of a classification and Judicial district, separated by "-".'
 
+ACTION_CHOICES = (
+    ('Attached file:', 'Attached file'),
+    ('Contacted complainant:', 'Contacted complainant'),
+    ('Report viewed:', 'Report viewed'),
+    ('Assigned section:', 'Assigned section'),
+    ('Added comment:', 'Added comment'),
+    ('ICM DJ Number:', 'ICM DJ Number'),
+    ('Secondary review:', 'Secondary review'),
+    ('Contact state:', 'Contact state'),
+    ('District:', 'District'),
+    ('Added summary:', 'Added summary'),
+)
+
 PRINT_CHOICES = (
     ('correspondent', 'Correspondent Information'),
     ('issue', 'Reported Issue'),

--- a/crt_portal/cts_forms/sorts.py
+++ b/crt_portal/cts_forms/sorts.py
@@ -1,19 +1,23 @@
 from django.db.models import F
 from django.http import Http404
+from actstream.models import actor_stream
 
 from .models import EmailReportCount, Report
 
 SORT_DESC_CHAR = '-'
 
 
-def _valid_sort_params(sort):
-    valid_fields = [f.name for f in Report._meta.fields] + [f.name for f in EmailReportCount._meta.fields]
+def _valid_sort_params(sort, type):
+    if type == 'activity':
+        valid_fields = ['timestamp', 'actions', 'detail', 'target_object_id']
+    else:
+        valid_fields = [f.name for f in Report._meta.fields] + [f.name for f in EmailReportCount._meta.fields]
     return all(elem.replace("-", '') in valid_fields for elem in sort)
 
 
 def report_sort(sort):
 
-    if not _valid_sort_params(sort):
+    if not _valid_sort_params(sort, 'report'):
         raise Http404(f'Invalid sort request: {sort}')
 
     sort_exprs = []
@@ -26,5 +30,22 @@ def report_sort(sort):
             sort_exprs.append(F(sort_item).asc(nulls_last=nulls_last))
 
     sort_exprs.extend([F('create_date').desc(), F('id').desc()])
+
+    return sort_exprs, sort
+
+def activity_sort(sort):
+
+    if not _valid_sort_params(sort, 'activity'):
+        raise Http404(f'Invalid sort request: {sort}')
+
+    sort_exprs = []
+
+    for sort_item in sort:
+        if sort_item[0] == SORT_DESC_CHAR:
+            sort_exprs.append(F(sort_item[1::]))
+        else:
+            sort_exprs.append(F(sort_item))
+
+    sort_exprs.extend([F('id').desc()])
 
     return sort_exprs, sort

--- a/crt_portal/cts_forms/sorts.py
+++ b/crt_portal/cts_forms/sorts.py
@@ -9,7 +9,7 @@ SORT_DESC_CHAR = '-'
 
 def _valid_sort_params(sort, type):
     if type == 'activity':
-        valid_fields = ['timestamp', 'actions', 'detail', 'target_object_id']
+        valid_fields = ['timestamp', 'verb', 'description', 'target_object_id']
     else:
         valid_fields = [f.name for f in Report._meta.fields] + [f.name for f in EmailReportCount._meta.fields]
     return all(elem.replace("-", '') in valid_fields for elem in sort)
@@ -33,6 +33,7 @@ def report_sort(sort):
 
     return sort_exprs, sort
 
+
 def activity_sort(sort):
 
     if not _valid_sort_params(sort, 'activity'):
@@ -41,6 +42,9 @@ def activity_sort(sort):
     sort_exprs = []
 
     for sort_item in sort:
+        sort_name = sort_item
+        if sort_item == 'actions':
+            sort_name = 'verb'
         if sort_item[0] == SORT_DESC_CHAR:
             sort_exprs.append(F(sort_item[1::]))
         else:

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-filter-controls.html
@@ -11,7 +11,7 @@
       {% include 'forms/complaint_view/dashboard/filters/action.html' %}
       {% include 'forms/complaint_view/index/filters/public_id_filter.html' %}
     </div>
-    <div style="display:none" class="usa-alert usa-alert--error usa-alert--slim" id="filter-notification">
+    <div style="display:none" class="usa-alert usa-alert--error usa-alert--slim margin-bottom-2" id="filter-notification">
       <div class="usa-alert__body">
         <em class="usa-alert__text"></em>
       </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-filter-controls.html
@@ -11,7 +11,11 @@
       {% include 'forms/complaint_view/dashboard/filters/action.html' %}
       {% include 'forms/complaint_view/index/filters/public_id_filter.html' %}
     </div>
-
+    <div style="display:none" class="usa-alert usa-alert--error usa-alert--slim" id="filter-notification">
+      <div class="usa-alert__body">
+        <em class="usa-alert__text"></em>
+      </div>
+    </div>
     <div class="text-right">
       <button class="usa-button" type="submit" id="apply-filters-button">
         Apply filters

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-filter-controls.html
@@ -1,13 +1,15 @@
 <form
   id="filters-form"
   method="GET"
-  action="/form/dashboard"
+  action="/form/dashboard/activity"
   novalidate
 >
   <div class="usa-form">
     <div class="intake-filters">
       {% include 'forms/complaint_view/dashboard/filters/assignee.html' %}
       {% include 'forms/complaint_view/index/filters/date.html' %}
+      {% include 'forms/complaint_view/dashboard/filters/action.html' %}
+      {% include 'forms/complaint_view/index/filters/public_id_filter.html' %}
     </div>
 
     <div class="text-right">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log-header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log-header.html
@@ -1,0 +1,5 @@
+<header class="dashboard-header">
+    <div class="title">
+      {% include 'forms/complaint_view/dashboard/dashboard_header_title.html' with page='activity-log' %}
+    </div>
+  </header>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
@@ -4,6 +4,7 @@
 {% include 'forms/complaint_view/dashboard/header.html' %}
 {% endblock %}
 {% block content %}
+{% include 'forms/complaint_view/dashboard/team-management-header.html' %}
 {% include 'forms/complaint_view/dashboard/activity-log-header.html' %}
 <div class="intake-content">
   <div id="status-update" class="grid-col-auto">
@@ -16,7 +17,7 @@
   <div class="grid-col-auto">
     <div class="intake-table">
       <div class="intake-table-header">
-        <h2 class="intake-section-title">Activity log</h2>
+        <h3 class="intake-section-title">Activity log</h3>
       </div>
       {% include "forms/complaint_view/dashboard/activity_table.html" with page_format=page_format sort_state=sort_state filter_state=filter_state %}
     </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
@@ -12,12 +12,21 @@
   </div>
   {% include "forms/complaint_view/dashboard/activity-filter-controls.html" with filters=filters form=form %}
   <div class="display-flex margin-top-8">
+    <span class="intake-pagination margin-left-auto">
+      Showing {{ page_format.page_range_start }} - {{ page_format.page_range_end }} of {{ page_format.count }} records
+      {% include 'forms/complaint_view/index/filters/per_page.html' with per_page=page_format.per_page %}
+    </span>
+  </div>
+  <div class="display-flex margin-top-8">
     {% include "forms/complaint_view/dashboard/active-filters.html" %}
   </div>
   <div class="grid-col-auto">
     <div class="intake-table">
       <div class="intake-table-header">
         <h3 class="intake-section-title">Activity log</h3>
+        <div class="margin-left-auto">
+          {% include "forms/snippets/pagination.html" with page_format=page_format page_args=page_args placement="top" %}
+        </div>
       </div>
       {% include "forms/complaint_view/dashboard/activity_table.html" with page_format=page_format sort_state=sort_state filter_state=filter_state %}
     </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
@@ -3,26 +3,24 @@
 {% block page_header %}
 {% include 'forms/complaint_view/dashboard/header.html' %}
 {% endblock %}
-
 {% block content %}
-{% include 'forms/complaint_view/dashboard/reports-touched-header.html' %}
+{% include 'forms/complaint_view/dashboard/activity-log-header.html' %}
 <div class="intake-content">
   <div id="status-update" class="grid-col-auto">
     {% include 'partials/messages.html' %}
   </div>
-  {% include "forms/complaint_view/dashboard/filter-controls.html" with filters=filters form=form %}
+  {% include "forms/complaint_view/dashboard/activity-filter-controls.html" with filters=filters form=form %}
   <div class="display-flex margin-top-8">
     {% include "forms/complaint_view/dashboard/active-filters.html" %}
   </div>
   <div class="grid-col-auto">
     <div class="intake-table">
       <div class="intake-table-header">
-        <h2 class="intake-section-title">Reports touched</h2>
+        <h2 class="intake-section-title">Activity log</h2>
       </div>
-      {% include "forms/complaint_view/dashboard/complaints_table.html" with page_format=page_format sort_state=sort_state filter_state=filter_state %}
+      {% include "forms/complaint_view/dashboard/activity_table.html" with page_format=page_format sort_state=sort_state filter_state=filter_state %}
     </div>
   </div>
-  {% include "forms/complaint_view/dashboard/analytics.html" with embeds=embeds %}
 </div>
 {% endblock %}
 {% block page_js %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity_table.html
@@ -1,0 +1,51 @@
+{% load sortable_table_heading %}
+<form class="usa-form"
+      method="get"
+      action="{% url 'crt_forms:crt-forms-actions' %}"
+      novalidate
+>
+  <input type="hidden" value="{{ return_url_args }}" name="next" id="next" />
+
+  <div>
+    {% if selected_actor %}
+    <table class="usa-table crt-table dashboard-table">
+      <thead>
+        <tr>
+          {% render_sortable_heading 'Timestamp' sort_state filter_state %}
+          {% render_sortable_heading 'User' sort_state filter_state %}
+          {% render_sortable_heading 'Action' sort_state filter_state nowrap=True %}
+          {% render_sortable_heading 'Detail' sort_state filter_state nowrap=True %}
+          {% render_sortable_heading 'Complaint ID' sort_state filter_state %}
+        </tr>
+      </thead>
+      {% if data %}
+        <tbody>
+          {% for datum in data %}
+            <tr class="tr-status-{{ datum.report.status }} tr--hover{% cycle ' stripe' '' %}">
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.timestamp }}</a></td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ selected_actor }}</a></td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.action }}</a></td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.detail }}</a></td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.reportid }}</a></td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      {% endif %}
+    </table>
+    {% endif %}
+  </div>
+</form>
+
+{% if not selected_actor %}
+  <div class="crt-portal-card table-message">
+    <div class="crt-portal-card__content">
+      <div class="grid-container padding-bottom-2">
+        <div class="align-center">
+          <img alt="filter icon" src="{% static 'img/filters.svg' %}" class="margin-top-1" />
+          <p class="margin-bottom-1 margin-top-1" role="status"><b>Select intake specialist</b></p>
+          <em>Please select an intake specialist to see activity log data</em>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity_table.html
@@ -1,4 +1,5 @@
 {% load sortable_table_heading %}
+
 <form class="usa-form"
       method="get"
       action="{% url 'crt_forms:crt-forms-actions' %}"
@@ -13,8 +14,8 @@
         <tr>
           {% render_sortable_heading 'Timestamp' sort_state filter_state %}
           {% render_sortable_heading 'User' sort_state filter_state %}
-          {% render_sortable_heading 'Action' sort_state filter_state nowrap=True %}
-          {% render_sortable_heading 'Detail' sort_state filter_state nowrap=True %}
+          {% render_sortable_heading 'Action' sort_state filter_state %}
+          {% render_sortable_heading 'Detail' sort_state filter_state %}
           {% render_sortable_heading 'Complaint ID' sort_state filter_state nowrap=True %}
         </tr>
       </thead>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity_table.html
@@ -15,7 +15,7 @@
           {% render_sortable_heading 'User' sort_state filter_state %}
           {% render_sortable_heading 'Action' sort_state filter_state nowrap=True %}
           {% render_sortable_heading 'Detail' sort_state filter_state nowrap=True %}
-          {% render_sortable_heading 'Complaint ID' sort_state filter_state %}
+          {% render_sortable_heading 'Complaint ID' sort_state filter_state nowrap=True %}
         </tr>
       </thead>
       {% if data %}
@@ -32,6 +32,19 @@
         </tbody>
       {% endif %}
     </table>
+    {% if not data %}
+        <div class="crt-portal-card table-message">
+            <div class="crt-portal-card__content">
+                <div class="grid-container padding-bottom-2">
+                    <div class="align-center">
+                        <img alt="filter icon" src="{% static 'img/filters.svg' %}" class="margin-top-1" />
+                        <p class="margin-bottom-1 margin-top-1" role="status"><b>No activity found</b></p>
+                        <em>Try adjusting your filters to see more activities</em>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
     {% endif %}
   </div>
 </form>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/analytics.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/analytics.html
@@ -1,5 +1,5 @@
 {% if embeds %}
-<h2 style="margin-top: 2em" class="intake-section-title">Analytics</h2>
+<h3 style="margin-top: 2em" class="intake-section-title">Analytics</h3>
 <div class="margin-bottom-2">Take a high-level look at report data.</div>
 
 {% for embed in embeds %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/dashboard_header_title.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/dashboard_header_title.html
@@ -1,0 +1,14 @@
+<div class="title">
+    <ul class="usa-nav__primary usa-accordion">
+      <li class="usa-nav__primary-item">
+        <a class="text-semibold text-base-dark crt-landing--menu_link reporting-header {% if page == 'team-management' %} selected {% endif %}" href="/form/dashboard">
+          Reports touched
+        </a>
+      </li>
+      <li class="usa-nav__primary-item">
+        <a class="text-semibold text-base-dark crt-landing--menu_link reporting-header {% if page == 'activity-log' %} selected {% endif %}" href="/form/dashboard/activity">
+          Activity log
+        </a>
+      </li>
+    </ul>
+  </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filters/action.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/filters/action.html
@@ -1,0 +1,12 @@
+{% extends "forms/complaint_view/index/filter.html" %}
+
+{% block classes %}actions{% endblock %}
+{% block controls %}actions{% endblock %}
+{% block label %}{{ form.actions.label }}{% endblock %}
+{% block id %}actions{% endblock %}
+
+{% block content %}
+  <div id="actions-filter" class="multicheckboxes-container">
+    {{ form.actions }}
+  </div>
+{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/index.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block content %}
+{% include 'forms/complaint_view/dashboard/team-management-header.html' %}
 {% include 'forms/complaint_view/dashboard/reports-touched-header.html' %}
 <div class="intake-content">
   <div id="status-update" class="grid-col-auto">
@@ -17,7 +18,7 @@
   <div class="grid-col-auto">
     <div class="intake-table">
       <div class="intake-table-header">
-        <h2 class="intake-section-title">Reports touched</h2>
+        <h3 class="intake-section-title">Reports touched</h3>
       </div>
       {% include "forms/complaint_view/dashboard/complaints_table.html" with page_format=page_format sort_state=sort_state filter_state=filter_state %}
     </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/reports-touched-header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/reports-touched-header.html
@@ -1,0 +1,6 @@
+<header class="dashboard-header">
+    <div class="title">
+      {% include 'forms/complaint_view/dashboard/dashboard_header_title.html' with page='team-management' %}
+    </div>
+  </header>
+  

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/team-management-header.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/team-management-header.html
@@ -1,0 +1,4 @@
+<div class="margin-left-4 padding-left-2">
+    <h2 class="intake-section-title padding-bottom-2">Team Management</h2>
+    <div class="margin-bottom-2">Review the activity log of intake specialists, including reports touched and actions taken.</div>
+</div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -1,4 +1,4 @@
-<h2 class="intake-section-title margin-bottom-105">Report Records</h2>
+<h2 class="intake-section-title margin-bottom-105 padding-bottom-2">Report Records</h2>
 <span>Find specific CRT Report Records by using the filter options below.</span>
 <form
   id="filters-form"

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -28,7 +28,7 @@
   <div class="grid-col-auto">
     <div class="intake-table">
       <div class="intake-table-header">
-        <h2 class="intake-section-title">Incoming records</h2>
+        <h3 class="intake-section-title">Incoming records</h3>
         <div class="margin-left-auto">
           {% include "forms/snippets/pagination.html" with page_format=page_format page_args=page_args placement="top" %}
         </div>

--- a/crt_portal/cts_forms/templatetags/get_field_label.py
+++ b/crt_portal/cts_forms/templatetags/get_field_label.py
@@ -31,6 +31,7 @@ variable_rename = {
     'correctional_facility_type': 'Prison type',
     'create_date_start': 'Submission date start',
     'create_date_end': 'Submission date end',
+    'actions': 'Actions',
 }
 
 

--- a/crt_portal/cts_forms/templatetags/sortable_table_heading.py
+++ b/crt_portal/cts_forms/templatetags/sortable_table_heading.py
@@ -14,8 +14,9 @@ sort_lookup = {
     'incident location': 'location_city_town',
     'incident date': 'last_incident_month',
     'timestamp': 'timestamp',
-    'action': 'actions',
-    'detail': 'detail',
+    'action': 'verb',
+    'detail': 'description',
+    'complaint id': 'target_object_id'
 }
 sortable_props = [
     'status',
@@ -28,8 +29,9 @@ sortable_props = [
     'location_city_town',
     'last_incident_month',
     'timestamp',
-    'actions',
-    'detail',
+    'verb',
+    'description',
+    'target_object_id',
 ]
 
 

--- a/crt_portal/cts_forms/templatetags/sortable_table_heading.py
+++ b/crt_portal/cts_forms/templatetags/sortable_table_heading.py
@@ -13,6 +13,9 @@ sort_lookup = {
     'location name': 'location_name',
     'incident location': 'location_city_town',
     'incident date': 'last_incident_month',
+    'timestamp': 'timestamp',
+    'action': 'actions',
+    'detail': 'detail',
 }
 sortable_props = [
     'status',
@@ -24,6 +27,9 @@ sortable_props = [
     'location_name',
     'location_city_town',
     'last_incident_month',
+    'timestamp',
+    'actions',
+    'detail',
 ]
 
 

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import (ActionsView, index_view, dashboard_view, RoutingGuideView, ShowView, ProFormView,
+from .views import (ActionsView, index_view, dashboard_view, dashboard_activity_log_view, RoutingGuideView, ShowView, ProFormView,
                     SaveCommentView, TrendView, ResponseView, SearchHelperView,
                     PrintView, ProfileView, ReportAttachmentView, ReportDataView, DataExport, RemoveReportAttachmentView)
 from .forms import ProForm
@@ -26,5 +26,6 @@ urlpatterns = [
     path('attachment/report/<int:report_id>/', ReportAttachmentView.as_view(), name='save-report-attachment'),
     path('attachment/<int:attachment_id>/', RemoveReportAttachmentView.as_view(), name='remove-report-attachment'),
     path('trends/', TrendView.as_view(), name='trends'),
-    path('dashboard/', dashboard_view, name='dashboard')
+    path('dashboard/', dashboard_view, name='dashboard'),
+    path('dashboard/activity', dashboard_activity_log_view, name='activity-log')
 ]

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -454,7 +454,8 @@ def process_activity_filters(request):
     per_page = request.GET.get('per_page', 15)
     page = request.GET.get('page', 1)
     sort_expr, sorts = activity_sort(request.GET.getlist('sort'))
-    selected_actions = selected_actions.order_by(*sort_expr)
+    if selected_actions != []:
+        selected_actions = selected_actions.order_by(*sort_expr)
     paginator = Paginator(selected_actions, per_page)
     selected_actions, page_format = pagination(paginator, page, per_page)
     sort_state = {}

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -436,15 +436,31 @@ def process_intake_filters(request):
     }
 
 
+def get_action_data(requested_actions):
+    data = []
+    for action in requested_actions:
+        data.append({
+            "action": action.verb,
+            "detail": action.description,
+            "timestamp": action.timestamp,
+            "reportid": action.target_object_id,
+            "url": f'/form/view/{action.target_object_id}'
+        })
+    return data
+
+
 def process_activity_filters(request):
+    query_filters, selected_actions = dashboard_filter(request.GET)
     selected_actor = request.GET.get("assigned_to", "")
     selected_actor_object = User.objects.filter(username=selected_actor).first()
     selected_actor_id = selected_actor_object.pk if selected_actor_object else ''
-
+    data = get_action_data(selected_actions)
     return {
         'form': Filters(request.GET),
         'selected_actor': selected_actor,
         'selected_actor_id': selected_actor_id,
+        'filters': query_filters,
+        'data': data,
     }
 
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -436,6 +436,18 @@ def process_intake_filters(request):
     }
 
 
+def process_activity_filters(request):
+    selected_actor = request.GET.get("assigned_to", "")
+    selected_actor_object = User.objects.filter(username=selected_actor).first()
+    selected_actor_id = selected_actor_object.pk if selected_actor_object else ''
+
+    return {
+        'form': Filters(request.GET),
+        'selected_actor': selected_actor,
+        'selected_actor_id': selected_actor_id,
+    }
+
+
 @login_required
 def dashboard_view(request):
     embeds = [model_to_dict(e) for e in DashboardEmbed.objects.all()]
@@ -446,6 +458,17 @@ def dashboard_view(request):
         {
             **process_intake_filters(request),
             'embeds': embeds,
+        })
+
+
+@login_required
+def dashboard_activity_log_view(request):
+
+    return render(
+        request,
+        'forms/complaint_view/dashboard/activity-log.html',
+        {
+            **process_activity_filters(request),
         })
 
 

--- a/crt_portal/static/js/dashboard_view_filters.js
+++ b/crt_portal/static/js/dashboard_view_filters.js
@@ -255,13 +255,13 @@
     const alertEl = document.getElementById('filter-notification');
     const textEl = alertEl.querySelector('.usa-alert__text');
     const value = inputEl.value;
-    console.log(value);
-    if (!value.length) {
+    if (!value.length || value == '(none)') {
       e.preventDefault()
       buttonEl.setAttribute('disabled', '');
       textEl.textContent =
         'Please select an intake specialist to see activity log data';
       alertEl.style.display = 'inline-block';
+      inputEl.addEventListener('change', (e) => {validateFilter(e)})
     } else {
       buttonEl.removeAttribute('disabled');
       textEl.textContent = '';

--- a/crt_portal/static/js/dashboard_view_filters.js
+++ b/crt_portal/static/js/dashboard_view_filters.js
@@ -121,6 +121,14 @@
       if (state.hasOwnProperty(key)) {
         state[key] = decodeFormData(value);
       }
+      if (key === 'per_page') {
+        const per_page_el = dom.querySelector('select[name="per_page"]');
+        if (per_page_el) {
+          per_page_el.value = value;
+        } else {
+          state[key] = '';
+        }
+      }
     }
   }
 
@@ -239,10 +247,14 @@
         'Component must be supplied with a valid DOM node and a `name` key corresponding to a key in the filterDataModel object'
       );
     }
-
-    props.el.addEventListener('change', function(event) {
+    function onChange(event) {
       filterDataModel[props.name] = event.target.value;
-    });
+      if (props.name == 'per_page') {
+        dom.getElementById('apply-filters-button').click();
+        return;
+      }
+    }
+    props.el.addEventListener('change', onChange);
   }
 
   function clearFiltersView(props) {
@@ -253,6 +265,7 @@
     const buttonEl = document.getElementById('apply-filters-button');
     const inputEl = document.getElementById('id_assigned_to');
     const alertEl = document.getElementById('filter-notification');
+    if (!alertEl) return;
     const textEl = alertEl.querySelector('.usa-alert__text');
     const value = inputEl.value;
     if (!value.length || value == '(none)') {
@@ -279,6 +292,7 @@
     var assigneeEl = formEl.querySelector('#id_assigned_to');
     const actionsEl = dom.getElementsByName('actions');
     const complaintIDEl = formEl.querySelector('input[name="public_id"]');
+    const perPageEl = dom.querySelector('select[name="per_page"]');
     /**
      * Update the filter data model when the user clears (clicks on) a filter tag,
      * and perform a new search with the updated filters applied.
@@ -338,14 +352,6 @@
       el: activeFiltersEl,
       onClick: onFilterTagClick
     });
-    checkBoxView({
-      el: actionsEl,
-      name: 'actions'
-    });
-    textInputView({
-      el: complaintIDEl,
-      name: 'public_id'
-    });
     textInputView({
       el: assigneeEl,
       name: 'assigned_to'
@@ -358,6 +364,21 @@
       el: createdateendEl,
       name: 'create_date_end'
     });
+    const location = window.location.href;
+    if (location.includes('activity')) {
+      checkBoxView({
+        el: actionsEl,
+        name: 'actions'
+      });
+      textInputView({
+        el: perPageEl,
+        name: 'per_page'
+      });
+      textInputView({
+        el: complaintIDEl,
+        name: 'public_id'
+      });
+    }
     clearFiltersView({
       el: clearAllEl,
       onClick: clearAllFilters

--- a/crt_portal/static/js/dashboard_view_filters.js
+++ b/crt_portal/static/js/dashboard_view_filters.js
@@ -256,12 +256,13 @@
     const textEl = alertEl.querySelector('.usa-alert__text');
     const value = inputEl.value;
     if (!value.length || value == '(none)') {
-      e.preventDefault()
+      e.preventDefault();
       buttonEl.setAttribute('disabled', '');
-      textEl.textContent =
-        'Please select an intake specialist to see activity log data';
+      textEl.textContent = 'Please select an intake specialist to see activity log data';
       alertEl.style.display = 'inline-block';
-      inputEl.addEventListener('change', (e) => {validateFilter(e)})
+      inputEl.addEventListener('change', e => {
+        validateFilter(e);
+      });
     } else {
       buttonEl.removeAttribute('disabled');
       textEl.textContent = '';

--- a/crt_portal/static/js/dashboard_view_filters.js
+++ b/crt_portal/static/js/dashboard_view_filters.js
@@ -103,9 +103,11 @@
     create_date_start: '',
     create_date_end: '',
     assigned_to: '',
+    actions: [],
     sort: '',
     page: '',
-    per_page: ''
+    per_page: '',
+    public_id: ''
   };
   var filterDataModel = {};
 
@@ -247,6 +249,26 @@
     props.el.addEventListener('click', props.onClick);
   }
 
+  function validateFilter(e) {
+    const buttonEl = document.getElementById('apply-filters-button');
+    const inputEl = document.getElementById('id_assigned_to');
+    const alertEl = document.getElementById('filter-notification');
+    const textEl = alertEl.querySelector('.usa-alert__text');
+    const value = inputEl.value;
+    console.log(value);
+    if (!value.length) {
+      e.preventDefault()
+      buttonEl.setAttribute('disabled', '');
+      textEl.textContent =
+        'Please select an intake specialist to see activity log data';
+      alertEl.style.display = 'inline-block';
+    } else {
+      buttonEl.removeAttribute('disabled');
+      textEl.textContent = '';
+      alertEl.style.display = 'none';
+    }
+  }
+
   function filterController() {
     var formEl = dom.getElementById('filters-form');
     var activeFiltersEl = dom.querySelector('[data-active-filters]');
@@ -254,6 +276,8 @@
     var createdateendEl = formEl.querySelector('input[name="create_date_end"]');
     var clearAllEl = dom.querySelector('[data-clear-filters]');
     var assigneeEl = formEl.querySelector('#id_assigned_to');
+    const actionsEl = dom.getElementsByName('actions');
+    const complaintIDEl = formEl.querySelector('input[name="public_id"]');
     /**
      * Update the filter data model when the user clears (clicks on) a filter tag,
      * and perform a new search with the updated filters applied.
@@ -272,7 +296,8 @@
         'commercial_or_public_place',
         'reported_reason',
         'language',
-        'correctional_facility_type'
+        'correctional_facility_type',
+        'actions'
       ];
       var filterIndex = multiSelectElements.indexOf(filterName);
       if (filterIndex !== -1) {
@@ -312,6 +337,14 @@
       el: activeFiltersEl,
       onClick: onFilterTagClick
     });
+    checkBoxView({
+      el: actionsEl,
+      name: 'actions'
+    });
+    textInputView({
+      el: complaintIDEl,
+      name: 'public_id'
+    });
     textInputView({
       el: assigneeEl,
       name: 'assigned_to'
@@ -338,7 +371,10 @@
     Object.keys(initialFilterState).forEach(function(key) {
       filterDataModel[key] = initialFilterState[key];
     });
-
+    const buttonEl = document.getElementById('apply-filters-button');
+    buttonEl.addEventListener('click', function(e) {
+      validateFilter(e);
+    });
     mutateFilterDataWithUpdates(filterDataModel, filterUpdates);
 
     filterController();

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -36,6 +36,12 @@
       }
     }
   }
+
+  .intake-table-header {
+    .intake-section-title {
+      font-size: 22px;
+    }
+  }
 }
 
 .intake-header {
@@ -792,7 +798,7 @@ form#cts-forms-profile {
   align-items: center;
   display: flex;
   border-radius: 5px 5px;
-  min-height: 5rem;
+  min-height: 3rem;
   padding-bottom: 1.2rem;
   padding-left: 1.3rem;
   padding-right: 2rem;

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -86,6 +86,7 @@
     font-weight: 500;
     &:hover {
       color: #fff;
+      background-color: transparent;
       border-bottom: 3px solid color('white');
     }
 
@@ -112,6 +113,40 @@
         background: color($theme-color-warning-light) !important;
       }
     }
+  }
+}
+
+.dashboard-header {
+  @include u-padding-x(4);
+  @include flex-container();
+  justify-content: space-between;
+  margin-bottom: 4rem;
+
+  .title {
+    @include flex-container();
+
+    .usa-nav__primary {
+      display: flex;
+      margin-top: 0;
+      .usa-nav__primary-item {
+        border-top: none;
+      }
+
+    }
+
+  }
+  .crt-landing--menu_link.reporting-header {
+    border: none;
+    margin: 0 1rem;
+    padding: 1rem 0;
+  }
+
+  .crt-landing--menu_link.reporting-header.selected {
+    border-bottom: 3px solid #005EA2;
+  }
+  .usa-nav__primary a:not(.usa-button):hover {
+    background-color: transparent;
+    border-bottom: 3px solid #005EA2;
   }
 }
 


### PR DESCRIPTION
[Issue 1558](https://github.com/usdoj-crt/crt-portal-management/issues/1558)

## What does this change?
This PR adds logic to sort and paginate the new team management activity view.
It depends on [this PR](https://github.com/usdoj-crt/crt-portal/pull/1428).
Navigate to /dashboard/activity to sort and paginate the activity table.
Navigate to /dashboard to verify that the reports touched table functions as it does on production.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
