### PR TITLE
Add prompts for ports to the standalone script.

### DIFF
--- a/standalone
+++ b/standalone
@@ -46,6 +46,28 @@ shift 2
 
 compose_files="-f docker-compose.yml -f docker-compose.standalone.yml"
 
+if command -v netstat >/dev/null && \
+  [[ -z "$WEB_PORT" ]] || [[ -z "$JUPYTER_PORT" ]] || [[ -z "$DATABASE_PORT" ]]; then
+  echo "(Ports currently in use:)"
+  netstat -natp tcp | grep "\*\." | sort 2>/dev/null
+fi
+
+if [[ -z "$WEB_PORT" ]]; then
+  read -p "Enter a port for the web server [8010]: "
+  WEB_PORT="${REPLY:-8010}"
+fi
+
+if [[ -z "$JUPYTER_PORT" ]]; then
+  read -p "Enter a port for Jupyter [8011]: "
+  JUPYTER_PORT="${REPLY:-8011}"
+fi
+
+if [[ -z "$DATABASE_PORT" ]]; then
+  read -p "Enter a port for the database (leave blank to not bind one): "
+  DATABASE_PORT="$REPLY"
+fi
+
+
 function standalone_compose() {
   # Run in a subshell so as to not pollute environment variables.
   (
@@ -102,6 +124,22 @@ if [[ "$command_to_run" == "setup" ]]; then
     standalone_compose run --rm web python /code/crt_portal/manage.py create_local_oauth --port "$JUPYTER_PORT" >> ".crt-portal-standalone-$project_suffix.env"
     standalone_compose stop jupyter && standalone_compose up -d jupyter
   fi
+
+  read -r -d '' setup_complete <<EOF
+Group $project_suffix has been set up!
+
+Postgres URI, if a database port was specified:
+- DB: postgres://postgres:passwordfortests@localhost:$DATABASE_PORT/postgres
+
+Quick URLs:
+- Landing: http://localhost:$WEB_PORT
+- Intake:  http://localhost:$WEB_PORT/form/view
+- Admin:   http://localhost:$WEB_PORT/admin
+- Jupyter: http://localhost:$JUPYTER_PORT
+
+EOF
+
+  echo "$setup_complete"
 
   exit 0
 fi


### PR DESCRIPTION
## What does this change?

- 🌎 When running standalone docker instances, you can specify ports to bind web, jupyter, and database to.
- ⛔ Right now you have to do that with env variables, which is bulky and annoying.
- ✅ This commit prompts for them if unset, instead. It also attempts to show what ports are currently being bound to (if netstat is installed, which it should be on most standard dev laptop setups).

## Screenshots (for front-end PR):

Excerpts from the new example output:

```
└─ $ ./standalone test setup
(Ports currently in use:)
tcp4       0      0  *.22                   *.*                    LISTEN
tcp46      0      0  *.1025                 *.*                    LISTEN
tcp46      0      0  *.1234                 *.*                    LISTEN
tcp46      0      0  *.4566                 *.*                    LISTEN
tcp46      0      0  *.5432                 *.*                    LISTEN
tcp46      0      0  *.56844                *.*                    LISTEN
tcp46      0      0  *.56845                *.*                    LISTEN
tcp46      0      0  *.56846                *.*                    LISTEN
tcp46      0      0  *.56847                *.*                    LISTEN
tcp46      0      0  *.8000                 *.*                    LISTEN
tcp46      0      0  *.8001                 *.*                    LISTEN
tcp46      0      0  *.8011                 *.*                    LISTEN
tcp46      0      0  *.8012                 *.*                    LISTEN
tcp46      0      0  *.8025                 *.*                    LISTEN
tcp46      0      0  *.9000                 *.*                    LISTEN
tcp6       0      0  *.22                   *.*                    LISTEN
Enter a port for the web server [8010]:
Enter a port for Jupyter [8011]: 8013
Enter a port for the database (leave blank to not bind one): 5433
Bringing up and configuring test, bear with me...
[+] Running 6/6
 ⠿ Container crt-portal-standalone-test-mailhog-1      Running                     0.0s
 ⠿ Container crt-portal-standalone-test-db-1           Started                    11.8s
 ⠿ Container crt-portal-standalone-test-clamav-rest-1  Running                     0.0s
 ⠿ Container crt-portal-standalone-test-localstack-1   Running                     0.0s
 ⠿ Container crt-portal-standalone-test-web-1          Started                    11.9s
 ⠿ Container crt-portal-standalone-test-jupyter-1      Started                     1.5s
All migrations have been applied, continuing!
Create superuser [y/N]? n
Seed the database (100 records) [y/N]? n
Configure Jupyter oauth (and restart jupyter) [y/N]? n
Group test has been set up!

Postgres URI, if a database port was specified:
- DB: postgres://postgres:passwordwouldgohere@localhost:5433/postgres

Quick URLs:
- Landing: http://localhost:8010
- Intake:  http://localhost:8010/form/view
- Admin:   http://localhost:8010/admin
- Jupyter: http://localhost:8013
```

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
