### PR TITLE
Fix Jupyterhub scheduled task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,7 +532,7 @@ jobs:
           command: cf login -u ${CRT_USERNAME_DEV} -p ${CRT_PASSWORD_DEV} -o doj-crtportal -s ${CF_SPACE}
       - run:
           name: run scheduled notebooks
-          command: cf ssh crt-portal-jupyter  -c "python run_scheduled_refresh.py"
+          command: cf ssh crt-portal-jupyter  -c 'export LD_LIBRARY_PATH="$HOME/deps/0/lib:$HOME/deps/1/lib:$HOME/deps/2/lib" && export PATH="$PATH:$HOME/deps/2/python/bin/" && cd /home/vcap/app && python run_scheduled_refresh.py'
 
 commands:
   acquire-lock:

--- a/jupyterhub/run_scheduled_refresh.py
+++ b/jupyterhub/run_scheduled_refresh.py
@@ -1,6 +1,5 @@
 """Automatically refreshes the output of files."""
 
-from django.conf import settings
 from typing import Optional, Dict, List
 from helpers.table_contents_manager import TableContentsManager
 import copy
@@ -11,7 +10,8 @@ import os
 from nbconvert.preprocessors.execute import ExecutePreprocessor
 import nbformat
 
-NOTEBOOK_DIR = os.path.join(settings.BASE_DIR, '..', 'jupyterhub')
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+NOTEBOOK_DIR = os.path.join(BASE_DIR)
 SCHEDULES_PATH = os.path.join(NOTEBOOK_DIR, 'schedules.json')
 
 


### PR DESCRIPTION
## What does this change?

- 🌎 This task works in docker, but fails on dev
- ⛔ It fails on dev because the process can't find `python` due to CF's droplet structure
- ✅ This commit gives the command the context it needs to run python (and the task)

Tested by a manual `cf push` to dev, followed by a manual call of the `cf ssh ...` that's now in circleci

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.