### PR TITLE
Fix the Discard Changes button on Dev

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -72,7 +72,7 @@
     </div>
     <div class="intake-section apply-discard">
       <button class="usa-button" type="submit" name='type' value='{{actions.CONTEXT_KEY}}'>Apply changes</button>
-      <button onclick="event.preventDefault();window.location.href = window.location.href" class="outline-button outline-button--blue">Discard changes</button>
+      <button onclick="event.preventDefault();window.location.reload();return false" class="outline-button outline-button--blue">Discard changes</button>
     </div>
     <hr/>
     <div class="intake-section">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -72,7 +72,7 @@
     </div>
     <div class="intake-section apply-discard">
       <button class="usa-button" type="submit" name='type' value='{{actions.CONTEXT_KEY}}'>Apply changes</button>
-      <button onclick="event.preventDefault();window.location.href = window.location.href;" type="button" class="outline-button outline-button--blue">Discard changes</button>
+      <button type="reset" class="outline-button outline-button--blue">Discard changes</button>
     </div>
     <hr/>
     <div class="intake-section">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -72,7 +72,7 @@
     </div>
     <div class="intake-section apply-discard">
       <button class="usa-button" type="submit" name='type' value='{{actions.CONTEXT_KEY}}'>Apply changes</button>
-      <button onclick="event.preventDefault();window.location.reload();return false" type="button" class="outline-button outline-button--blue">Discard changes</button>
+      <button onclick="event.preventDefault();window.location.href = window.location.href;" type="button" class="outline-button outline-button--blue">Discard changes</button>
     </div>
     <hr/>
     <div class="intake-section">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -72,7 +72,7 @@
     </div>
     <div class="intake-section apply-discard">
       <button class="usa-button" type="submit" name='type' value='{{actions.CONTEXT_KEY}}'>Apply changes</button>
-      <button onclick="event.preventDefault();window.location.reload();return false" class="outline-button outline-button--blue">Discard changes</button>
+      <button onclick="event.preventDefault();window.location.reload();return false" type="button" class="outline-button outline-button--blue">Discard changes</button>
     </div>
     <hr/>
     <div class="intake-section">


### PR DESCRIPTION
## What does this change?

- 🌎 Discard changes refreshes the page to "undo" form changes.
- ⛔ On Dev, this is causes a 400, because the form is being submitted.
- ✅ This PR fixes that by using HTML5's `button type="reset"` instead.

Note that I'm unable to reproduce this in my local environment - however, using the chrome inspector to change the button type to "reset" on dev works.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
