### PR TITLE
update ci/cd docker postgres image to 12.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           PIPENV_VENV_IN_PROJECT: true
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
       # CircleCI PostgreSQL images available at: https://hub.docker.com/_/postgres
-      - image: postgres:11.14-alpine
+      - image: postgres:12.15-alpine
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
@@ -219,7 +219,7 @@ jobs:
           CF_MANIFEST: manifest_dev.yaml
           CF_SPACE: dev
       # CircleCI PostgreSQL images available at: https://hub.docker.com/_/postgres
-      - image: postgres:11.14-alpine
+      - image: postgres:12.15-alpine
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
@@ -287,7 +287,7 @@ jobs:
           CF_MANIFEST: manifest_staging.yaml
           CF_SPACE: staging
       # CircleCI PostgreSQL images available at: https://hub.docker.com/_/postgres
-      - image: postgres:11.14-alpine
+      - image: postgres:12.15-alpine
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
@@ -346,7 +346,7 @@ jobs:
           CF_MANIFEST: manifest_prod.yaml
           CF_SPACE: prod
       # CircleCI PostgreSQL images available at: https://hub.docker.com/_/postgres
-      - image: postgres:11.14-alpine
+      - image: postgres:12.15-alpine
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1568)

## What does this change?
CI/CD postgres image changed to 12.15

## Checklist:
Check CI/CD logs for postgres 12.15 successful start.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
