### PR TITLE
Fix paths not relative to BASE_DIR

### DIFF
--- a/crt_portal/analytics/models.py
+++ b/crt_portal/analytics/models.py
@@ -285,9 +285,13 @@ class FileGroupAssignment(models.Model):
     show_only_for_sections = models.ManyToManyField(RoutingSection, blank=True, help_text="If set, the notebook will only be displayed for the given section(s). If unset, the notebook will be displayed for all sections.")
 
 
+NOTEBOOK_DIR = os.path.join(settings.BASE_DIR, '..', 'jupyterhub')
+
+
 def get_dashboard_structure_from_json():
     """Returns the dashboard structure from the JSON file."""
-    with open('jupyterhub/dashboards.json', 'r') as f:
+    config = os.path.join(NOTEBOOK_DIR, 'dashboards.json')
+    with open(config, 'r') as f:
         return json.load(f)
 
 

--- a/crt_portal/cts_forms/management/commands/dump_dashboards_from_db.py
+++ b/crt_portal/cts_forms/management/commands/dump_dashboards_from_db.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):  # pragma: no cover
         del args, options  # Unused
 
         structure = get_dashboard_structure_from_db(include_content=False)
-        with open(f'{NOTEBOOK_DIR}/dashboards.json', 'w') as f:
+        with open(os.path.join(NOTEBOOK_DIR, 'dashboards.json'), 'w') as f:
             json.dump(structure, f, indent=2, sort_keys=True)
 
         self.stdout.write(self.style.SUCCESS('Wrote ./jupyterhub/dashboards.json'))


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1614

## What does this change?

- 🌎 The portal in dev and local have different working directories for commands. We use BASE_DIR to account for this.
- ⛔ These paths weren't using BASE_DIR, causing a dev deployment failure
- ✅ This commit fixes / standardizes the paths.
- 🔮 Future commits will also address this in the schedules PR

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
