### PR TITLE
update clamAV for CI/CD prod

### DIFF
--- a/manifest_prod.yaml
+++ b/manifest_prod.yaml
@@ -32,6 +32,6 @@ applications:
     MAX_FILE_SIZE: 100M
     SIGNATURE_CHECKS: 8
   docker:
-    image: ajilaag/clamav-rest:20230520 # ##20220511
+    image: ajilaag/clamav-rest:20230729 # ##20230520
   routes:
   - route: clamav-rest-prod.apps.internal


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1597)

## What does this change?
This tech task update the clamAV rest image to ajilaag/clamav-rest:20230729 

## Checklist:
CI/CD log for prod should show ajilaag/clamav-rest:20230729 image reference.

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
