### PR TITLE
Fix typo in cron

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -639,7 +639,7 @@ workflows:
       - dev-jupyter-tasks
     triggers:
       - schedule:
-          cron: "* 0,6,12,18 * * *" # run four times per day
+          cron: "0 0,6,12,18 * * *" # run four times per day
           filters:
             branches:
               only: develop


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

Run "on minute zero of these hours" instead of "every minute"

## Screenshots (for front-end PR):

QA'd using a cron translator:

<img width="861" alt="image" src="https://github.com/usdoj-crt/crt-portal/assets/15126660/671cf906-1736-43c3-915b-f2b779ac1371">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
