### PR TITLE
Tweak Referral Recipients

### DIFF
--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -309,6 +309,7 @@ class ResponseAction(APIView):
                 'recipients': complainant_letter.recipients,
                 'subject': complainant_letter.subject,
                 'html_message': complainant_letter.html_message,
+                'disallowed_recipients': complainant_letter.disallowed_recipients or [],
             }
         }
 
@@ -320,6 +321,7 @@ class ResponseAction(APIView):
                 'recipients': referral_letter.recipients,
                 'subject': referral_letter.subject,
                 'html_message': referral_letter.html_message,
+                'disallowed_recipients': referral_letter.disallowed_recipients or [],
             },
             'template': model_to_dict(template),
             'referral_contact': model_to_dict(template.referral_contact),

--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -333,11 +333,10 @@ class ResponseAction(APIView):
         if not template.referral_contact:
             return complainant_letter, None
 
-        extra_ccs = [request.user.email] if request.user.email else []
         agency_letter = render_agency_mail(complainant_letter=complainant_letter,
                                            report=report,
                                            template=template,
-                                           extra_ccs=extra_ccs)
+                                           extra_ccs=[])
         return complainant_letter, agency_letter
 
     def post(self, request) -> JsonResponse:

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/refer_modal_agency_letter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/refer_modal_agency_letter.html
@@ -10,6 +10,9 @@
 <div tabindex="0" class="yes-agency-email modal-subsection">
   <p><strong>Email: </strong><span class="agency email"></span></p>
   <p><strong>CC: </strong><span class="agency ccs"></span></p>
+  <p class="agency blocked-email-hideshow yes-agency-email">
+    <span class="error-message">(emails to <span class="agency blocked-email"></span> will not be sent from this test site)</span>
+  </p>
   <p><strong>Subject: </strong><span class="agency subject"></span></p>
 </div>
 

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/refer_modal_complainant_letter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/refer_modal_complainant_letter.html
@@ -27,6 +27,7 @@
   <strong class="complainant email" data-email="{{data.contact_email|default_if_none:''}}">
     {{data.contact_email|default_if_none:""}}
   </strong>
+  <span class="error-message complainant blocked-email-hideshow">(will not be sent from this test site)</span>
 </p>
 
 <p tabindex="0">

--- a/crt_portal/cts_forms/tests/integration_authed/report_detail.py
+++ b/crt_portal/cts_forms/tests/integration_authed/report_detail.py
@@ -256,7 +256,7 @@ def test_refer_complaint_modal_with_email(page):
     ])
     agency_select.select_option('(es) Referrals integration test - with agency email')
 
-    assert element.normalize_text(letter_step.locator('p').filter(has_text='Email: ')) == 'Email: test@testing.com'
+    assert element.normalize_text(letter_step.locator('p').filter(has_text='Email: ')) == 'Email: test@testing.com (will not be sent from this test site)'
     letter_step.locator('.subject').filter(has_text='Re: [es] your referrals test').wait_for()
     letter_step.locator('.letter-html').filter(has_text='Dear ReferralTestingWithEmail,').wait_for()
 

--- a/crt_portal/static/js/refer_modal.js
+++ b/crt_portal/static/js/refer_modal.js
@@ -113,6 +113,10 @@
     if (letterBox) {
       letterBox.innerHTML = data?.letter?.html_message || 'Message failed to preview.';
     }
+    const blocked = data.letter.disallowed_recipients?.join(', ');
+    modal
+      .querySelectorAll('.complainant.blocked-email-hideshow')
+      .forEach(hideshow => (hideshow.hidden = !blocked || blocked.length <= 0));
   }
 
   function displayAgencyDetails(modal, data) {
@@ -130,7 +134,12 @@
     const yesEmails = document.querySelectorAll('.yes-agency-email');
     const noEmails = document.querySelectorAll('.no-agency-email');
 
-    if (!data.letter.recipients?.length) {
+    const allRecipients = [
+      ...(data.letter.recipients || []),
+      ...(data.letter.disallowed_recipients || [])
+    ];
+
+    if (!allRecipients.length) {
       noEmails.forEach(noEmail => (noEmail.hidden = false));
       yesEmails.forEach(yesEmail => (yesEmail.hidden = true));
       return;
@@ -138,10 +147,16 @@
     noEmails.forEach(noEmail => (noEmail.hidden = true));
     yesEmails.forEach(yesEmail => (yesEmail.hidden = false));
 
-    modal.querySelectorAll('.agency.email').forEach(e => (e.innerText = data.letter.recipients[0]));
+    modal.querySelectorAll('.agency.email').forEach(e => (e.innerText = allRecipients[0] || ''));
     modal.querySelectorAll('.agency.subject').forEach(e => (e.innerText = data.letter.subject));
-    const ccs = data.letter.recipients.slice(1).join(', ');
+    const ccs = allRecipients.slice(1).join(', ');
     modal.querySelectorAll('.agency.ccs').forEach(e => (e.innerText = ccs || ''));
+
+    const blocked = data.letter.disallowed_recipients?.join(', ');
+    modal
+      .querySelectorAll('.agency.blocked-email-hideshow')
+      .forEach(hideshow => (hideshow.hidden = !blocked || blocked.length <= 0));
+    modal.querySelectorAll('.agency.blocked-email').forEach(e => (e.innerText = blocked || ''));
   }
 
   function getComplaintLetterInvalidReasons(modal, { currentStepName, targetStepName }) {


### PR DESCRIPTION
## What does this change?

Two small changes:

- 🌎 The intake specialist is currently cc'd on referral emails.
- ⛔ We want a generic section inbox instead.
- ✅ This commit removes the specialist (current user) from the ccs

- 🌎 We filter out emails in dev sites to prevent sending test emails to real addresses.
- ⛔ This makes it hard to test how something might look in production.
- ✅ This commit shows the emails, but adds warnings when they won't be sent.

## Screenshots (for front-end PR):

- ![2a535290dccee678793de3ce9bdc5cf2](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/6046bdd1-9c0d-46b6-ba5e-72dece6367a4)
- ![5ae7f014fec4cdfc567bbaf69bd88ab5](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/4472f93a-72f5-4a27-ba31-82cde3f240f6)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
