### PR TITLE
Allow exporting reports as PDFs

### DIFF
--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -1,10 +1,9 @@
-from django.forms.models import model_to_dict
 from api.filters import form_letters_filter, reports_accessed_filter, autoresponses_filter, report_cws
 from django.utils.html import mark_safe
 from api.serializers import ReportSerializer, ResponseTemplateSerializer, RelatedReportSerializer
 from utils.pdf import convert_html_to_pdf
 from cts_forms.filters import report_filter
-from cts_forms.mail import CustomHTMLExtension, mail_to_complainant, mail_to_agency, render_agency_mail, render_complainant_mail
+from cts_forms.mail import CustomHTMLExtension, mail_to_complainant, mail_to_agency, build_letters, build_preview
 from cts_forms.models import Report, ResponseTemplate
 from cts_forms.views import mark_report_as_viewed, mark_reports_as_viewed
 from cts_forms.forms import add_activity
@@ -303,44 +302,6 @@ class ResponseAction(APIView):
 
     MAIL_SERVICE = "govDelivery TMS"
 
-    def _build_preview(self, template, complainant_letter, referral_letter):
-        complainant = {
-            'letter': {
-                'recipients': complainant_letter.recipients,
-                'subject': complainant_letter.subject,
-                'html_message': complainant_letter.html_message,
-                'disallowed_recipients': complainant_letter.disallowed_recipients or [],
-            }
-        }
-
-        if not referral_letter:
-            return {'complainant': complainant}
-
-        agency = {
-            'letter': {
-                'recipients': referral_letter.recipients,
-                'subject': referral_letter.subject,
-                'html_message': referral_letter.html_message,
-                'disallowed_recipients': referral_letter.disallowed_recipients or [],
-            },
-            'template': model_to_dict(template),
-            'referral_contact': model_to_dict(template.referral_contact),
-        }
-        return {'complainant': complainant, 'agency': agency}
-
-    def _build_letters(self, report, template, request):
-        complainant_letter = render_complainant_mail(report=report,
-                                                     template=template)
-
-        if not template.referral_contact:
-            return complainant_letter, None
-
-        agency_letter = render_agency_mail(complainant_letter=complainant_letter,
-                                           report=report,
-                                           template=template,
-                                           extra_ccs=[])
-        return complainant_letter, agency_letter
-
     def post(self, request) -> JsonResponse:
         report_id = request.data.get('report_id')
         if report_id is None:
@@ -352,10 +313,10 @@ class ResponseAction(APIView):
         template = get_object_or_404(ResponseTemplate, pk=template_id)
         action = request.data['action']
         recipient = request.data.get('recipient', None)
-        complainant_letter, agency_letter = self._build_letters(report, template, request)
+        complainant_letter, agency_letter = build_letters(report, template)
 
         if action == 'preview':
-            preview = self._build_preview(template, complainant_letter, agency_letter)
+            preview = build_preview(template, complainant_letter, agency_letter)
             return JsonResponse(preview)
 
         if action == 'print':

--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -1,5 +1,5 @@
 import types
-from typing import List, Optional
+from typing import List, Optional, Tuple
 import logging
 from django.forms.models import model_to_dict
 import markdown
@@ -13,7 +13,7 @@ from datetime import datetime
 from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
-from cts_forms.models import Report
+from cts_forms.models import Report, ResponseTemplate
 from tms.models import TMSEmail
 
 logger = logging.getLogger(__name__)
@@ -196,3 +196,45 @@ def _build_referral_content(*, complainant_letter, template, report) -> Optional
         'report': model_to_dict(report),
     }
     return render_to_string('referral_info.html', data)
+
+
+def build_preview(template, complainant_letter, referral_letter):
+    """Turns Mails into a jsonable bunch of metadata for sending replies."""
+    complainant = {
+        'letter': {
+            'recipients': complainant_letter.recipients,
+            'subject': complainant_letter.subject,
+            'html_message': complainant_letter.html_message,
+            'disallowed_recipients': complainant_letter.disallowed_recipients or [],
+        }
+    }
+
+    if not referral_letter:
+        return {'complainant': complainant}
+
+    agency = {
+        'letter': {
+            'recipients': referral_letter.recipients,
+            'subject': referral_letter.subject,
+            'html_message': referral_letter.html_message,
+            'disallowed_recipients': referral_letter.disallowed_recipients or [],
+        },
+        'template': model_to_dict(template),
+        'referral_contact': model_to_dict(template.referral_contact),
+    }
+    return {'complainant': complainant, 'agency': agency}
+
+
+def build_letters(report: Report, template: ResponseTemplate) -> Tuple[Mail, Optional[Mail]]:
+    """Creates Mails related to replying to or referring a template."""
+    complainant_letter = render_complainant_mail(report=report,
+                                                 template=template)
+
+    if not template.referral_contact:
+        return complainant_letter, None
+
+    agency_letter = render_agency_mail(complainant_letter=complainant_letter,
+                                       report=report,
+                                       template=template,
+                                       extra_ccs=[])
+    return complainant_letter, agency_letter

--- a/crt_portal/cts_forms/templates/referral_info.html
+++ b/crt_portal/cts_forms/templates/referral_info.html
@@ -58,6 +58,7 @@
 
     <div style="margin-left:1rem; margin-right: 1rem">
 
+      {% if referral_contact %}
       <div style="display: flex; margin-bottom: 2rem">
         <div class="spacer" style="flex-grow: 1"></div>
         <pre style="font-family: unset">{{referral_contact.addressee_text}}</pre>
@@ -66,6 +67,7 @@
       <p><strong>Attn:</strong> {{referral_contact.name}}</p>
       <br/>
       <p>The Department of Justice's Civil Rights Divison has received a complaint we feel is more appropriate for your agency. Please review the following details below:</p>
+      {% endif %}
 
     <h1>Complainant Information</h1>
 
@@ -186,6 +188,7 @@
       </div>
     </p>
 
+      {% if complainant_letter %}
       <h1>Complainant Letter</h1>
       <p>The following is a copy of the letter sent to the complainant:</p>
       <hr/><br/>
@@ -194,6 +197,7 @@
       <div style="border: 1px dashed black">
         {{complainant_letter.html_message | safe}}
       </div>
+      {% endif %}
     </div>
   </body>
 </html>


### PR DESCRIPTION
[Link to issue](https://github.com/usdoj-crt/crt-portal-management/issues/1613)

## What does this change?

- 🌎 We can export reports as CSVs, which is efficient for data analysis
- ⛔ However, CSVs aren't great for individual exports of reports for humans to read
- ✅ This commit adds PDF export
- 🔮 Future commits will improve on the export content (same as referrals ticket)

## Screenshots (for front-end PR):

![Demo](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/a7153001-8b74-412b-8dae-b35e03474859)

[Example export: 1-DXS.pdf](https://github.com/usdoj-crt/crt-portal-management/files/12467533/1-DXS.pdf)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
