### PR TITLE
Clean up routing logic

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -366,54 +366,53 @@ class Report(models.Model):
         'language'
     }
 
-    def __is_not_disabled(self, pcs):
-        return 'disability' not in pcs
+    disability_classes = {
+        'disability'
+    }
 
     def assign_section(self):
         """See the SectionAssignmentTests for expected behaviors"""
         protected_classes = {pc.value for pc in self.protected_class.all()}
+        is_disabled = bool(self.disability_classes & protected_classes)
+        is_only_immigration = bool(protected_classes - self.immigration_classes)
 
         if self.primary_complaint == 'voting':
-            if self.__is_not_disabled(protected_classes):
-                return 'VOT'
-            else:
+            if is_disabled:
                 return 'DRS'
+            return 'VOT'
 
-        elif self.primary_complaint == 'workplace':
+        if self.primary_complaint == 'workplace':
             if not protected_classes:
                 return 'ELS'
-            if protected_classes - self.immigration_classes:
+            if is_only_immigration:
                 return 'ELS'
             return 'IER'
 
-        elif self.primary_complaint == 'commercial_or_public':
-            if not self.__is_not_disabled(protected_classes):
+        if self.primary_complaint == 'commercial_or_public':
+            if is_disabled:
                 return 'DRS'
-            elif self.commercial_or_public_place == 'healthcare':
+            if self.commercial_or_public_place == 'healthcare':
                 return 'SPL'
-            else:
-                return 'HCE'
-
-        elif self.primary_complaint == 'housing':
             return 'HCE'
 
-        elif self.primary_complaint == 'education':
+        if self.primary_complaint == 'housing':
+            return 'HCE'
+
+        if self.primary_complaint == 'education':
             if self.public_or_private_school == 'public' or self.public_or_private_school == 'not_sure':
                 return 'EOS'
-            elif self.__is_not_disabled(protected_classes):
-                return 'EOS'
-            elif self.public_or_private_school == 'private' and not self.__is_not_disabled(protected_classes):
+            if is_disabled:
                 return 'DRS'
+            return 'EOS'
 
-        elif self.primary_complaint == 'police':
-            if self.__is_not_disabled(protected_classes) and self.inside_correctional_facility == 'inside':
+        if self.primary_complaint == 'police':
+            if is_disabled:
+                return 'DRS'
+            if self.inside_correctional_facility == 'inside':
                 return 'SPL'
-            elif self.__is_not_disabled(protected_classes) and self.inside_correctional_facility == 'outside':
-                return 'CRM'
-            else:
-                return 'DRS'
+            return 'CRM'
 
-        elif self.primary_complaint == 'something_else' and not self.__is_not_disabled(protected_classes):
+        if self.primary_complaint == 'something_else' and is_disabled:
             return 'DRS'
 
         return 'ADM'


### PR DESCRIPTION
[Issue link](https://github.com/usdoj-crt/crt-portal-management/issues/1612)

## What does this change?

Code cleanup - no functionality change

- 🌎 We're making some changes to the routing logic.
- ⛔ There are a few antipatterns present making it hard to read
- ✅ This commit fixes a few, including:
  * Unnecessary elif/else after if
  * Avoiding negative variables (if not is_not_disabled -> is_disabled)
  * Treating things as sets / doing set logic to compare unique values

## Screenshots (for front-end PR):

N/A - changes no functionality, tests remain the same.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
