### PR TITLE
Referrals: Enable the Print button from the modal

### DIFF
--- a/crt_portal/cts_forms/tests/integration_authed/report_detail.py
+++ b/crt_portal/cts_forms/tests/integration_authed/report_detail.py
@@ -153,6 +153,17 @@ def test_refer_complaint_modal_no_email(page):
     assert element.all_normalized_text(letter_step.locator('.modal-step-content.agency .actions button')) == ['Print letter']
     assert element.all_normalized_text(letter_step.locator('.modal-step-content.complainant .actions button')) == ['Print letter']
 
+    with page.expect_download():
+        letter_step.locator('.modal-step-content.agency .actions button').filter(has_text='Print letter').click()
+    assert letter_step.locator('.agency .usa-alert--success').is_visible()
+
+    with page.expect_download():
+        letter_step.locator('.modal-step-content.complainant .actions button').filter(has_text='Print letter').click()
+    assert letter_step.locator('.complainant .usa-alert--success').is_visible()
+
+    with page.expect_navigation():
+        modal.locator('button').filter(has_text='Return to detail page').click()
+
     admin_models.delete(
         page,
         '/admin/cts_forms/responsetemplate',
@@ -166,7 +177,6 @@ def test_refer_complaint_modal_no_email(page):
 
 
 @pytest.mark.only_browser("chromium")
-@pytest.mark.boop
 @console.raise_errors(ignore=['404', 'The user aborted a request.'])
 @features.login_as_superuser_with_feature('separate-referrals-workflow')
 def test_refer_complaint_modal_with_email(page):

--- a/crt_portal/static/js/refer_modal.js
+++ b/crt_portal/static/js/refer_modal.js
@@ -7,6 +7,10 @@
     return document.getElementById('template-report-id').value;
   }
 
+  function getPublicId() {
+    return document.querySelector('.details-id h2').innerText.replaceAll('ID: ', '');
+  }
+
   function getOpenModalButton() {
     return document.getElementById('refer_complaint');
   }
@@ -243,10 +247,19 @@
     root.CRT.cancelModal(modal, cancelButton);
   }
 
+  function downloadBase64Pdf(filename, content) {
+    const pdfLink = document.createElement('a');
+    pdfLink.setAttribute('download', `${filename}.pdf`);
+    pdfLink.href = `data:application/pdf;base64,${content}`;
+    pdfLink.click();
+    pdfLink.remove();
+  }
+
   function onReply(modal, button, action) {
     const actions = button.closest('.actions');
     const templateId = button.closest('form').querySelector('.template-field select').value;
     const reportId = getReportId();
+    const publicId = getPublicId();
     const sectionClass = button.closest('.modal-step-content').classList;
     let recipient;
     if (sectionClass.contains('agency')) recipient = 'agency';
@@ -260,6 +273,7 @@
         const tag = status >= 300 ? 'error' : 'success';
         root.CRT.showMessage(actions, { tag, content: data.response });
         if (tag !== 'success') return;
+        if (data.pdf) downloadBase64Pdf(`Report ${publicId} (${recipient})`, data.pdf);
         button.disabled = true;
         const actionsTaken = Number(modal.dataset.actionsTaken) + 1;
         modal.dataset.actionsTaken = isNaN(actionsTaken) ? 1 : actionsTaken;


### PR DESCRIPTION
[Issue link](https://github.com/usdoj-crt/crt-portal-management/issues/1590)

## What does this change?

- 🌎 The referral modal lets users send and print referrals.
- ⛔ Right now the print button does nothing!
- ✅ This commit generates printed documents from the server and triggers a browser download on the client.

## Screenshots (for front-end PR):

![referral4](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/7702c606-adc8-41e9-8001-8bc070682070)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
