### PR TITLE
Fix the discard changes button's CSP

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -72,7 +72,7 @@
     </div>
     <div class="intake-section apply-discard">
       <button class="usa-button" type="submit" name='type' value='{{actions.CONTEXT_KEY}}'>Apply changes</button>
-      <button type="button" onclick="resetChanges()" class="outline-button outline-button--blue">Discard changes</button>
+      <button type="button" class="discard outline-button outline-button--blue">Discard changes</button>
     </div>
     <hr/>
     <div class="intake-section">
@@ -92,16 +92,6 @@
       </button>
     </div>
   </fieldset>
-  <script nonce="{{request.csp_nonce}}">
-    function resetChanges() {
-      const form = document.getElementById('complaint-view-actions');
-      form.reset();
-      [...form.getElementsByClassName('usa-combo-box')].forEach(combobox => {
-        const select = combobox.getElementsByTagName('select')[0];
-        select.nextSibling.value = select.value;
-      });
-    }
-  </script>
 </form>
 
 {% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -118,4 +118,5 @@
 <script src="{% static 'js/attachments.min.js' %}"></script>
 <script src="{% static 'js/show_count.min.js'%}"></script>
 <script src="{% static 'js/activity_stream.min.js'%}"></script>
+<script src="{% static 'js/discard_button.min.js'%}"></script>
 {%endblock%}

--- a/crt_portal/static/js/discard_button.js
+++ b/crt_portal/static/js/discard_button.js
@@ -1,0 +1,16 @@
+(function() {
+  function resetChanges(button) {
+    const form = button.closest('form');
+    form.reset();
+    [...form.getElementsByClassName('usa-combo-box')].forEach(combobox => {
+      const select = combobox.getElementsByTagName('select')[0];
+      select.nextSibling.value = select.value;
+    });
+  }
+
+  document.querySelectorAll('.discard').forEach(discardButton => {
+    discardButton.addEventListener('click', () => {
+      resetChanges(discardButton);
+    });
+  });
+})();


### PR DESCRIPTION
[Link to Issue](https://github.com/usdoj-crt/crt-portal-management/issues/1602)

## What does this change?

- 🌎 The discard changes button on the form detail page resets and user-created changes. The DJ button is a special input element, and so needs extra help resetting.
- ⛔ This script was failing on dev because the `onclick` script wasn't loading to set the listener
- ✅ This commit moves the script to a separate file, to satisfy CSP and make it reusable

## Screenshots (for front-end PR):

![discard](https://github.com/usdoj-crt/crt-portal/assets/15126660/dd3dcee2-c1b2-4e82-90dc-ea452c2d72ef)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
