### PR TITLE
Make system vs user comment clearer in activity log

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
@@ -1,5 +1,13 @@
 {% extends "forms/complaint_view/show/card.html" %}
 {% block title %}{{title}}{% endblock %}
+{% block extra_title %}
+  <div class="card-controls">
+    <span class="usa-tooltip" data-position="right" title="Include system messages in the activity log">
+      <input checked="checked" type="checkbox" name="show_system" class="usa-checkbox__input" aria-label="Include system messages in activity" id="id_activity_system">
+      <label for="id_activity_system" class="usa-checkbox__label crt-checkbox__label">System</label>
+    </span>
+  </div>
+{% endblock %}
 {% block icon %}
   <img src="{% static icon %}" alt="" class="icon" />
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream.html
@@ -2,9 +2,9 @@
 {% block title %}{{title}}{% endblock %}
 {% block extra_title %}
   <div class="card-controls">
-    <span class="usa-tooltip" data-position="right" title="Include system messages in the activity log">
-      <input checked="checked" type="checkbox" name="show_system" class="usa-checkbox__input" aria-label="Include system messages in activity" id="id_activity_system">
-      <label for="id_activity_system" class="usa-checkbox__label crt-checkbox__label">System</label>
+    <span class="usa-tooltip" data-position="right" title="Show only comments in the activity log">
+      <input type="checkbox" name="show_comment" class="usa-checkbox__input" aria-label="Show only comments" id="id_activity_comment">
+      <label for="id_activity_comment" class="usa-checkbox__label crt-checkbox__label">Comments only</label>
     </span>
   </div>
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream_item.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/activity_stream_item.html
@@ -6,6 +6,9 @@
     </span>
   </div>
   <p class="margin-top-05">
+    <span class="comment-icon">
+      {% include 'partials/sprite.html' with icon='comment' %}
+    </span>
     {{ activity.verb }}{{ activity.description|linebreaks }}
   </p>
 </li>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -112,4 +112,5 @@
 <script src="{% static 'js/print_report.min.js' %}"></script>
 <script src="{% static 'js/attachments.min.js' %}"></script>
 <script src="{% static 'js/show_count.min.js'%}"></script>
+<script src="{% static 'js/activity_stream.min.js'%}"></script>
 {%endblock%}

--- a/crt_portal/cts_forms/templates/partials/sprite.html
+++ b/crt_portal/cts_forms/templates/partials/sprite.html
@@ -1,0 +1,3 @@
+<svg class="icon" fill="#162e51" aria-hidden="true" focusable="false" role="img">
+  <use xlink:href="{% static 'img/sprite.svg' %}#{{icon}}"></use>
+</svg>

--- a/crt_portal/static/js/activity_stream.js
+++ b/crt_portal/static/js/activity_stream.js
@@ -6,14 +6,14 @@
     });
   };
 
-  const toggleSystem = function() {
+  const toggleComment = function() {
     document.querySelectorAll('.activity-stream-item.system').forEach(item => {
-      item.hidden = !this.checked;
+      item.hidden = this.checked;
     });
-    sendGAClickEvent('activity stream toggle system');
+    sendGAClickEvent('activity stream toggle comment');
   };
-  toggleSystemButton = document.querySelector('#id_activity_system');
-  toggleSystemButton.addEventListener('change', toggleSystem);
+  toggleCommentButton = document.querySelector('#id_activity_comment');
+  toggleCommentButton.addEventListener('change', toggleComment);
 
   root.addEventListener('load', tagComments);
 })(window, document);

--- a/crt_portal/static/js/activity_stream.js
+++ b/crt_portal/static/js/activity_stream.js
@@ -10,6 +10,7 @@
     document.querySelectorAll('.activity-stream-item.system').forEach(item => {
       item.hidden = !this.checked;
     });
+    sendGAClickEvent('activity stream toggle system');
   };
   toggleSystemButton = document.querySelector('#id_activity_system');
   toggleSystemButton.addEventListener('change', toggleSystem);

--- a/crt_portal/static/js/activity_stream.js
+++ b/crt_portal/static/js/activity_stream.js
@@ -1,0 +1,18 @@
+(function(root, dom) {
+  const tagComments = function() {
+    document.querySelectorAll('.activity-stream-item').forEach(item => {
+      const kind = item.innerText.includes('Added comment:') ? 'comment' : 'system';
+      item.classList.add(kind);
+    });
+  };
+
+  const toggleSystem = function() {
+    document.querySelectorAll('.activity-stream-item.system').forEach(item => {
+      item.hidden = !this.checked;
+    });
+  };
+  toggleSystemButton = document.querySelector('#id_activity_system');
+  toggleSystemButton.addEventListener('change', toggleSystem);
+
+  root.addEventListener('load', tagComments);
+})(window, document);

--- a/crt_portal/static/sass/custom/complaint.scss
+++ b/crt_portal/static/sass/custom/complaint.scss
@@ -36,13 +36,27 @@ $complaint-header-min-height: 200px;
 }
 
 .activity-stream {
-  .crt-portal-card__content {
-    max-height: 43.75rem;
+  .crt-portal-card__content ul {
+    max-height: 40rem;
     overflow-y: scroll;
   }
 
   .activity-stream-list {
     .activity-stream-item {
+      svg {
+        width: 1.25rem;
+        height: 1.25rem;
+      }
+
+      .comment-icon {
+        display: none;
+      }
+      &.comment .comment-icon {
+        display: inline-block;
+        padding-top: 5px;
+        vertical-align: middle;
+      }
+
       border-bottom: 1px solid color('gray-cool-20'); // USWDS system color design token: https://designsystem.digital.gov/design-tokens/color/system-tokens/
       padding: 0.5rem 0 0.5rem 0;
 

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -350,6 +350,14 @@
   }
 }
 
+.title .card-controls {
+  margin-left: auto;
+
+  label.usa-checkbox__label {
+    margin-bottom: 1.5rem;
+  }
+}
+
 #intake_print:not([disabled="disabled"]),#intake_copy:not([disabled="disabled"]) {
   background-color: #ecf1f7;
   color: #162e51;


### PR DESCRIPTION
[Issue](https://github.com/usdoj-crt/crt-portal-management/issues/402)

## What does this change?

- 🌎 The activity log show system activity combined with user comments.
- ⛔ This can be confusing because there can be a lot of system
  activity.
- ✅ This commit adds an icon and checkbox for distinguishing user
  comments, or filtering to just user comments

## Screenshots (for front-end PR):

![activity](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/95bb7670-055b-4673-857b-f8afc2b44b2b)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
