### PR TITLE
Change Jupyterhub docker to use Python docker

### DIFF
--- a/jupyterhub.Dockerfile
+++ b/jupyterhub.Dockerfile
@@ -1,24 +1,45 @@
-FROM jupyterhub/jupyterhub:3.1.1
-WORKDIR /srv/jupyterhub
+# Pull base image. We use the python image instead of Jupyterhub to be more consistent with available Cloud Foundry buildpacks.
+FROM python:3.11.4
+
+# Brings output to the terminal
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
 
 # Use a shared notebook directory
+RUN mkdir -p ./srv/jupyterhub
+WORKDIR /srv/jupyterhub
 RUN mkdir -p ./assignments
 
 # This must be done as one step to avoid docker caching the update portion:
 RUN \
+  echo "deb https://deb.nodesource.com/node_14.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
+  wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   apt-get -y update && \
   apt-get -y install \
+    git \
     sudo \
     r-base r-base-dev \
-    r-cran-irkernel r-cran-tidyverse r-cran-rpostgresql
+    r-cran-irkernel r-cran-tidyverse r-cran-rpostgresql && \
+  apt-get install -yqq nodejs npm && \
+  pip install -U pip && \
+  pip install pipenv && \
+  pip --version && \
+  npm i -g npm@^8 && \
+  npm -v && \
+  node -v i  && \
+  rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip
-RUN pip install pipenv
+COPY jupyterhub/package*.json /srv/jupyterhub/
+RUN npm ci
+
 COPY jupyterhub/Pipfile jupyterhub/Pipfile.lock /srv/jupyterhub
 RUN pipenv sync --dev --system
+
 RUN R -e "IRkernel::installspec(user = FALSE)"
 
 COPY jupyterhub/ /srv/jupyterhub/
+
+RUN ln -s "/srv/jupyterhub/node_modules/.bin/configurable-http-proxy" /usr/bin/configurable-http-proxy
 
 # Run as root to allow JupyterHub to spawn containers and create users.
 USER root

--- a/jupyterhub.Dockerfile
+++ b/jupyterhub.Dockerfile
@@ -29,8 +29,8 @@ RUN \
   node -v i  && \
   rm -rf /var/lib/apt/lists/*
 
-COPY jupyterhub/package*.json /srv/jupyterhub/
-RUN npm ci
+# TODO: Install this from package-lock.json
+RUN npm install -g configurable-http-proxy@^4.5.6
 
 COPY jupyterhub/Pipfile jupyterhub/Pipfile.lock /srv/jupyterhub
 RUN pipenv sync --dev --system
@@ -38,8 +38,6 @@ RUN pipenv sync --dev --system
 RUN R -e "IRkernel::installspec(user = FALSE)"
 
 COPY jupyterhub/ /srv/jupyterhub/
-
-RUN ln -s "/srv/jupyterhub/node_modules/.bin/configurable-http-proxy" /usr/bin/configurable-http-proxy
 
 # Run as root to allow JupyterHub to spawn containers and create users.
 USER root

--- a/jupyterhub/Procfile
+++ b/jupyterhub/Procfile
@@ -1,3 +1,2 @@
 # used by cloud.gov - see: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html
-# iptables is necessary because Jupyter needs to make requests to itself for authentication. Without IP tables, its requests get translated into localhost:80 (which is closed).
 web: mkdir -p assignments && jupyterhub --ip 0.0.0.0 --port $PORT


### PR DESCRIPTION
## What does this change?

- 🌎 We use the jupyterhub/jupyterhub image.
- ⛔ This uses the wrong / nonspecific python version.
- ✅ This commit switches to base our image off the python docker, similar to how cloudfoundry works.

## Screenshots (for front-end PR):

n/a

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
