### PR TITLE
Add tests for new team management view and grouping

### DIFF
--- a/crt_portal/cts_forms/model_variables.py
+++ b/crt_portal/cts_forms/model_variables.py
@@ -679,6 +679,8 @@ ACTION_CHOICES = (
     ('Contact state:', 'Contact state'),
     ('District:', 'District'),
     ('Added summary:', 'Added summary'),
+    ('Updated summary: ', 'Updated summary'),
+    ('Updated comment: ', 'Updated comment'),
 )
 
 PRINT_CHOICES = (

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -8,7 +8,7 @@ from django.http import QueryDict
 from django.test import SimpleTestCase, TestCase, TransactionTestCase
 import pytz
 
-from ..filters import report_filter
+from ..filters import report_filter, report_grouping
 from api.filters import form_letters_filter, autoresponses_filter
 from ..models import Report, ProtectedClass, FormLettersSent
 from .test_data import SAMPLE_REPORT_1, SAMPLE_REPORT_2, SAMPLE_REPORT_3, SAMPLE_REPORT_4
@@ -57,6 +57,12 @@ class ReportFilterTests(TestCase):
         test_data['violation_summary'] = 'boat plane'
         Report.objects.create(**test_data)
 
+        test_data['violation_summary'] = 'motorcycle'
+        Report.objects.create(**test_data)
+
+        test_data['violation_summary'] = 'motorcycle'
+        Report.objects.create(**test_data)
+
     def test_no_filters(self):
         """Returns all reports when no filters provided"""
         reports, _ = report_filter(QueryDict(''))
@@ -83,7 +89,7 @@ class ReportFilterTests(TestCase):
         self.assertEqual(reports.count(), 1)
         # Since non numeric characters are stripped, it should return all results.
         reports, _ = report_filter(QueryDict('contact_phone=Hello'))
-        self.assertEqual(reports.count(), 9)
+        self.assertEqual(reports.count(), 11)
 
     def test_or_search_for_violation_summary(self):
         """
@@ -151,7 +157,7 @@ class ReportFilterTests(TestCase):
         # This one is a little counter-intuitive, because one result will have "truck"
         # and "boat" in it. Why? Because the search query translates to "all entries
         # without 'boat'", and "all entries with truck, regardless of whether it has 'boat".
-        self.assertEqual(reports.count(), 4)
+        self.assertEqual(reports.count(), 6)
         for report in reports:
             self.assertEqual('truck' in report.violation_summary or 'boat' not in report.violation_summary, True)
 
@@ -212,6 +218,11 @@ class ReportFilterTests(TestCase):
         """
         reports, _ = report_filter(QueryDict('violation_summary=boat%20AND%20(hovercraft%20OR%20(truck%20AND%20fishing))'))
         self.assertEqual(reports.count(), 2)
+    
+    def test_grouping(self):
+        group_queries, _ = report_grouping(QueryDict('grouping="matching-descriptions"'))
+        self.assertEqual(group_queries.count(), 2)
+        self.assertEqual(group_queries[0]['qs'].count(), 2)
 
 
 # This is a separate test suite from the above search query tests because

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -221,7 +221,7 @@ class ReportFilterTests(TestCase):
     
     def test_grouping(self):
         group_queries, _ = report_grouping(QueryDict('grouping="matching-descriptions"'))
-        self.assertEqual(group_queries.count(), 2)
+        self.assertEqual(len(group_queries), 2)
         self.assertEqual(group_queries[0]['qs'].count(), 2)
 
 

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -218,7 +218,7 @@ class ReportFilterTests(TestCase):
         """
         reports, _ = report_filter(QueryDict('violation_summary=boat%20AND%20(hovercraft%20OR%20(truck%20AND%20fishing))'))
         self.assertEqual(reports.count(), 2)
-    
+
     def test_grouping(self):
         group_queries, _ = report_grouping(QueryDict('grouping="matching-descriptions"'))
         self.assertEqual(len(group_queries), 2)

--- a/crt_portal/cts_forms/tests/test_views.py
+++ b/crt_portal/cts_forms/tests/test_views.py
@@ -691,7 +691,7 @@ class CRT_FILTER_Tests(TestCase):
         # We've specified ADM as a query param, we should only see reports from that section
         expected_reports = Report.objects.filter(assigned_section='ADM').count()
         self.assertEqual(len(reports), expected_reports)
-    
+
     def test_grouping_filter(self):
         grouping_filter = 'grouping=matching-descriptions'
         response = self.client.get(f'{self.url_base}?{grouping_filter}')
@@ -786,6 +786,7 @@ class CRT_Dashboard_Tests(TestCase):
         response = self.client.get(url)
         self.assertTrue('0 reports' in str(response.content))
 
+
 class CRT_Activity_Dashboard_Tests(TestCase):
     def setUp(self):
         # We'll need a report and a handful of actions
@@ -830,18 +831,19 @@ class CRT_Activity_Dashboard_Tests(TestCase):
         self.client.force_login(self.superuser)
         response = self.client.get(url)
         self.assertTrue('2 records' in str(response.content))
-    
+
     def test_verb_filter(self):
         url = f'{self.url}?create_date_start=2021-09-01&create_date_end=2035-09-30&assigned_to=superduperuser&actions=Added summary: '
         self.client.force_login(self.superuser)
         response = self.client.get(url)
         self.assertTrue('1 record' in str(response.content))
-    
+
     def test_complaint_id_filter(self):
         url = f'{self.url}?create_date_start=2021-09-01&create_date_end=2035-09-30&assigned_to=superduperuser&public_id={self.report.id}'
         self.client.force_login(self.superuser)
         response = self.client.get(url)
         self.assertTrue('2 records' in str(response.content))
+
 
 class CRT_Analytics_Tests(TestCase):
     def setUp(self):

--- a/crt_portal/cts_forms/tests/test_views.py
+++ b/crt_portal/cts_forms/tests/test_views.py
@@ -696,7 +696,7 @@ class CRT_FILTER_Tests(TestCase):
         grouping_filter = 'grouping=matching-descriptions'
         response = self.client.get(f'{self.url_base}?{grouping_filter}')
         groups = response.context['groups']
-        self.assertEqual(len(groups), 3)
+        self.assertEqual(len(groups), 2)
         self.assertTrue('Group 1' in str(response.content))
 
 


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

This PR adds tests for the Activity Log filtering in the new Team Management view and grouping filtering in the Reports view.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
