### PR TITLE
Add District Edge Cases

### DIFF
--- a/crt_portal/analytics/migrations/0002_dev_access.py
+++ b/crt_portal/analytics/migrations/0002_dev_access.py
@@ -2,6 +2,7 @@
 import os
 
 from django.db import migrations
+from django.conf import settings
 
 from analytics import models
 
@@ -16,7 +17,10 @@ class Migration(migrations.Migration):
         ('analytics', '0001_initial'),
     ]
 
-    if os.environ.get('ENV', 'UNDEFINED') in ['LOCAL', 'DEVELOP']:
+    if settings.TESTING:
+        # The analytics user isn't needed for tests, and having the tests try to create it can break local development.
+        operations = []
+    elif os.environ.get('ENV', 'UNDEFINED') in ['LOCAL', 'DEVELOP']:
         operations = models.make_analytics_user()
     else:
         operations = []

--- a/crt_portal/cts_forms/tests/test_models.py
+++ b/crt_portal/cts_forms/tests/test_models.py
@@ -1,9 +1,12 @@
 """
 Testing multilingual properties used to make messages
 """
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
+from types import SimpleNamespace
 
 from .factories import ReportFactory
+
+from cts_forms.models import JudicialDistrict
 
 
 class ReportSimpleTests(SimpleTestCase):
@@ -42,3 +45,32 @@ class ReportSimpleTests(SimpleTestCase):
         report = ReportFactory.build(contact_last_name="", contact_first_name="")
         expected = "Thank you for your report"
         self.assertEqual(report.addressee, expected)
+
+
+class ReportTests(TestCase):
+    class DistrictEdgeCase(SimpleNamespace):
+        city_user_enters: str
+        expected_correction: str
+
+    district_edge_cases = [
+        DistrictEdgeCase(city_user_enters='normal city',
+                         expected_correction='NORMAL CITY'),
+        DistrictEdgeCase(city_user_enters='st petersburg',
+                         expected_correction='SAINT PETERSBURG'),
+        DistrictEdgeCase(city_user_enters='ft petersburg',
+                         expected_correction='FORT PETERSBURG'),
+        DistrictEdgeCase(city_user_enters='st. petersburg',
+                         expected_correction='SAINT PETERSBURG'),
+        DistrictEdgeCase(city_user_enters='ft. petersburg',
+                         expected_correction='FORT PETERSBURG'),
+    ]
+
+    def test_assign_district_edge_cases(self):
+        for case in self.district_edge_cases:
+            JudicialDistrict.objects.filter(city=case.expected_correction).delete()
+            JudicialDistrict.objects.create(
+                city=case.expected_correction, state='FL', district='123ABC')
+            report = ReportFactory.build(
+                location_city_town=case.city_user_enters, location_state='FL')
+            district = report.assign_district()
+            self.assertEqual(district, '123ABC')

--- a/crt_portal/utils/sanitize.py
+++ b/crt_portal/utils/sanitize.py
@@ -1,0 +1,14 @@
+CITY_PREFIXES = [
+    ('ST', 'SAINT'),
+    ('FT', 'FORT'),
+]
+
+
+def sanitize_city(city: str) -> str:
+    city = city.upper().strip()
+    for prefix, replacement in CITY_PREFIXES:
+        if city.startswith(f'{prefix}.'):
+            return replacement + city.removeprefix(f'{prefix}.')
+        if city.startswith(f'{prefix} '):
+            return replacement + city.removeprefix(f'{prefix}')
+    return city


### PR DESCRIPTION
## What does this change?

- 🌎 Judicial district assignment matches exactly on city name.
- ⛔ Some cities can be written different ways (ft instead of fort, st instead of st).
- ✅ This commit sanitizes `ft` and `st` to be `fort` and `saint`, in a way to be extensible to future abbreviations and sanitization.
- 🔮 Future commits will add more edge cases as we discover them.

## Screenshots (for front-end PR):

N/A (See edge cases in changed tests for examples)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
