### PR TITLE
Hide Outreach on Print Report

### DIFF
--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):  # pragma: no cover
             report.create_date = date
             salt_chars = salt()
             report.public_id = f'{report.pk}-{salt_chars}'
-            title = random_form_letters[i]
+            title = random_form_letters[i].get('title')
 
             campaign_chance = random.randint(1, 100)  # nosec
             if campaign_chance > 75:

--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -84,6 +84,7 @@ class Command(BaseCommand):  # pragma: no cover
             report.create_date = date
             salt_chars = salt()
             report.public_id = f'{report.pk}-{salt_chars}'
+            title = random_form_letters[i]
 
             campaign_chance = random.randint(1, 100)  # nosec
             if campaign_chance > 75:
@@ -115,7 +116,7 @@ class Command(BaseCommand):  # pragma: no cover
             # 3%
             elif rand <= 3:
                 report.contact_email = "frequentflier2@test.test"
-                add_activity(user1, 'Contacted complainant:', f"Copied '{random_form_letters[i]}' template", report)
+                add_activity(user1, 'Contacted complainant:', f"Copied '{title}' template", report)
                 protected_example = ProtectedClass.objects.get(value=PROTECTED_MODEL_CHOICES[5][0])
                 protected_example2 = ProtectedClass.objects.get(value=PROTECTED_MODEL_CHOICES[6][0])
                 protected_example3 = ProtectedClass.objects.get(value=PROTECTED_MODEL_CHOICES[7][0])
@@ -129,7 +130,7 @@ class Command(BaseCommand):  # pragma: no cover
             # 6%
             elif rand <= 6:
                 report.contact_email = "frequentflier3@test.test"
-                add_activity(user2, 'Contacted complainant:', f"Printed '{random_form_letters[i]}' template", report)
+                add_activity(user2, 'Contacted complainant:', f"Printed '{title}' template", report)
                 protected_example = ProtectedClass.objects.get(value=PROTECTED_MODEL_CHOICES[8][0])
                 protected_example2 = ProtectedClass.objects.get(value=PROTECTED_MODEL_CHOICES[9][0])
                 protected_example3 = ProtectedClass.objects.get(value=PROTECTED_MODEL_CHOICES[10][0])
@@ -145,11 +146,11 @@ class Command(BaseCommand):  # pragma: no cover
                 if report.assigned_section != 'DRS':
                     add_activity(user3, 'Assigned section:', f'Updated from "{report.assigned_section}" to "DRS"', report)
                     report.assigned_section = 'DRS'
-                add_activity(user3, 'Contacted complainant:', f"Email sent: '{random_form_letters[i]}' to {report.contact_email} via govDelivery TMS", report)
-                add_activity(user3, 'Contacted complainant:', f"Email sent: '{random_form_letters[i]}' to {report.contact_email} via govDelivery TMS", report)
-                add_activity(user3, 'Contacted complainant:', f"Email sent: '{random_form_letters[i]}' to {report.contact_email} via govDelivery TMS", report)
-                add_activity(user3, 'Contacted complainant:', f"Email sent: '{random_form_letters[i]}' to {report.contact_email} via govDelivery TMS", report)
-                add_activity(user3, 'Contacted complainant:', f"Email sent: '{random_form_letters[i]}' to {report.contact_email} via govDelivery TMS", report)
+                add_activity(user3, 'Contacted complainant:', f"Email sent: '{title}' to {report.contact_email} via govDelivery TMS", report)
+                add_activity(user3, 'Contacted complainant:', f"Email sent: '{title}' to {report.contact_email} via govDelivery TMS", report)
+                add_activity(user3, 'Contacted complainant:', f"Email sent: '{title}' to {report.contact_email} via govDelivery TMS", report)
+                add_activity(user3, 'Contacted complainant:', f"Email sent: '{title}' to {report.contact_email} via govDelivery TMS", report)
+                add_activity(user3, 'Contacted complainant:', f"Email sent: '{title}' to {report.contact_email} via govDelivery TMS", report)
                 template = ResponseTemplate.objects.get(**random_form_letters[i])
                 crt_send_mail(report, template, TMSEmail.MANUAL_EMAIL, dry_run=True)
                 protected_example = ProtectedClass.objects.get(value=PROTECTED_MODEL_CHOICES[0][0])

--- a/crt_portal/static/js/print_report.js
+++ b/crt_portal/static/js/print_report.js
@@ -1,95 +1,94 @@
-(function(root, dom) {
-  var complaint_page = document.querySelector('.complaint-show-body');
-  var option_mapping_to_section = {
+((root, dom) => {
+  const complaintPage = document.querySelector('.complaint-show-body');
+  const OPTION_MAPPING_TO_SECTION = {
     id_options_0: '.crt-correspondent-card',
     id_options_1: '.crt-report-card',
     id_options_2: '.crt-description-card',
     id_options_3: '.crt-activities-card',
     id_options_4: '.crt-summary-card'
   };
+  const ALWAYS_HIDE = ['.crt-outreach-card'];
 
-  var modal = document.getElementById('print_report');
-  var original_beforeprint = root.onbeforeprint;
-  var original_afterprint = root.onafterprint;
-  var showModal = function(event) {
+  const modal = document.getElementById('print_report');
+  const originalBeforeprint = root.onbeforeprint;
+  const originalAfterprint = root.onafterprint;
+  const showModal = event => {
     event.preventDefault();
-    if (modal.getAttribute('hidden') !== null) {
-      // set up before and after print handlers so that we can
-      // selectively hide or show sections.
-      root.onbeforeprint = function(event) {
-        for (var option_id in option_mapping_to_section) {
-          var el = document.getElementById(option_id);
-          var classname = option_mapping_to_section[option_id];
-          var sections = complaint_page.querySelectorAll(classname);
-          if (!el.checked) {
-            sections.forEach(function(section) {
-              section.setAttribute('hidden', 'hidden');
-            });
-          }
-        }
-      };
-      root.onafterprint = function(event) {
-        for (var option_id in option_mapping_to_section) {
-          var el = document.getElementById(option_id);
-          var classname = option_mapping_to_section[option_id];
-          var sections = complaint_page.querySelectorAll(classname);
-          if (!el.checked) {
-            sections.forEach(function(section) {
-              section.removeAttribute('hidden');
-            });
-          }
-        }
-      };
-      root.CRT.openModal(modal);
-    } else {
-      // reset before and after print handlers.
-      root.onbeforeprint = original_beforeprint;
-      root.onafterprint = original_afterprint;
+
+    if (modal.getAttribute('hidden') === null) {
+      root.onbeforeprint = originalBeforeprint;
+      root.onafterprint = originalAfterprint;
       root.CRT.closeModal(modal);
+      return;
     }
+
+    root.onbeforeprint = event => {
+      Object.entries(OPTION_MAPPING_TO_SECTION).forEach(([optionId, className]) => {
+        const el = document.getElementById(optionId);
+        if (el.checked) return;
+
+        const sections = complaintPage.querySelectorAll(className);
+        sections.forEach(section => {
+          section.setAttribute('hidden', 'hidden');
+        });
+      });
+
+      ALWAYS_HIDE.forEach(className => {
+        complaintPage.querySelectorAll(className).forEach(toHide => {
+          toHide.setAttribute('hidden', 'hidden');
+        });
+      });
+    };
+
+    root.onafterprint = event => {
+      Object.entries(OPTION_MAPPING_TO_SECTION).forEach(([optionId, className]) => {
+        const el = document.getElementById(optionId);
+        const sections = complaintPage.querySelectorAll(className);
+        if (el.checked) return;
+
+        sections.forEach(section => {
+          section.removeAttribute('hidden');
+        });
+      });
+    };
+    root.CRT.openModal(modal);
   };
 
-  var report = document.getElementById('printout_report');
+  const report = document.getElementById('printout_report');
   report.addEventListener('click', showModal);
 
-  var cancel_modal = document.getElementById('print_report_cancel');
-  root.CRT.cancelModal(modal, cancel_modal);
+  const cancelModal = document.getElementById('print_report_cancel');
+  root.CRT.cancelModal(modal, cancelModal);
 
-  // if no options are clicked, disable the print button.
-  var print_buttons = document.querySelectorAll('.print-report-button');
-  for (var option_id in option_mapping_to_section) {
-    var el = document.getElementById(option_id);
-    el.onclick = function(event) {
-      var selected = modal.querySelectorAll('input[type=checkbox]:checked');
-      for (var i = 0; i < print_buttons.length; i++) {
-        var print_button = print_buttons[i];
+  const printButtons = document.querySelectorAll('.print-report-button');
+  Object.keys(OPTION_MAPPING_TO_SECTION).forEach(optionId => {
+    const el = document.getElementById(optionId);
+    el.onclick = event => {
+      const selected = modal.querySelectorAll('input[type=checkbox]:checked');
+      printButtons.forEach(printButton => {
         if (selected.length == 0) {
-          print_button.setAttribute('disabled', 'disabled');
+          printButton.setAttribute('disabled', 'disabled');
         } else {
-          print_button.removeAttribute('disabled');
+          printButton.removeAttribute('disabled');
         }
-      }
+      });
     };
-  }
+  });
 
-  for (var i = 0; i < print_buttons.length; i++) {
-    var print_button = print_buttons[i];
-    print_button.onclick = function(event) {
-      // display extra reports only if user hits "print all"
-      var print_all = event.target.value === 'print_all';
-      var extra_reports = document.querySelectorAll('.bulk-print-report-extra');
-      for (var j = 0; j < extra_reports.length; j++) {
-        var report = extra_reports[j];
-        if (print_all) {
-          report.removeAttribute('hidden');
+  printButtons.forEach(printButton => {
+    printButton.onclick = event => {
+      const printAll = event.target.value === 'print_all';
+      const extraReports = document.querySelectorAll('.bulk-print-report-extra');
+      extraReports.forEach(extraReport => {
+        if (printAll) {
+          extraReport.removeAttribute('hidden');
         } else {
-          report.setAttribute('hidden', 'hidden');
+          extraReport.setAttribute('hidden', 'hidden');
         }
-      }
-      // hide the modal lest we print the modal itself.
+      });
       dom.body.classList.remove('is-modal');
       modal.setAttribute('hidden', 'hidden');
       root.print();
     };
-  }
+  });
 })(window, document);


### PR DESCRIPTION
(per conversation)

## What does this change?

- The title for mock report contact events was showing as {'title': 'etc'} instead of 'etc'.
- Remove the "outreach" panel from the print report view
- Bring print_report.js up to ECMAScript6 standards

## Screenshots (for front-end PR):

Fake report data as example: [printed.pdf](https://github.com/usdoj-crt/crt-portal/files/12044399/prined.pdf)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
