### PR TITLE
Litigation hold filter

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -33,6 +33,7 @@ filter_options = {
     'assigned_to': 'foreign_key',  # aka "Assignee"
     'origination_utm_campaign': 'foreign_key',
     'origination_utm_campaign': 'foreign_key',
+    'litigation_hold': 'eq',
     'location_address_line_1': '__icontains',  # not in filter controls?
     'location_address_line_2': '__icontains',  # not in filter controls?
     'location_city_town': '__icontains',

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1345,6 +1345,14 @@ class Filters(ModelForm):
         widget=get_dj_widget(),
         required=False,
     )
+    litigation_hold = MultipleChoiceField(
+        required=False,
+        label='Litigation hold',
+        choices=((True, 'Yes'),),
+        widget=UsaCheckboxSelectMultiple(attrs={
+            'name': 'litigation_hold',
+        }),
+    )
 
     class Meta:
         model = Report
@@ -1372,6 +1380,7 @@ class Filters(ModelForm):
             'language',
             'correctional_facility_type',
             'dj_number',
+            'litigation_hold',
         ]
 
         labels = {

--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -136,6 +136,7 @@ class Command(BaseCommand):  # pragma: no cover
                     report.assigned_section = 'SPL'
             # 6%
             elif rand <= 6:
+                report.litigation_hold = True
                 report.contact_email = "frequentflier3@test.test"
                 add_activity(user2, 'Contacted complainant:', f"Printed '{title}' template", report)
                 protected_example = ProtectedClass.objects.get(value=PROTECTED_MODEL_CHOICES[8][0])

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -40,6 +40,9 @@
       {% if ENABLED_FEATURES.dj_number %}
         {% include 'forms/complaint_view/index/filters/dj_number.html' %}
       {% endif %}
+      {% if ENABLED_FEATURES.disposition %}
+        {% include 'forms/complaint_view/index/filters/litigation_hold.html' %}
+      {% endif %}
     </div>
     <div class="grid-row flex-wrap flex-justify flex-align-end padding-bottom-5 border-gray-50 border-bottom">
       <div class="grid-col flex-3">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/litigation_hold.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/litigation_hold.html
@@ -1,0 +1,11 @@
+{% extends "forms/complaint_view/index/filter.html" %}
+
+{% block controls %}litigation_hold{% endblock %}
+{% block label %}{{ form.litigation_hold.label }}{% endblock %}
+{% block id %}litigation_hold{% endblock %}
+
+{% block content %}
+  <div id="litigation_hold-filter" class="multicheckboxes-container multicheckboxes-yesno">
+    {{ form.litigation_hold }}
+  </div>
+{% endblock %}

--- a/crt_portal/cts_forms/templatetags/get_field_label.py
+++ b/crt_portal/cts_forms/templatetags/get_field_label.py
@@ -32,6 +32,7 @@ variable_rename = {
     'create_date_start': 'Submission date start',
     'create_date_end': 'Submission date end',
     'actions': 'Actions',
+    'litigation_hold': 'Litigation hold',
 }
 
 

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -414,7 +414,6 @@ class LitigationHoldFilterTests(TestCase):
         test_data['litigation_hold'] = True
         cls.report2 = Report.objects.create(**test_data)
 
-        # test setup for language Chinese traditional
         test_data['litigation_hold'] = False
         cls.report3 = Report.objects.create(**test_data)
 

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -403,6 +403,30 @@ class ReportDjNumberFilterTests(TestCase):
         ])
 
 
+class LitigationHoldFilterTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        test_data = SAMPLE_REPORT_1.copy()
+
+        test_data['litigation_hold'] = True
+        cls.report1 = Report.objects.create(**test_data)
+
+        test_data['litigation_hold'] = True
+        cls.report2 = Report.objects.create(**test_data)
+
+        # test setup for language Chinese traditional
+        test_data['litigation_hold'] = False
+        cls.report3 = Report.objects.create(**test_data)
+
+    def test_no_litigation_hold_filter(self):
+        reports, _ = report_filter(QueryDict('litigation_hold=False'))
+        self.assertEqual(reports.count(), 1)
+
+    def test_litigation_hold_filter(self):
+        reports, _ = report_filter(QueryDict('litigation_hold=True'))
+        self.assertEqual(reports.count(), 2)
+
+
 class FormLettersFilterTests(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -173,7 +173,7 @@
     correctional_facility_type: [],
     grouping: 'default',
     group_params: [],
-    litigation_hold: [],
+    litigation_hold: []
   };
   var filterDataModel = {};
 

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -172,7 +172,8 @@
     contact_phone: '',
     correctional_facility_type: [],
     grouping: 'default',
-    group_params: []
+    group_params: [],
+    litigation_hold: [],
   };
   var filterDataModel = {};
 
@@ -438,6 +439,7 @@
     var languageEl = dom.getElementsByName('language');
     var contactPhoneEL = dom.getElementsByName('contact_phone')[0];
     var correctionalFacilityTypeEl = dom.getElementsByName('correctional_facility_type');
+    var litigationHoldEl = dom.getElementsByName('litigation_hold');
     /**
      * Update the filter data model when the user clears (clicks on) a filter tag,
      * and perform a new search with the updated filters applied.
@@ -615,6 +617,10 @@
     checkBoxView({
       el: correctionalFacilityTypeEl,
       name: 'correctional_facility_type'
+    });
+    checkBoxView({
+      el: litigationHoldEl,
+      name: 'litigation_hold'
     });
   }
 


### PR DESCRIPTION
[Issue 1628](https://github.com/usdoj-crt/crt-portal-management/issues/1628)

## What does this change?
This PR adds a litigation hold filter to the complaint table behind a feature flag "disposition".
## Screenshots (for front-end PR):
![Image](https://github.com/usdoj-crt/crt-portal-management/assets/18104884/eb94c48c-9466-445f-af9b-b2756ff30cb4)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
