### PR TITLE
Add a "litigation hold" checkbox.

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -100,6 +100,16 @@ def get_retention_schedule_widget():
     })
 
 
+def get_litigation_hold_widget():
+    if not Feature.is_feature_enabled('disposition'):
+        return HiddenInput()
+
+    return UsaCheckboxSelectMultiple(attrs={
+        'field_label': 'Litigation Hold',
+        'name': 'litigation_hold',
+    }),
+
+
 class ActivityStreamUpdater(object):
     """Utility functions to update activity stream for all changed fields"""
 
@@ -1519,6 +1529,14 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
             'aria-label': 'Secondary review',
         })
     )
+    litigation_hold = BooleanField(
+        label='Litigation hold',
+        required=False,
+        widget=CheckboxInput(attrs={
+            'class': 'usa-checkbox__input',
+            'aria-label': 'Litigation hold',
+        })
+    )
 
     def field_changed(self, field):
         # if both are Falsy, nothing actually changed (None ~= "")
@@ -1546,6 +1564,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
             'district',
             'assigned_to',
             'retention_schedule',
+            'litigation_hold',
             'referred',
             'dj_number',
         ]
@@ -1618,6 +1637,8 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
             # rename referred if applicable
             if field == 'referred':
                 name = 'Secondary review'
+            if field == 'litigation_hold':
+                name = 'Litigation hold'
             if field == 'dj_number':
                 name = 'ICM DJ Number'
             original = self.initial[field]

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/actions.html
@@ -77,6 +77,20 @@
       {{ actions.retention_schedule }}
     {% endif %}
 
+    {% if ENABLED_FEATURES.disposition %}
+      <div class="margin-bottom-2 crt-checkbox">
+        <label class="intake-label">
+          {{ actions.fields.litigation_hold.label }}
+        </label>
+        {{ actions.litigation_hold }}
+        {# empty label for the checkbox to render using the ::before selector #}
+        <label for="id_litigation_hold" class="usa-checkbox__label crt-checkbox__label"></label>
+      </div>
+    {% else %}
+      <!-- Hidden input as the feature is off, but we don't want to lose the value. -->
+      {{ actions.litigation_hold }}
+    {% endif %}
+
     <div class="margin-bottom-2 crt-checkbox">
       <label class="intake-label">
         {{ actions.fields.referred.label }}

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -44,6 +44,7 @@ class ActionTests(TestCase):
             'dj_number': '39-1-1234',
             'assigned_to': self.user1.pk,
             'retention_schedule': self.schedule1.pk,
+            'litigation_hold': False,
         }
 
     def test_valid(self):
@@ -118,6 +119,21 @@ class ActionTests(TestCase):
 
         self.assertCountEqual(form.get_actions(), [
             ('Retention schedule:', 'Updated from "1 Year" to "3 Year"'),
+        ])
+
+    def test_litigation_hold(self):
+        form = ComplaintActions(
+            initial=self.initial_values,
+            data={
+                **self.initial_values,
+                'litigation_hold': True,
+            }
+        )
+
+        self.assertEqual(form.errors, {})
+
+        self.assertCountEqual(form.get_actions(), [
+            ('Litigation hold:', 'Updated from "False" to "True"'),
         ])
 
     def test_referral(self):


### PR DESCRIPTION
[Issue link](https://github.com/usdoj-crt/crt-portal-management/issues/1629)

## What does this change?

- 🌎 We have a model field for lit hold
- ⛔ We don't have a way to set that in the UI
- ✅ This commit adds a way to the actions pane (under the "disposition" feature flag)
- 🔮 Future commits will restrict this to specific groups, regardless of the flags

## Screenshots (for front-end PR):

![lit hold](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/e3213189-05ef-4028-8d78-83cf35fbd06a)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
