### PR TITLE
Lower RAM allocation for portal.

### DIFF
--- a/manifest_dev.yaml
+++ b/manifest_dev.yaml
@@ -3,7 +3,7 @@ applications:
 - name: crt-portal-django
   routes:
   - route: crt-portal-django-dev.app.cloud.gov
-  memory: 2G
+  memory: 512M
   disk_quota: 2G
   instances: 1
   env:

--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -5,7 +5,7 @@ applications:
   - route: crt-portal-django-prod.app.cloud.gov
   - route: civilrights.justice.gov
   - route: www.civilrights.justice.gov
-  memory: 1G
+  memory: 2G
   disk_quota: 2G
   instances: 4
   env:

--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -5,7 +5,7 @@ applications:
   - route: crt-portal-django-prod.app.cloud.gov
   - route: civilrights.justice.gov
   - route: www.civilrights.justice.gov
-  memory: 2G
+  memory: 1G
   disk_quota: 2G
   instances: 4
   env:

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -3,7 +3,7 @@ applications:
 - name: crt-portal-django
   routes:
   - route: crt-portal-django-stage.app.cloud.gov
-  memory: 2G
+  memory: 512M
   disk_quota: 2G
   instances: 2
   env:


### PR DESCRIPTION
🛑 To be merged after discussion

## What does this change?
- 🌎 Portal is allocated a lot of ram
- ⛔ Django uses <256MB on average
- ✅ This commit reduces that usage.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
