### PR TITLE
Replace current docker database to postgres 12.15

### DIFF
--- a/db/db.Dockerfile
+++ b/db/db.Dockerfile
@@ -1,5 +1,12 @@
-FROM postgres:11.14-alpine
+FROM postgres:12.15-alpine
 RUN apk update
+
+# added for openssl vulnerability remediation
+# https://dso.docker.com/packages/pkg:alpine/openssl
+# https://dso.docker.com/cve/CVE-2023-2650
+
+RUN apk add --update openssl && \
+    rm -rf /var/cache/apk/*
 RUN apk add gettext  # For envsubst
 
 ARG analytics_password


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1557)

## What does this change?
Replace the current docker DB version to 12.15

## Checklist:
+ [x] validate the docker image is postgres 12.15

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

Docker will be upgraded to Postgres 12.15.
Note, this will require removing of current mount volume in docker for the database.
This is not a DB upgrade, rather replacement of current docker version with the new version.
New user and test data creation will be needed to test features using the application.

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
