### PR TITLE
Fix ul/li css for django upgrade.

### DIFF
--- a/crt_portal/static/sass/custom/form.scss
+++ b/crt_portal/static/sass/custom/form.scss
@@ -89,7 +89,7 @@ form#cts-forms-profile {
 // Form styles
 .usa-form {
   max-width: 100% !important;
-  ul {
+  div.multicheckboxes-container > div,ul {
     margin-left: 0;
     padding-left: 0;
   }
@@ -131,6 +131,12 @@ form#cts-forms-profile {
     padding-left: 1rem;
     border-left: 2px solid color($theme-color-primary-darker);
 
+    div.multicheckboxes-container > div > div:last-child {
+      height: 25px;
+      margin-bottom: 0 !important;
+      padding-bottom: 0;
+    }
+
     ul > li:last-child {
       height: 25px;
       margin-bottom: 0 !important;
@@ -149,7 +155,7 @@ form#cts-forms-profile {
       margin-top: 0;
     }
 
-    ul {
+    div.multicheckboxes-container > div,ul {
       margin-bottom: 0;
     }
   }
@@ -173,7 +179,7 @@ form#cts-forms-profile {
     }
   }
 
-  li {
+  div.multicheckboxes-container > div > div {
     > .usa-checkbox {
       margin-bottom: 1rem;
       &:last-child {

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -239,16 +239,16 @@
     }
 
     &.intake-checkbox {
-      ul {
+      > div {
         @include flex-container();
         flex-wrap: wrap;
         white-space: normal;
 
-        li {
+        > div {
           margin: 0.5rem;
         }
 
-        li:first-child {
+        > div:first-child {
           margin-left: 0;
         }
 
@@ -323,7 +323,7 @@
       overflow-y: scroll;
       position: relative;
 
-      ul {
+      > div,ul {
         padding: 0;
         margin: 0.5rem;
 


### PR DESCRIPTION
[Issue link](https://github.com/usdoj-crt/crt-portal-management/issues/1587)

## What does this change?

- 🌎 Django 4.2.2 renders checkboxes as divs instead of ul/li
- ⛔ This breaks our custom CSS, because our custom CSS is looking for ul / li
- ✅ This commit adjusts the CSS to target the new div structure as well.

When we do:

```
{{filters.reported_reason}}
```

Old structure (django builds):

```
<div class="multiselectbox-container">
  <ul>
    <li></li>
    <li></li>
    <li></li>
  </ul>
</div>
```

New structure:
```
<div class="multiselectbox-container">
  <div>
    <div></div>
    <div></div>
    <div></div>
  </div>
</div>
```

## Screenshots (for front-end PR):

<img width="1149" alt="image" src="https://github.com/usdoj-crt/crt-portal-management/assets/15126660/3125e2bf-b0c1-48e6-afce-a71d137e6de7">

![submission](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/81e35026-0963-413c-ac59-38e0630082a6)

![a11y](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/b2ea9b27-d29d-4adb-951b-673b04172351)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
