### PR TITLE
Add random DJ numbers to some mock reports.

### DIFF
--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -9,7 +9,7 @@ from pytz import timezone
 import random
 from cts_forms.signals import salt
 from cts_forms.models import EmailReportCount, ProtectedClass, Campaign, ResponseTemplate
-from cts_forms.model_variables import PROTECTED_MODEL_CHOICES, DISTRICT_CHOICES
+from cts_forms.model_variables import PROTECTED_MODEL_CHOICES, DISTRICT_CHOICES, STATUTE_CHOICES
 from cts_forms.forms import add_activity
 from django.contrib.auth.models import User
 from random import randrange
@@ -84,6 +84,13 @@ class Command(BaseCommand):  # pragma: no cover
             report.create_date = date
             salt_chars = salt()
             report.public_id = f'{report.pk}-{salt_chars}'
+
+            dj_number_chance = random.randint(1, 100)  # nosec
+            if dj_number_chance > 90:
+                statute = random.choice(STATUTE_CHOICES)[0]  # nosec
+                district = random.choice(DISTRICT_CHOICES)[0]  # nosec
+                sequence = random.randint(1, 9999)  # nosec
+                report.dj_number = f'{statute}-{district}-{sequence}'
 
             campaign_chance = random.randint(1, 100)  # nosec
             if campaign_chance > 75:


### PR DESCRIPTION
## What does this change?

- 🌎 We want to test features using DJ numbers.
- ⛔ Right now we have to manually add DJ numbers to reports.
- ✅ This commit adds a ~10%~ 9%* chance that DJ numbers will be on mock reports.

## Screenshots (for front-end PR):

Examples of DJ numbers produced when generating 1000 reports:
```
    dj_number    
-----------------
 175-28-7289
 230-60-5127
 188-27-691
 259-51-2432
 ...
(90 rows)
```

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
