### PR TITLE
Ignore user migration if running tests

### DIFF
--- a/crt_portal/analytics/migrations/0002_dev_access.py
+++ b/crt_portal/analytics/migrations/0002_dev_access.py
@@ -2,6 +2,7 @@
 import os
 
 from django.db import migrations
+from django.conf import settings
 
 from analytics import models
 
@@ -16,7 +17,10 @@ class Migration(migrations.Migration):
         ('analytics', '0001_initial'),
     ]
 
-    if os.environ.get('ENV', 'UNDEFINED') in ['LOCAL', 'DEVELOP']:
+    if settings.TESTING:
+        # The analytics user isn't needed for tests, and having the tests try to create it can break local development.
+        operations = []
+    elif os.environ.get('ENV', 'UNDEFINED') in ['LOCAL', 'DEVELOP']:
         operations = models.make_analytics_user()
     else:
         operations = []


### PR DESCRIPTION
## What does this change?

- 🌎 Locally, migrations can run in the same postgres data for tests and local development
- ⛔ Users are shared across databases, so creating a user in both places causes a failure
- ✅ This commit skips analytics user creation in a test environment

## Screenshots (for front-end PR):

N/A - run local dev server and unit tests, having both point to a local postgres database (the default)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
