### PR TITLE
Add a retention label select to the actions panel

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -235,6 +235,9 @@ class RetentionSchedule(models.Model):
     da_number = models.CharField(max_length=255, null=False, blank=False, help_text="The disposition authority number for this schedule (assigned by NARA).")
     is_retired = models.BooleanField(default=False, null=False, help_text="Whether this schedule is no longer active (show as a retired / expired schedule)")
 
+    def __str__(self):
+        return self.name
+
 
 # NOTE: If you add fields to report, they'll automatically be set to empty on the edit form. Make sure to address any additions in ReportEditForm as well!
 class Report(models.Model):

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -62,6 +62,21 @@
         {{ actions.assigned_to }}
       </div>
     </div>
+
+    {% if ENABLED_FEATURES.disposition %}
+    <div class="margin-bottom-2 crt-dropdown">
+      <label for="id_retention_schedule" class="intake-label">
+        {{ actions.fields.retention_schedule.label }}
+      </label>
+      <div class="usa-combo-box" data-placeholder="Assign schedule" data-default-value="{{ actions.retention_schedule.value }}">
+        {{ actions.retention_schedule }}
+      </div>
+    </div>
+    {% else %}
+      <!-- Hidden input as the feature is off, but we don't want to lose the value. -->
+      {{ actions.retention_schedule }}
+    {% endif %}
+
     <div class="margin-bottom-2 crt-checkbox">
       <label class="intake-label">
         {{ actions.fields.referred.label }}


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1629

## What does this change?

- 🌎 We have models for retention labels
- ⛔ We don't have a way to assign those models to reports
- ✅ This commit adds a way to assign them to the status panel
- 🔮 Future commits will add a lit hold checkbox and filters

## Screenshots (for front-end PR):

![schedule](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/65779611-fdb8-444b-83ca-94328b01b09d)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
