### PR TITLE
Back to all and GA fix

### DIFF
--- a/crt_portal/cts_forms/templates/base.html
+++ b/crt_portal/cts_forms/templates/base.html
@@ -143,7 +143,7 @@
       {% endblock footer_extra %}
     </footer>
     {% endblock %}
-    {% feature_script %}
+    {% feature_script request.csp_nonce %}
     <script src="{% static 'js/url_params_polyfill.min.js' %}"></script>
     <script src="{% static 'vendor/uswds.min.js' %}"></script>
     <script src="{% static 'js/focus_alert.min.js' %}"></script>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/activity-log.html
@@ -39,5 +39,5 @@
 {{ block.super }}
 <script src="{% static 'js/dashboard_quick_view.min.js' %}"></script>
 <script src="{% static 'js/dashboard_view_filters.min.js' %}"></script>
-<script src="{% static 'js/ga_util.js' %}"></script>
+<script src="{% static 'js/ga_util.min.js' %}"></script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/index.html
@@ -30,5 +30,5 @@
 {{ block.super }}
 <script src="{% static 'js/dashboard_quick_view.min.js' %}"></script>
 <script src="{% static 'js/dashboard_view_filters.min.js' %}"></script>
-<script src="{% static 'js/ga_util.js' %}"></script>
+<script src="{% static 'js/ga_util.min.js' %}"></script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/grouped_index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/grouped_index.html
@@ -84,5 +84,5 @@
 <script src="{% static 'js/dashboard_view_all.min.js'%}"></script>
 <script src="{% static 'js/constant_writer.min.js'%}"></script>
 <script src="{% static 'js/paste_dj_field.min.js' %}"></script>
-<script type="module" src="{% static 'js/ga_util.js' %}"></script>
+<script type="module" src="{% static 'js/ga_util.min.js' %}"></script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/index.html
@@ -50,5 +50,5 @@
 <script src="{% static 'js/dashboard_view_all.min.js'%}"></script>
 <script src="{% static 'js/constant_writer.min.js'%}"></script>
 <script src="{% static 'js/paste_dj_field.min.js' %}"></script>
-<script type="module" src="{% static 'js/ga_util.js' %}"></script>
+<script type="module" src="{% static 'js/ga_util.min.js' %}"></script>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/description.html
@@ -32,4 +32,4 @@
     </p>
   </div>
 </div>
-<script src="{% static 'js/ga_util.js' %}"></script>
+<script src="{% static 'js/ga_util.min.js' %}"></script>

--- a/crt_portal/cts_forms/templates/landing.html
+++ b/crt_portal/cts_forms/templates/landing.html
@@ -366,7 +366,7 @@
 {% endblock footer_extra %}
 
 {% block page_js %}
-  <script src="{% static 'js/ga_util.js' %}"></script>
+  <script src="{% static 'js/ga_util.min.js' %}"></script>
   <script src="{% static 'js/modal.min.js' %}"></script>
   <script src="{% static 'js/redirect-modal.min.js' %}"></script>
 {% endblock %}

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -467,7 +467,7 @@ def get_action_data(requested_actions, report_url_args, paginated_offset):
             "detail": action.description,
             "timestamp": action.timestamp,
             "reportid": action.target_object_id,
-            "url": f'/form/view/{action.target_object_id}?next={report_url_args}&index={paginated_offset + index}'
+            "url": f'/form/view/{action.target_object_id}/?next={report_url_args}&index={paginated_offset + index}'
         })
     return data
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -92,8 +92,7 @@ def preserve_filter_parameters(report, querydict):
     index = querydict.get('index', '')
 
     if return_url_args:
-        requested_query = reconstruct_query(return_url_args)
-        requested_ids = list(requested_query.values_list('id', flat=True))
+        requested_ids = get_requested_ids(return_url_args)
         try:
             index = requested_ids.index(report.id)
         except ValueError:
@@ -119,8 +118,7 @@ def setup_filter_parameters(report, querydict):
         index = None
 
     if return_url_args and index is not None:
-        requested_query = reconstruct_query(return_url_args)
-        requested_ids = list(requested_query.values_list('id', flat=True))
+        requested_ids = get_requested_ids(return_url_args)
 
         index = int(index)
         if report.id in requested_ids:
@@ -153,6 +151,31 @@ def setup_filter_parameters(report, querydict):
         })
 
     return output
+
+
+def get_requested_ids(return_url_args):
+    return_url_querydict = QueryDict(return_url_args[1:])
+    activity = return_url_querydict.get('activity', None)
+    if activity:
+        requested_query = reconstruct_activity_query(return_url_args)
+        return list(map(int, requested_query.values_list('target_object_id', flat=True)))
+    requested_query = reconstruct_query(return_url_args)
+    return list(requested_query.values_list('id', flat=True))
+
+
+def reconstruct_activity_query(next_qp):
+    """
+    Reconstruct the query filter on the previous page using the next
+    query parameter. note that if next is empty, the resulting query
+    will return all records.
+    """
+    querydict = QueryDict(next_qp)
+
+    _, selected_actions = dashboard_filter(querydict)
+    sort_expr, _ = activity_sort(querydict.getlist('sort'))
+    if not selected_actions:
+        return selected_actions
+    return selected_actions.order_by(*sort_expr)
 
 
 def mark_report_as_viewed(report, user):
@@ -534,7 +557,7 @@ def serialize_data(report, request, report_id):
     return_url_args = request.GET.get('next', '')
     return_url_args = urllib.parse.unquote(return_url_args)
     querydict = QueryDict(return_url_args).dict()
-    activity = querydict.get('activity', 'false')
+    activity = querydict.get('?activity', None)
 
     output = {
         'actions': ComplaintActions(instance=report),

--- a/crt_portal/features/templatetags/feature_script.py
+++ b/crt_portal/features/templatetags/feature_script.py
@@ -10,7 +10,7 @@ register = template.Library()
 
 
 @register.simple_tag
-def feature_script():
+def feature_script(csp_nonce):
     all_features = Feature.objects.all()
 
     feature_json = json.dumps({
@@ -23,7 +23,7 @@ def feature_script():
     ], separators=(',', ':'))
 
     script = textwrap.dedent(f"""
-        <script nonce="{{ request.csp_nonce }}">
+        <script nonce="{csp_nonce}">
             const ENABLED_FEATURES = {feature_json};
             document.documentElement.classList.add(...{feature_classes});
         </script>

--- a/crt_portal/features/templatetags/feature_script.py
+++ b/crt_portal/features/templatetags/feature_script.py
@@ -23,7 +23,7 @@ def feature_script():
     ], separators=(',', ':'))
 
     script = textwrap.dedent(f"""
-        <script>
+        <script nonce="{{ request.csp_nonce }}">
             const ENABLED_FEATURES = {feature_json};
             document.documentElement.classList.add(...{feature_classes});
         </script>

--- a/crt_portal/features/tests.py
+++ b/crt_portal/features/tests.py
@@ -54,7 +54,7 @@ class FeatureTests(TestCase):
         Feature(name='feature-off').save()
         template = Template(
             '{% load feature_script %}'
-            '{% feature_script %}'
+            '{% feature_script request.csp_nonce %}'
         )
         content = template.render(Context({}))
         self.assertIn('const ENABLED_FEATURES', content)

--- a/crt_portal/static/js/ga_util.js
+++ b/crt_portal/static/js/ga_util.js
@@ -25,7 +25,7 @@ function sendGAClickEvent(event_name) {
       });
     }
     const navItems = document.getElementsByClassName('usa-nav__primary-item');
-    navItems.forEach(navItem => {
+    Array.from(navItems).forEach(navItem => {
       navItem.addEventListener('click', e =>
         sendGAPublicClickEvent('main nav ' + e.target.innerText)
       );

--- a/crt_portal/templates/admin/base_site.html
+++ b/crt_portal/templates/admin/base_site.html
@@ -3,5 +3,5 @@
 {% block extrahead %}
     <link rel="icon" href="{% static "img/favicon.png" %}">
     <script src="{% static 'vendor/turndown.js' %}"></script>
-    {% feature_script %}
+    {% feature_script request.csp_nonce %}
 {% endblock %}


### PR DESCRIPTION
## What does this change?

This PR fixes the back to all button so it directs user to the appropriate page from the individual report page rather than always sending them to the activity dashboard page. An e2e test for the report detail page will be added in another PR.
It also fixes a js error for the GA script.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
