### PR TITLE
Add new api route for referral flow

### DIFF
--- a/crt_portal/api/urls.py
+++ b/crt_portal/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
-from api.views import ResponseList, ResponseDetail, ReportSummary, ReportCountView, ReportCWs, ReportList, ReportDetail, RelatedReports, FormLettersIndex, api_root, ResponseTemplateFilePreview, ResponseTemplateFormPreview
+from api.views import ResponseList, ResponseDetail, ReportSummary, ReportCountView, ReportCWs, ReportList, ReportDetail, RelatedReports, FormLettersIndex, api_root, ResponseTemplateFilePreview, ResponseTemplateFormPreview, ReferralResponse
 
 app_name = 'api'
 
@@ -17,6 +17,7 @@ urlpatterns = [
     path('report-summary/', ReportSummary.as_view(), name='report-summary'),
     path('related-reports/', RelatedReports.as_view(), name='related-reports'),
     path('form-letters/', FormLettersIndex.as_view(), name='form-letters'),
+    path('referral-response/', ReferralResponse.as_view(), name='referral-response'),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -305,12 +305,7 @@ class ReferralResponse(APIView):
         action = request.data['action']
         preview = {'preview': {}}
         if not action:
-            return JsonResponse(
-                {
-                    'response': 'No action provided',
-                    **preview,
-                  }, status=400
-            )
+            return JsonResponse({'response': 'No action provided', **preview}, status=400)
         if action == 'send':
             try:
                 email_response = crt_send_mail(report, template)

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -7,7 +7,7 @@ from cts_forms.models import Report, ResponseTemplate
 from cts_forms.views import mark_report_as_viewed, mark_reports_as_viewed
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render, get_object_or_404
 from django.template import Context, Template
 from rest_framework import generics
@@ -307,7 +307,7 @@ class ReferralResponse(APIView):
         if not action:
             return JsonResponse(
               {
-                'message': 'No action provided',
+                'response': 'No action provided',
                 **preview,
               }, status=400
               )
@@ -315,9 +315,9 @@ class ReferralResponse(APIView):
             try:
                 email_response = crt_send_mail(report, template)
             except Exception as e:
-                return Response({'response': f'502: Referral email template #{template.id} failed to send to report #{report.id}: {e}', **preview})
+                return JsonResponse({'response': f'Referral email template #{template.id} failed to send to report #{report.id}: {e}', **preview}, status=502)
             if not email_response:
-                return Response({'response': f'502: Referral email template #{template.id} failed to send to report #{report.id}', **preview})
+                return JsonResponse({'response': f'Referral email template #{template.id} failed to send to report #{report.id}', **preview}, status=502)
             return Response({'response': f'Sent referral email template #{template.id} to report #{report.id}', **preview})
         if action == 'copy letter':
             return Response({'response': f'Referral email template #{template.id} copied to clipboard', **preview})

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -305,7 +305,12 @@ class ReferralResponse(APIView):
         action = request.data['action']
         preview = {'preview': {}}
         if not action:
-            return Response({'response': '500: No action provided', **preview})
+            return JsonResponse(
+              {
+                'message': 'No action provided',
+                **preview,
+              }, status=400
+              )
         if action == 'send':
             try:
                 email_response = crt_send_mail(report, template)

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -303,18 +303,18 @@ class ReferralResponse(APIView):
         template_id = request.data['template_id']
         template = get_object_or_404(ResponseTemplate, pk=template_id)
         action = request.data['action']
-        preview = {}
+        preview = {'preview': {}}
+        if not action:
+            return Response({'response': '500: No action provided', **preview})
         if action == 'send':
             try:
                 email_response = crt_send_mail(report, template)
-                if email_response:
-                    response = f'Sent referral email template #{template.id} to report #{report.id}'
-                else:
-                    response = f'Referral email template #{template.id} failed to send to report #{report.id}'
             except Exception as e:
-                response = f'Referral email template #{template.id} failed to send to report #{report.id}: {e}'
+                return Response({'response': f'502: Referral email template #{template.id} failed to send to report #{report.id}: {e}', **preview})
+            if not email_response:
+                return Response({'response': f'502: Referral email template #{template.id} failed to send to report #{report.id}', **preview})
+            return Response({'response': f'Sent referral email template #{template.id} to report #{report.id}', **preview})
         if action == 'copy letter':
-            response = f'Referral email template #{template.id} copied to clipboard'
+            return Response({'response': f'Referral email template #{template.id} copied to clipboard', **preview})
         if action == 'print':
-            response = f'Referral email template #{template.id} printed'
-        return Response({'email_response': response, 'preview': preview})
+            return Response({'response': f'Referral email template #{template.id} printed', **preview})

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -306,11 +306,11 @@ class ReferralResponse(APIView):
         preview = {'preview': {}}
         if not action:
             return JsonResponse(
-              {
-                'response': 'No action provided',
-                **preview,
-              }, status=400
-              )
+                {
+                    'response': 'No action provided',
+                    **preview,
+                  }, status=400
+            )
         if action == 'send':
             try:
                 email_response = crt_send_mail(report, template)

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -313,4 +313,8 @@ class ReferralResponse(APIView):
                     response = f'Referral email template #{template.id} failed to send to report #{report.id}'
             except Exception as e:
                 response = f'Referral email template #{template.id} failed to send to report #{report.id}: {e}'
+        if action == 'copy letter':
+            response = f'Referral email template #{template.id} copied to clipboard'
+        if action == 'print':
+            response = f'Referral email template #{template.id} printed'
         return Response({'email_response': response, 'preview': preview})

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -308,7 +308,7 @@ class ReferralResponse(APIView):
             try:
                 email_response = crt_send_mail(report, template)
                 if email_response:
-                    response = f'Sent email referral template #{template.id} to report #{report.id}'
+                    response = f'Sent referral email template #{template.id} to report #{report.id}'
                 else:
                     response = f'Referral email template #{template.id} failed to send to report #{report.id}'
             except Exception as e:

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -102,6 +102,7 @@
 <script src="{% static 'js/edit_details.min.js' %}"></script>
 <script src="{% static 'js/modal.min.js' %}"></script>
 <script src="{% static 'js/form_letter.min.js' %}"></script>
+<script src="{% static 'js/referral_response.min.js' %}"></script>
 <script src="{% static 'js/restrict_field.min.js' %}"></script>
 <script src="{% static 'js/soft_validation.min.js' %}"></script>
 <script src="{% static 'js/paste_dj_field.min.js' %}"></script>

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -2,6 +2,7 @@
 DRF API Tests
 """
 
+import logging
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.client import Client
@@ -442,7 +443,7 @@ class APIReferralResponseTests(TestCase):
             {"report_id": self.test_report.id, "template_id": self.template.id, "action": "send"}
         )
         self.assertTrue(
-            "email template" in str(response.data)
+            "email template" in str(response.content, 'utf-8')
         )
 
     def test_unauthenticated_referral_response_url(self):

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -2,7 +2,6 @@
 DRF API Tests
 """
 
-import logging
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.client import Client

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -442,6 +442,9 @@ class APIReferralResponseTests(TestCase):
             {"report_id": self.test_report.id, "template_id": self.template.id, "action": "send"}
         )
         self.assertContains(response, "email template")
+        self.assertTrue(
+            "email template" in str(response.data)
+        )
 
     def test_unauthenticated_referral_response_url(self):
         """test report detail not logged in"""

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -441,7 +441,6 @@ class APIReferralResponseTests(TestCase):
             self.url,
             {"report_id": self.test_report.id, "template_id": self.template.id, "action": "send"}
         )
-        self.assertContains(response, "email template")
         self.assertTrue(
             "email template" in str(response.data)
         )

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -441,7 +441,7 @@ class APIReferralResponseTests(TestCase):
             self.url,
             {"report_id": self.test_report.id, "template_id": self.template.id, "action": "send"}
         )
-        self.assertContains(response, "Sent")
+        self.assertContains(response, "email template")
     
     def test_unauthenticated_referral_response_url(self):
         """test report detail not logged in"""

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -421,3 +421,36 @@ class APIRelatedReportsTests(TestCase):
         self.assertTrue('recent_email_sent' in str(response.content))
         self.assertTrue('create_date' in str(response.content))
         self.assertTrue('email' in str(response.content))
+
+
+class APIReferralResponseTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user("DELETE_USER", "george@thebeatles.com", "")
+        self.test_report = Report.objects.create(**SAMPLE_REPORT_1)
+        self.template = ResponseTemplate.objects.create(**SAMPLE_RESPONSE_TEMPLATE)
+        self.url = reverse("api:referral-response")
+
+    def tearDown(self):
+        self.user.delete()
+
+    def test_referral_response(self):
+        """Makes sure our route for sending referral emails works."""
+        self.client.login(username="DELETE_USER", password="")  # nosec
+        response = self.client.post(
+            self.url,
+            {"report_id": self.test_report.id, "template_id": self.template.id, "action": "send"}
+        )
+        self.assertContains(response, "Sent")
+    
+    def test_unauthenticated_referral_response_url(self):
+        """test report detail not logged in"""
+        self.client.logout()
+        response = self.client.post(
+            self.url,
+            {"report_id": self.test_report.id, "template_id": self.template.id, "action": "send"}
+        )
+        self.assertTrue(
+            "Authentication credentials were not provided" in str(response.content)
+        )
+        self.assertEqual(response.status_code, 403)

--- a/crt_portal/static/js/ga_util.js
+++ b/crt_portal/static/js/ga_util.js
@@ -25,7 +25,7 @@ function sendGAClickEvent(event_name) {
       });
     }
     const navItems = document.getElementsByClassName('usa-nav__primary-item');
-    navItems.forEach(navItem => {
+    Array.from(navItems).forEach(navItem => {
       navItem.addEventListener('click', e =>
         sendGAPublicClickEvent('main nav ' + e.target.innerText)
       );

--- a/crt_portal/static/js/referral_response.js
+++ b/crt_portal/static/js/referral_response.js
@@ -1,0 +1,28 @@
+(function(root) {
+  const actionButtons = document.querySelectorAll('.action_button');
+  const report_id = document.getElementById('report-id').value;
+  const template_id = document.getElementById('template-id').value;
+  function getReferralResponse(e) {
+    e.preventDefault();
+    window
+      .fetch('/api/referral-response/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': Cookies.get('csrftoken')
+        },
+        mode: 'same-origin',
+        body: JSON.stringify({ report_id, template_id, action: e.target.innerText.toLowerCase() })
+      })
+      .then(function(response) {
+        return response.json();
+      })
+      .then(function(data) {
+        console.log(data);
+      })
+      .catch(error => {
+        console.log(error);
+      });
+  }
+  actionButtons.forEach(button => button.addEventListener('click', getReferralResponse));
+})(window);


### PR DESCRIPTION
[Issue 1577](https://github.com/usdoj-crt/crt-portal-management/issues/1577)

## What does this change?
This PR adds an API route for the new referral flow so users can send, print, or copy response templates without refreshing the page.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
