### PR TITLE
Fix dj number bugs

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -72,7 +72,7 @@
     </div>
     <div class="intake-section apply-discard">
       <button class="usa-button" type="submit" name='type' value='{{actions.CONTEXT_KEY}}'>Apply changes</button>
-      <button type="reset" class="outline-button outline-button--blue">Discard changes</button>
+      <button type="button" onclick="resetChanges()" class="outline-button outline-button--blue">Discard changes</button>
     </div>
     <hr/>
     <div class="intake-section">
@@ -92,6 +92,16 @@
       </button>
     </div>
   </fieldset>
+  <script nonce="{{request.csp_nonce}}">
+    function resetChanges() {
+      const form = document.getElementById('complaint-view-actions');
+      form.reset();
+      [...form.getElementsByClassName('usa-combo-box')].forEach(combobox => {
+        const select = combobox.getElementsByTagName('select')[0];
+        select.nextSibling.value = select.value;
+      });
+    }
+  </script>
 </form>
 
 {% endblock %}


### PR DESCRIPTION
[Issue #1602](https://github.com/usdoj-crt/crt-portal-management/issues/1602)
[Issue #1603](https://github.com/usdoj-crt/crt-portal-management/issues/1603)

## What does this change?

This PR fixes the following two bugs:
1. Currently when "Apply Changes" is clicked in the Complaint Status form the activity log and success message reflect a change to the DJ Number even when no change was made. This PR adds a check to ensure None to None updates are not counted.
2. Currently when "Discard Changes" is clicked in the Complaint Status form and there is a DJ number entered (and saved prior), the first two fields of the DJ and reset but then repopulated when the page is reloaded. This PR ensures that previously saved values to that field are not cleared.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
