### PR TITLE
Only load analytics vars where supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,6 @@ report-data/
 output.csv
 
 jupyterhub/**/.ipynb_checkpoints/
-jupyterhub/jupyterhub.sqlite
+jupyterhub/jupyterhub.sqlite*
 jupyterhub/jupyterhub_cookie_secret
 jupyterhub/jupyterhub-proxy.pid

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -518,11 +518,12 @@ if environment == 'LOCAL':
     except ImportError:
         pass
 
-DATABASES['analytics'] = {  # This must happen after importing local_settings
-    **DATABASES['default'],
-    'USER': os.environ['POSTGRES_ANALYTICS_USER'],
-    'PASSWORD': os.environ['POSTGRES_ANALYTICS_PASSWORD'],
-}
+if os.environ.get('ENV', 'UNDEFINED') in ['LOCAL', 'DEVELOP']:
+    DATABASES['analytics'] = {  # This must happen after importing local_settings
+        **DATABASES['default'],
+        'USER': os.environ['POSTGRES_ANALYTICS_USER'],
+        'PASSWORD': os.environ['POSTGRES_ANALYTICS_PASSWORD'],
+    }
 
 # Don't activate the debug toolbar in a test environment; it can unexpectedly
 # output HTML content that will break test assertions


### PR DESCRIPTION
## What does this change?

Check if we're on dev or local (where Jupyter is currently deployed) before trying to load analytics vars.

Also includes a gitignore change for sqlite.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
