### PR TITLE
Be less specific in 422 wording

### DIFF
--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -4,7 +4,7 @@ from cts_forms.tests.integration_util import console
 
 
 @pytest.mark.only_browser("chromium")
-@console.raise_errors(ignore='422 (Unprocessable Entity)')
+@console.raise_errors(ignore='422')
 def test_error_if_form_refreshed(page, base_url):
 
     def next_step():


### PR DESCRIPTION
## What does this change?

Upon merging the integration console error tests to dev, one of the tests is throwing an error.

We were trying to ignore this, but the console messaging is different in dev vs CircleCI and local, so we need to be more generic.

## Screenshots (for front-end PR):

Details: https://app.circleci.com/pipelines/github/usdoj-crt/crt-portal/8512/workflows/6f67bb94-b963-426c-82de-f1b4c6cfb9ed/jobs/11583

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
