### PR TITLE
Add report location data to dashboard

### DIFF
--- a/jupyterhub/assignments/intake-dashboard/whats_happening_where.ipynb
+++ b/jupyterhub/assignments/intake-dashboard/whats_happening_where.ipynb
@@ -1,0 +1,130 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext sql\n",
+    "%config SqlMagic.feedback = False\n",
+    "%config SqlMagic.displaylimit = 0\n",
+    "%config SqlMagic.displaycon = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "\n",
+    "start = datetime.datetime.now() - datetime.timedelta(days=90)\n",
+    "end = datetime.datetime.now()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql report_locations <<\n",
+    "\n",
+    "SELECT location_name, COUNT(*) count\n",
+    "FROM cts_forms_report\n",
+    "WHERE location_name notnull\n",
+    "GROUP BY location_name\n",
+    "HAVING COUNT(*) > 1\n",
+    "ORDER BY count desc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_location_count(location):\n",
+    "    reports = %sql SELECT * \\\n",
+    "    FROM report_districts \\\n",
+    "    WHERE location_name = '{{location}}';\n",
+    "    \n",
+    "    return reports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display, HTML\n",
+    "\n",
+    "readable_start = start.strftime(\"%B %d, %Y\")\n",
+    "readable_end = end.strftime(\"%B %d, %Y\")\n",
+    "reports = report_locations.DataFrame()\n",
+    "locations = []\n",
+    "for i, location in enumerate(reports[reports['location_name'].notnull()]['location_name'].values):\n",
+    "    count = reports[reports['location_name'] == location]['count'].values[0]\n",
+    "    if i < 10:\n",
+    "        locations.append(\n",
+    "            f'<div class=\"flex-row flex-justify display-flex location-{location}\"><span>{location}</span> <strong>{count}</strong></div><hr/>'\n",
+    "        )\n",
+    "\n",
+    "display(HTML(f\"\"\"\n",
+    "    <div class=\"crt-portal-card light\">\n",
+    "    <h3>Location names and report count</h3>\n",
+    "    <p style=\"font-size: 0.75rem\">\n",
+    "      <em>Repeated report locations submitted between\n",
+    "        <strong>{readable_start}</strong> and\n",
+    "        <strong>{readable_end}</strong>\n",
+    "      </em>\n",
+    "    </p>\n",
+    "    <br />\n",
+    "    {''.join(locations)}\n",
+    "    </div>\n",
+    "\"\"\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "232eb2f6ad4acac17d9e24b6d0f453226823219613976de71a2e8f62915dfec1"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/jupyterhub/assignments/intake-dashboard/whats_happening_where.ipynb
+++ b/jupyterhub/assignments/intake-dashboard/whats_happening_where.ipynb
@@ -2,21 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import warnings\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\", category=FutureWarning)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
     "%load_ext sql\n",
     "%config SqlMagic.feedback = False\n",
     "%config SqlMagic.displaylimit = 0\n",
@@ -48,21 +38,8 @@
     "WHERE location_name notnull\n",
     "GROUP BY location_name\n",
     "HAVING COUNT(*) > 1\n",
-    "ORDER BY count desc"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_location_count(location):\n",
-    "    reports = %sql SELECT * \\\n",
-    "    FROM report_districts \\\n",
-    "    WHERE location_name = '{{location}}';\n",
-    "    \n",
-    "    return reports"
+    "ORDER BY count desc\n",
+    "LIMIT 10"
    ]
   },
   {
@@ -77,12 +54,11 @@
     "readable_end = end.strftime(\"%B %d, %Y\")\n",
     "reports = report_locations.DataFrame()\n",
     "locations = []\n",
-    "for i, location in enumerate(reports[reports['location_name'].notnull()]['location_name'].values):\n",
+    "for location in reports[reports['location_name'].notnull()]['location_name'].values:\n",
     "    count = reports[reports['location_name'] == location]['count'].values[0]\n",
-    "    if i < 10:\n",
-    "        locations.append(\n",
-    "            f'<div class=\"flex-row flex-justify display-flex location-{location}\"><span>{location}</span> <strong>{count}</strong></div><hr/>'\n",
-    "        )\n",
+    "    locations.append(\n",
+    "        f'<div class=\"flex-row flex-justify display-flex location-{location}\"><span>{location}</span> <strong>{count}</strong></div><hr/>'\n",
+    "    )\n",
     "\n",
     "display(HTML(f\"\"\"\n",
     "    <div class=\"crt-portal-card light\">\n",


### PR DESCRIPTION
[Issue 1615](https://github.com/usdoj-crt/crt-portal-management/issues/1615)

## What does this change?
This PR adds a dashboard view of recurring report incident locations for a given period of time.

![image](https://github.com/usdoj-crt/crt-portal-management/assets/18104884/d4f0ae16-0bce-4fb3-952f-40fa122c514f)

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
