### PR TITLE
Drop Analytics User on Migrate Down

### DIFF
--- a/crt_portal/analytics/models.py
+++ b/crt_portal/analytics/models.py
@@ -47,6 +47,7 @@ def make_analytics_user():
         RunSQLIgnoringErrors(
             f"CREATE USER {user};",
             reverse_sql=f"""
+                REASSIGN OWNED BY {user} TO {superuser};
                 DROP OWNED BY {user};
                 DROP ROLE {user};
             """,

--- a/crt_portal/analytics/models.py
+++ b/crt_portal/analytics/models.py
@@ -46,7 +46,10 @@ def make_analytics_user():
     return [
         RunSQLIgnoringErrors(
             f"CREATE USER {user};",
-            reverse_sql=special.RunSQL.noop,
+            reverse_sql=f"""
+                DROP OWNED BY {user};
+                DROP ROLE {user};
+            """,
         ),
         RunSQLIgnoringErrors(
             f"GRANT CONNECT ON DATABASE {db} TO {user};",

--- a/jupyterhub.Dockerfile
+++ b/jupyterhub.Dockerfile
@@ -1,21 +1,40 @@
-FROM jupyterhub/jupyterhub:3.1.1
-WORKDIR /srv/jupyterhub
+# Pull base image. We use the python image instead of Jupyterhub to be more consistent with available Cloud Foundry buildpacks.
+FROM python:3.11.4
+
+# Brings output to the terminal
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
 
 # Use a shared notebook directory
+RUN mkdir -p ./srv/jupyterhub
+WORKDIR /srv/jupyterhub
 RUN mkdir -p ./assignments
 
 # This must be done as one step to avoid docker caching the update portion:
 RUN \
+  echo "deb https://deb.nodesource.com/node_14.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
+  wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   apt-get -y update && \
   apt-get -y install \
+    git \
     sudo \
     r-base r-base-dev \
-    r-cran-irkernel r-cran-tidyverse r-cran-rpostgresql
+    r-cran-irkernel r-cran-tidyverse r-cran-rpostgresql && \
+  apt-get install -yqq nodejs npm && \
+  pip install -U pip && \
+  pip install pipenv && \
+  pip --version && \
+  npm i -g npm@^8 && \
+  npm -v && \
+  node -v i  && \
+  rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip
-RUN pip install pipenv
+# TODO: Install this from package-lock.json
+RUN npm install -g configurable-http-proxy@^4.5.6
+
 COPY jupyterhub/Pipfile jupyterhub/Pipfile.lock /srv/jupyterhub
 RUN pipenv sync --dev --system
+
 RUN R -e "IRkernel::installspec(user = FALSE)"
 
 COPY jupyterhub/ /srv/jupyterhub/

--- a/jupyterhub/Procfile
+++ b/jupyterhub/Procfile
@@ -1,3 +1,2 @@
 # used by cloud.gov - see: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html
-# iptables is necessary because Jupyter needs to make requests to itself for authentication. Without IP tables, its requests get translated into localhost:80 (which is closed).
 web: mkdir -p assignments && jupyterhub --ip 0.0.0.0 --port $PORT


### PR DESCRIPTION
## What does this change?

Currently, when running this migration twice, an error will occur because the user already exists in the database.

This drops the analytics user when migrating down in order to properly deconstruct this migration.



## Screenshots (for front-end PR):

```sh
└╼ docker compose run web bash
[+] Running 2/0
 ⠿ Container crt-portal-localstack-1  Running                                                                                              0.0s
 ⠿ Container crt-portal-db-1          Running                                                                                              0.0s
root@web:/code# clear^C
root@web:/code# cd crt_portal/
```
```sh
root@web:/code/crt_portal# python manage.py migrate analytics 0001 --fake
Operations to perform:
  Target specific migration: 0001_initial, from analytics
Running migrations:
  Rendering model states... DONE
  Unapplying analytics.0002_dev_access... FAKED
```
```sh
root@web:/code/crt_portal# python manage.py migrate analytics 0002 # this should fail
Operations to perform:
  Target specific migration: 0002_dev_access, from analytics
Running migrations:
  Applying analytics.0002_dev_access...{"message": "Ignoring error in RunSQL (this message can probably be ignored): role \"testanalytics\" already exists\n", "exc_info": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py\", line 87, in _execute\n    return self.cursor.execute(sql)\n           ^^^^^^^^^^^^^^^^^^^^^^^^\npsycopg2.errors.DuplicateObject: role \"testanalytics\" already exists\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/code/crt_portal/analytics/models.py\", line 28, in database_forwards\n    super().database_forwards(*args, **kwargs)\n  File ...
```
```sh
root@web:/code/crt_portal# python manage.py migrate analytics 0002 --fake # Go back, so we can unapply it
Operations to perform:
  Target specific migration: 0002_dev_access, from analytics
Running migrations:
  Applying analytics.0002_dev_access... FAKED
```
```sh
root@web:/code/crt_portal# python manage.py migrate analytics 0001  # Unapply 0002 migration - drop the user
Operations to perform:
  Target specific migration: 0001_initial, from analytics
Running migrations:
  Rendering model states... DONE
  Unapplying analytics.0002_dev_access... OK
```
```sh
root@web:/code/crt_portal# python manage.py migrate analytics # Everything should work now that the user does not exist
Operations to perform:
  Apply all migrations: analytics
Running migrations:
  Applying analytics.0002_dev_access... OK
root@web:/code/crt_portal#
```


## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

Using `--fake` should allow running this "down" migration, and then the corresponding up, regardless of what migrations you've applied so far:

```
python manage.py migrate analytics 0002 --fake
python manage.py migrate analytics zero
python manage.py migrate analytics
```

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
