### PR TITLE
Don't allow editing reports under lit hold

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -120,7 +120,7 @@ class LitigationHoldLock(object):
         if hasattr(self, 'instance'):
             bad_ids = (
                 [self.instance.public_id]
-                if self.initial.get('litigation_hold', False)
+                if self.instance.litigation_hold
                 else []
             )
         elif hasattr(self, 'queryset'):

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -114,9 +114,9 @@ class LitigationHoldLock(object):
     """Prevents updates to ModelForms with litigation hold set."""
 
     def clean(self, *args, **kwargs):
-        super(LitigationHoldLock, self).clean(*args, **kwargs)
+        superclean = super(LitigationHoldLock, self).clean(*args, **kwargs)
         if self.cleaned_data.get('litigation_hold') is False:
-            return
+            return superclean
         if hasattr(self, 'instance'):
             bad_ids = (
                 [self.instance.public_id]
@@ -129,7 +129,7 @@ class LitigationHoldLock(object):
             raise ValidationError('Litigation hold lock requires either instance or queryset')
 
         if not bad_ids:
-            return
+            return superclean
 
         readable_ids = ', '.join(str(id) for id in bad_ids)
         readable_target = (

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -110,6 +110,37 @@ def get_litigation_hold_widget():
     }),
 
 
+class LitigationHoldLock(object):
+    """Prevents updates to ModelForms with litigation hold set."""
+
+    def clean(self, *args, **kwargs):
+        super(LitigationHoldLock, self).clean(*args, **kwargs)
+        if self.cleaned_data.get('litigation_hold') is False:
+            return
+        if hasattr(self, 'instance'):
+            bad_ids = (
+                [self.instance.public_id]
+                if self.initial.get('litigation_hold', False)
+                else []
+            )
+        elif hasattr(self, 'queryset'):
+            bad_ids = self.queryset.filter(litigation_hold=True).values_list('public_id', flat=True)
+        else:
+            raise ValidationError('Litigation hold lock requires either instance or queryset')
+
+        if not bad_ids:
+            return
+
+        readable_ids = ', '.join(str(id) for id in bad_ids)
+        readable_target = (
+            f'report {readable_ids} while it is'
+            if len(bad_ids) == 1
+            else f'reports {readable_ids} while they are'
+        )
+
+        raise ValidationError(f'No changes can be made to {readable_target} under litigation hold')
+
+
 class ActivityStreamUpdater(object):
     """Utility functions to update activity stream for all changed fields"""
 
@@ -1527,7 +1558,7 @@ class ResponseActions(Form):
         )
 
 
-class ComplaintActions(ModelForm, ActivityStreamUpdater):
+class ComplaintActions(LitigationHoldLock, ModelForm, ActivityStreamUpdater):
     report_closed = False
     CONTEXT_KEY = 'actions'
     assigned_to = ModelChoiceField(
@@ -1745,7 +1776,7 @@ class ComplaintActions(ModelForm, ActivityStreamUpdater):
         return report
 
 
-class ComplaintOutreach(ModelForm, ActivityStreamUpdater):
+class ComplaintOutreach(LitigationHoldLock, ModelForm, ActivityStreamUpdater):
     report_closed = False
     CONTEXT_KEY = 'outreach'
     origination_utm_campaign = ModelChoiceField(
@@ -1884,7 +1915,7 @@ class PrintActions(Form):
     )
 
 
-class BulkActionsForm(Form, ActivityStreamUpdater):
+class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
     EMPTY_CHOICE = 'Multiple'
     assigned_section = ChoiceField(
         label='Section',
@@ -1964,6 +1995,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
 
     def __init__(self, query, *args, **kwargs):
         Form.__init__(self, *args, **kwargs)
+        self.queryset = query
         # set initial values if applicable
         keys = ['assigned_section', 'status', 'primary_statute', 'district']
         for key, initial_value in BulkActionsForm.get_initial_values(query, keys):
@@ -2108,7 +2140,7 @@ class BulkActionsForm(Form, ActivityStreamUpdater):
         return updated_number or len(reports)  # sometimes only a comment is added
 
 
-class ContactEditForm(ModelForm, ActivityStreamUpdater):
+class ContactEditForm(LitigationHoldLock, ModelForm, ActivityStreamUpdater):
     CONTEXT_KEY = 'contact_form'
     SUCCESS_MESSAGE = "Successfully updated contact information."
     FAIL_MESSAGE = "Failed to update contact details."
@@ -2170,7 +2202,7 @@ class ContactEditForm(ModelForm, ActivityStreamUpdater):
         return self.SUCCESS_MESSAGE
 
 
-class ReportEditForm(ProForm, ActivityStreamUpdater):
+class ReportEditForm(LitigationHoldLock, ProForm, ActivityStreamUpdater):
     CONTEXT_KEY = "details_form"
     FAIL_MESSAGE = "Failed to update complaint details."
     SUCCESS_MESSAGE = "Successfully updated complaint details."

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -936,7 +936,11 @@ class ActionsView(LoginRequiredMixin, FormView):
         else:
             for key in bulk_actions_form.errors:
                 errors = '; '.join(bulk_actions_form.errors[key])
-                error_message = f'Could not bulk update {key}: {errors}'
+                if key == '__all__':
+                    target = ':'
+                else:
+                    target = f' {key}:'
+                error_message = f'Could not bulk update {target}: {errors}'
                 messages.add_message(request, messages.ERROR, error_message)
 
             all_ids_count = requested_query.count()

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -770,7 +770,7 @@ class ShowView(LoginRequiredMixin, View):
 
             if not form.is_valid():
                 error_items = ''.join([
-                    f'<li>{field} {form.cleaned_data.get(field)}: {error}</li>'
+                    f'<li>Problem modifying {field if field != "__all__" else "report"}: {error}</li>'
                     for field, error
                     in form.errors.items()
                 ])

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -940,7 +940,7 @@ class ActionsView(LoginRequiredMixin, FormView):
                     target = ':'
                 else:
                     target = f' {key}:'
-                error_message = f'Could not bulk update {target}: {errors}'
+                error_message = f'Could not bulk update{target} {errors}'
                 messages.add_message(request, messages.ERROR, error_message)
 
             all_ids_count = requested_query.count()


### PR DESCRIPTION
[Link to issue](https://github.com/usdoj-crt/crt-portal-management/issues/1640)

## What does this change?

- 🌎 Lit hold reports should not be edited.
- ⛔ Right now they can be.
- ✅ This commit adds server-side validation preventing modification of
  these reports for bulk and non-bulk actions.
- 🔮 Future commits may add a front-end indicator (besides failed
  validation) that these reports are uneditable.

## Screenshots (for front-end PR):

![Image](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/3153367d-5fc1-4626-a06a-4331c313f41f)

![Image](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/30b433ae-1981-44da-85a1-9abaa814ccd2)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
