### PR TITLE
Add notebook for report closing velocity

### DIFF
--- a/jupyterhub/assignments/examples/reports_closed_velocity.ipynb
+++ b/jupyterhub/assignments/examples/reports_closed_velocity.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show velocity as a ratio of reports processed vs count of specialists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext sql\n",
+    "\n",
+    "%config SqlMagic.feedback = False\n",
+    "\n",
+    "%config SqlMagic.displaycon = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql --save closed_reports\n",
+    "SELECT \n",
+    "  a.timestamp,\n",
+    "  r.assigned_section\n",
+    "FROM cts_forms_report r\n",
+    "LEFT JOIN actstream_action a\n",
+    "ON r.id::TEXT = a.target_object_id\n",
+    "WHERE a.verb = 'Status:' and a.description = 'Updated from \"open\" to \"closed\"'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql --save intake_specialists\n",
+    "SELECT \n",
+    "   COUNT(*) \n",
+    "FROM \n",
+    "   auth_user\n",
+    "WHERE is_staff = true AND is_active = true"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_closed_report_count(*, month='6', year='2023'):\n",
+    "    count = %sql --with closed_reports SELECT \\\n",
+    "            COUNT(*) \\\n",
+    "            FROM closed_reports \\\n",
+    "            WHERE \\\n",
+    "            EXTRACT(YEAR FROM date) = '{{ year }}' \\\n",
+    "            AND EXTRACT(MONTH FROM date) = '{{ month }}' \\\n",
+    "\n",
+    "    return count.DataFrame().fillna(0)['count'][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MONTHS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']\n",
+    "monthly_count = []\n",
+    "intake_specialists_sql = %sql --with intake_specialists SELECT count FROM intake_specialists\n",
+    "intake_specialists_count = intake_specialists_sql.DataFrame().fillna(0)['count'][0]\n",
+    "for month in MONTHS:\n",
+    "    count = get_closed_report_count(month=month)\n",
+    "    monthly_count.append(count/intake_specialists_count)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "import pandas as pd\n",
+    "df1 = pd.DataFrame(dict(Month=MONTHS))\n",
+    "df2 = pd.DataFrame(dict(velocity=monthly_count))\n",
+    "fig = px.bar(df1, x=df1.Month, y=df2.velocity, title='Reports closed per intake specialist each month 2023', labels={'y':'Reports Closed'})\n",
+    "fig.update_layout(font_size=10, height=500)\n",
+    "fig.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.3 (main, Apr  7 2023, 20:13:31) [Clang 14.0.0 (clang-1400.0.29.202)]"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/jupyterhub/assignments/examples/reports_closed_velocity.ipynb
+++ b/jupyterhub/assignments/examples/reports_closed_velocity.ipynb
@@ -26,10 +26,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%sql --save closed_reports\n",
+    "%%sql --save closed_reports --no-execute\n",
     "SELECT \n",
-    "  a.timestamp,\n",
-    "  r.assigned_section\n",
+    "  DATE(a.timestamp) as date,\n",
+    "  r.assigned_section as section\n",
     "FROM cts_forms_report r\n",
     "LEFT JOIN actstream_action a\n",
     "ON r.id::TEXT = a.target_object_id\n",

--- a/jupyterhub/assignments/examples/reports_closed_velocity.ipynb
+++ b/jupyterhub/assignments/examples/reports_closed_velocity.ipynb
@@ -1,10 +1,11 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Show velocity as a ratio of reports processed vs count of specialists"
+    "# District and classification by section"
    ]
   },
   {
@@ -14,9 +15,7 @@
    "outputs": [],
    "source": [
     "%load_ext sql\n",
-    "\n",
     "%config SqlMagic.feedback = False\n",
-    "\n",
     "%config SqlMagic.displaycon = False"
    ]
   },
@@ -26,60 +25,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%sql --save closed_reports --no-execute\n",
+    "%%sql --save report_districts\n",
     "SELECT \n",
-    "  DATE(a.timestamp) as date,\n",
-    "  r.assigned_section as section\n",
+    "    r.district as district,\n",
+    "    r.assigned_section as section,\n",
+    "    r.primary_statute as classification,\n",
+    "    COUNT(*) count\n",
     "FROM cts_forms_report r\n",
-    "LEFT JOIN actstream_action a\n",
-    "ON r.id::TEXT = a.target_object_id\n",
-    "WHERE a.verb = 'Status:' and a.description = 'Updated from \"open\" to \"closed\"'\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%sql --save intake_specialists\n",
-    "SELECT \n",
-    "   COUNT(*) \n",
-    "FROM \n",
-    "   auth_user\n",
-    "WHERE is_staff = true AND is_active = true"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_closed_report_count(*, month='6', year='2023'):\n",
-    "    count = %sql --with closed_reports SELECT \\\n",
-    "            COUNT(*) \\\n",
-    "            FROM closed_reports \\\n",
-    "            WHERE \\\n",
-    "            EXTRACT(YEAR FROM date) = '{{ year }}' \\\n",
-    "            AND EXTRACT(MONTH FROM date) = '{{ month }}' \\\n",
-    "\n",
-    "    return count.DataFrame().fillna(0)['count'][0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "MONTHS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']\n",
-    "monthly_count = []\n",
-    "intake_specialists_sql = %sql --with intake_specialists SELECT count FROM intake_specialists\n",
-    "intake_specialists_count = intake_specialists_sql.DataFrame().fillna(0)['count'][0]\n",
-    "for month in MONTHS:\n",
-    "    count = get_closed_report_count(month=month)\n",
-    "    monthly_count.append(count/intake_specialists_count)"
+    "WHERE district notnull AND primary_statute notnull\n",
+    "GROUP BY district, section, classification\n",
+    "HAVING COUNT(*) > 1\n",
+    "ORDER BY count desc"
    ]
   },
   {
@@ -89,12 +45,30 @@
    "outputs": [],
    "source": [
     "import plotly.express as px\n",
-    "import pandas as pd\n",
-    "df1 = pd.DataFrame(dict(Month=MONTHS))\n",
-    "df2 = pd.DataFrame(dict(velocity=monthly_count))\n",
-    "fig = px.bar(df1, x=df1.Month, y=df2.velocity, title='Reports closed per intake specialist each month 2023', labels={'y':'Reports Closed'})\n",
-    "fig.update_layout(font_size=10, height=500)\n",
-    "fig.show()"
+    "\n",
+    "def make_district_chart(section='(any)'):\n",
+    "    results = %sql --with report_districts SELECT * \\\n",
+    "        FROM report_districts \\\n",
+    "        WHERE \\\n",
+    "        '{{section}}' = '(any)' \\\n",
+    "        OR ('{{section}}' != '(any)' AND section='{{section}}');\n",
+    "    df = results.DataFrame()\n",
+    "    fig = px.bar(df, x=\"count\", y=\"district\", color=\"classification\", title=f'Reports by District for: {section}', barmode='group', height=600)\n",
+    "    return fig\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sections = %sql --with report_districts SELECT section FROM report_districts GROUP BY 1;\n",
+    "sections = sections.DataFrame().section\n",
+    "\n",
+    "for section in sections:\n",
+    "    district_chart = make_district_chart(section)\n",
+    "    district_chart.show()\n"
    ]
   }
  ],

--- a/jupyterhub/assignments/examples/reports_closed_velocity.ipynb
+++ b/jupyterhub/assignments/examples/reports_closed_velocity.ipynb
@@ -1,11 +1,10 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# District and classification by section"
+    "Show velocity as a ratio of reports processed vs count of specialists"
    ]
   },
   {
@@ -15,7 +14,9 @@
    "outputs": [],
    "source": [
     "%load_ext sql\n",
+    "\n",
     "%config SqlMagic.feedback = False\n",
+    "\n",
     "%config SqlMagic.displaycon = False"
    ]
   },
@@ -25,17 +26,60 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%sql --save report_districts\n",
+    "%%sql --save closed_reports --no-execute\n",
     "SELECT \n",
-    "    r.district as district,\n",
-    "    r.assigned_section as section,\n",
-    "    r.primary_statute as classification,\n",
-    "    COUNT(*) count\n",
+    "  DATE(a.timestamp) as date,\n",
+    "  r.assigned_section as section\n",
     "FROM cts_forms_report r\n",
-    "WHERE district notnull AND primary_statute notnull\n",
-    "GROUP BY district, section, classification\n",
-    "HAVING COUNT(*) > 1\n",
-    "ORDER BY count desc"
+    "LEFT JOIN actstream_action a\n",
+    "ON r.id::TEXT = a.target_object_id\n",
+    "WHERE a.verb = 'Status:' and a.description = 'Updated from \"open\" to \"closed\"'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql --save intake_specialists\n",
+    "SELECT \n",
+    "   COUNT(*) \n",
+    "FROM \n",
+    "   auth_user\n",
+    "WHERE is_staff = true AND is_active = true"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_closed_report_count(*, month='6', year='2023'):\n",
+    "    count = %sql --with closed_reports SELECT \\\n",
+    "            COUNT(*) \\\n",
+    "            FROM closed_reports \\\n",
+    "            WHERE \\\n",
+    "            EXTRACT(YEAR FROM date) = '{{ year }}' \\\n",
+    "            AND EXTRACT(MONTH FROM date) = '{{ month }}' \\\n",
+    "\n",
+    "    return count.DataFrame().fillna(0)['count'][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MONTHS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']\n",
+    "monthly_count = []\n",
+    "intake_specialists_sql = %sql --with intake_specialists SELECT count FROM intake_specialists\n",
+    "intake_specialists_count = intake_specialists_sql.DataFrame().fillna(0)['count'][0]\n",
+    "for month in MONTHS:\n",
+    "    count = get_closed_report_count(month=month)\n",
+    "    monthly_count.append(count/intake_specialists_count)"
    ]
   },
   {
@@ -45,30 +89,12 @@
    "outputs": [],
    "source": [
     "import plotly.express as px\n",
-    "\n",
-    "def make_district_chart(section='(any)'):\n",
-    "    results = %sql --with report_districts SELECT * \\\n",
-    "        FROM report_districts \\\n",
-    "        WHERE \\\n",
-    "        '{{section}}' = '(any)' \\\n",
-    "        OR ('{{section}}' != '(any)' AND section='{{section}}');\n",
-    "    df = results.DataFrame()\n",
-    "    fig = px.bar(df, x=\"count\", y=\"district\", color=\"classification\", title=f'Reports by District for: {section}', barmode='group', height=600)\n",
-    "    return fig\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sections = %sql --with report_districts SELECT section FROM report_districts GROUP BY 1;\n",
-    "sections = sections.DataFrame().section\n",
-    "\n",
-    "for section in sections:\n",
-    "    district_chart = make_district_chart(section)\n",
-    "    district_chart.show()\n"
+    "import pandas as pd\n",
+    "df1 = pd.DataFrame(dict(Month=MONTHS))\n",
+    "df2 = pd.DataFrame(dict(velocity=monthly_count))\n",
+    "fig = px.bar(df1, x=df1.Month, y=df2.velocity, title='Reports closed per intake specialist each month 2023', labels={'y':'Reports Closed'})\n",
+    "fig.update_layout(font_size=10, height=500)\n",
+    "fig.show()"
    ]
   }
  ],


### PR DESCRIPTION
[#1564](https://github.com/usdoj-crt/crt-portal-management/issues/1564)

## What does this change?

This adds a report to show the reports closed per intake specialist per month.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
