### PR TITLE
Load Dashboards from JSON

### DIFF
--- a/crt_portal/cts_forms/management/commands/dump_dashboards_from_db.py
+++ b/crt_portal/cts_forms/management/commands/dump_dashboards_from_db.py
@@ -1,0 +1,22 @@
+import json
+import os
+
+from analytics.models import get_dashboard_structure_from_db
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+NOTEBOOK_DIR = os.path.join(settings.BASE_DIR, '..', 'jupyterhub')
+
+
+class Command(BaseCommand):  # pragma: no cover
+    help = 'Save the database dashboard state so it can be reloaded.'
+
+    def handle(self, *args, **options):
+        del args, options  # Unused
+
+        structure = get_dashboard_structure_from_db(include_content=False)
+        with open(f'{NOTEBOOK_DIR}/dashboards.json', 'w') as f:
+            json.dump(structure, f, indent=2, sort_keys=True)
+
+        self.stdout.write(self.style.SUCCESS('Wrote ./jupyterhub/dashboards.json'))

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -25,7 +25,7 @@ from django.shortcuts import get_object_or_404, redirect, render, reverse
 from django.utils.html import mark_safe
 from django.views.generic import FormView, TemplateView, View
 from formtools.wizard.views import SessionWizardView
-from analytics.models import get_dashboard_structure
+from analytics.models import get_dashboard_structure_from_db
 from tms.models import TMSEmail
 from datetime import datetime
 
@@ -532,7 +532,7 @@ def data_view(request):
         'forms/complaint_view/data/index.html',
         {
             'profile_form': profile_form,
-            'groups': get_dashboard_structure(),
+            'groups': get_dashboard_structure_from_db(),
             'sections': [choice[0] for choice in SECTION_CHOICES],
         })
 

--- a/jupyterhub/dashboards.json
+++ b/jupyterhub/dashboards.json
@@ -1,0 +1,29 @@
+[
+  {
+    "header": "Submission statistics",
+    "notebooks": [
+      {
+        "path": "assignments/intake-dashboard/assignable.ipynb",
+        "show_only_for_sections": []
+      }
+    ],
+    "order": 0
+  },
+  {
+    "header": "Test Group",
+    "notebooks": [
+      {
+        "path": "assignments/intake-dashboard/only_for_adm.ipynb",
+        "show_only_for_sections": []
+      },
+      {
+        "path": "assignments/intake-dashboard/assignable.ipynb",
+        "show_only_for_sections": [
+          "ADM",
+          "APP"
+        ]
+      }
+    ],
+    "order": 1
+  }
+]

--- a/jupyterhub/dashboards.json
+++ b/jupyterhub/dashboards.json
@@ -3,7 +3,7 @@
     "header": "Submission statistics",
     "notebooks": [
       {
-        "path": "assignments/intake-dashboard/assignable.ipynb",
+        "path": "assignments/intake-dashboard/total_complaints.ipynb",
         "show_only_for_sections": []
       }
     ],


### PR DESCRIPTION
[Issue Link](https://github.com/usdoj-crt/crt-portal-management/issues/1614)

## What does this change?

- Data dashboards were only configurable through the admin panel
- Now we can store them as code, because it's confusing to set them up in the panel

## Screenshots (for front-end PR):

N/A - See dashboards.json

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.

These will be loaded when the following is run (which is already run automatically):

```
docker-compose run web python /code/crt_portal/manage.py update_ipynb_examples
```
