### PR TITLE
Fix "Discard Changes" for combo boxes

### DIFF
--- a/crt_portal/static/js/discard_button.js
+++ b/crt_portal/static/js/discard_button.js
@@ -2,9 +2,10 @@
   function resetChanges(button) {
     const form = button.closest('form');
     form.reset();
-    [...form.getElementsByClassName('usa-combo-box')].forEach(combobox => {
-      const select = combobox.getElementsByTagName('select')[0];
-      select.nextSibling.value = select.value;
+    form.querySelectorAll('.usa-combo-box').forEach(combobox => {
+      const rawInput = combobox.querySelector('select');
+      const uswdsInput = combobox.querySelector('input');
+      uswdsInput.value = rawInput.options[rawInput.selectedIndex].text;
     });
   }
 


### PR DESCRIPTION
No issue link - quick fix on top of retention changes.

## What does this change?

- 🌎 The discard changes button currently clears values if already set
- ⛔ This isn't great - "discard" should reset to the previous value,
  not blank value. This happens because the form input is replaced by a
  USWDS select.
- ✅ This commit fixes it by setting the select option value to the form
  input value

## Screenshots (for front-end PR):

Before:
![before](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/fe97b4a6-0486-40bc-a198-bd87acaa2841)

After:
![after](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/851269d6-7e40-475f-9d10-a800806a7c9c)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
