### PR TITLE
Persist the "per-page" option

### DIFF
--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -291,7 +291,9 @@ def render_default_view(request, profile_form, selected_assignee_id, selected_ca
         'selected_assignee_id': selected_assignee_id,
         'selected_origination_utm_campaign': selected_campaign_uuid
     })
-    return render(request, 'forms/complaint_view/index/index.html', final_data)
+    response = render(request, 'forms/complaint_view/index/index.html', final_data)
+    response.set_cookie('complaint_view_per_page', final_data['per_page'])
+    return response
 
 
 def get_group_view_data(request, requested_reports, query_filters, grouping, group_params, desc_id):
@@ -345,7 +347,7 @@ def get_view_data(request, report_query, query_filters):
     requested_reports = report_query.annotate(email_count=F('email_report_count__email_count'))
 
     # Sort data based on request from params, default to `created_date` of complaint
-    per_page = request.GET.get('per_page', 15)
+    per_page = request.GET.get('per_page', request.COOKIES.get('complaint_view_per_page', 15))
     page = request.GET.get('page', 1)
     sort_expr, sorts = report_sort(request.GET.getlist('sort'))
 
@@ -377,6 +379,7 @@ def get_view_data(request, report_query, query_filters):
         'grouping': 'default',
         'page_format': page_format,
         'page_args': page_args,
+        'per_page': per_page,
         'sort_state': sort_state,
         'filter_state': filter_args,
         'filters': query_filters,


### PR DESCRIPTION
This is a quick change to remember the pagination value

## What does this change?

- 🌎 The form has pagination options
- ⛔ Those options are reset when you go to the /form/view page
- ✅ This commit persists "per page"
- 🔮 Future commits may expand this out to some kind of "user profile". This is very naive right now and simply remembers the last "per page" param used, if it was explicitly set, but should be an improvement for most workflows.

## Screenshots (for front-end PR):

Demo shows a few behaviors:
- Setting the pagination value is remembered when re-visiting the list page
- Pages that were previously open with lists of results _don't lose their pagination_
- Clicking "next" on those pages sets a new default pagination value for when you go to a new page (this is something that proper user preferences would improve)

![per_page](https://github.com/usdoj-crt/crt-portal/assets/15126660/60c0aa78-0fc1-40e4-9e58-91464a2cad86)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.

@blaughman fyi