### PR TITLE
Fix internal helplinks having popups

### DIFF
--- a/crt_portal/cts_forms/templates/partials/example-accordion.html
+++ b/crt_portal/cts_forms/templates/partials/example-accordion.html
@@ -22,7 +22,12 @@
 
       {% if choice.helplink %}
       <div class="crt-landing--helplink">
-        <a aria-label="{{ choice.helplink.aria_prefix }} {{ choice.helplink.text }}" class="external-link--blue external-link--popup" href="{{ choice.helplink.href }}">{{ choice.helplink.text }}</a>
+        <a
+          aria-label="{{ choice.helplink.aria_prefix }} {{ choice.helplink.text }}"
+          {% if choice.helplink.href|first != '.' and choice.helplink.href|first != '/' %}
+          class="external-link--blue external-link--popup"
+          {% endif %}
+          href="{{ choice.helplink.href }}">{{ choice.helplink.text }}</a>
       </div>
       {% endif %}
 


### PR DESCRIPTION
## What does this change?

- 🌎 External links show a "you are leaving" popup
- ⛔ With the education helplinks, internal links show that, too.
- ✅ This commit fixes it - links starting with `/` or `./` won't show the popup

## Screenshots (for front-end PR):

![activity](https://github.com/usdoj-crt/crt-portal/assets/15126660/6c0d228d-507e-4920-a526-5492b8fadb14)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
