### PR TITLE
Change 'Print' button on confirmation page

### DIFF
--- a/crt_portal/cts_forms/locale/all/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/all/LC_MESSAGES/django.po
@@ -1148,6 +1148,10 @@ msgstr ""
 msgid "Print report"
 msgstr ""
 
+#: templates/forms/confirmation.html:62
+msgid "Save report"
+msgstr ""
+
 #: templates/forms/confirmation.html:72
 msgid "What to expect"
 msgstr ""

--- a/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/es/LC_MESSAGES/django.po
@@ -1301,7 +1301,11 @@ msgstr "Su número de registro es:"
 
 #: templates/forms/confirmation.html:61
 msgid "Print report"
-msgstr ""
+msgstr "Imprimir reporte"
+
+#: templates/forms/confirmation.html:62
+msgid "Save report"
+msgstr "Guardar reporte"
 
 #: templates/forms/confirmation.html:72
 msgid "What to expect"

--- a/crt_portal/cts_forms/locale/ko/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/ko/LC_MESSAGES/django.po
@@ -1233,6 +1233,10 @@ msgstr "당신의 기록 번호:"
 msgid "Print report"
 msgstr "보고서 출력"
 
+#: templates/forms/confirmation.html:62
+msgid "Save report"
+msgstr "보고서 저장하기"
+
 #: templates/forms/confirmation.html:72
 msgid "What to expect"
 msgstr "추후 상황"

--- a/crt_portal/cts_forms/locale/tl/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/tl/LC_MESSAGES/django.po
@@ -1316,6 +1316,10 @@ msgstr "Ang numero ng iyong tala ay:"
 msgid "Print report"
 msgstr "Ilimbag ang ulat"
 
+#: templates/forms/confirmation.html:62
+msgid "Save report"
+msgstr "I-save ang ulat"
+
 #: templates/forms/confirmation.html:72
 msgid "What to expect"
 msgstr "Ano ang dapat asahan"

--- a/crt_portal/cts_forms/locale/vi/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/vi/LC_MESSAGES/django.po
@@ -1284,6 +1284,10 @@ msgstr "Số hồ sơ của quý vị là:"
 msgid "Print report"
 msgstr "In baìo caìo"
 
+#: templates/forms/confirmation.html:62
+msgid "Save report"
+msgstr "Hãy biết về quyền lợi của mình"
+
 #: templates/forms/confirmation.html:72
 msgid "What to expect"
 msgstr "Những việc sẽ diễn ra"

--- a/crt_portal/cts_forms/locale/vi/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/vi/LC_MESSAGES/django.po
@@ -1286,7 +1286,7 @@ msgstr "In baìo caìo"
 
 #: templates/forms/confirmation.html:62
 msgid "Save report"
-msgstr "Hãy biết về quyền lợi của mình"
+msgstr "Lưu bản báo cáo"
 
 #: templates/forms/confirmation.html:72
 msgid "What to expect"

--- a/crt_portal/cts_forms/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1191,7 +1191,7 @@ msgstr "打印报告"
 
 #: templates/forms/confirmation.html:62
 msgid "Save report"
-msgstr "了解您的权利"
+msgstr "保存报告"
 
 #: templates/forms/confirmation.html:72
 msgid "What to expect"

--- a/crt_portal/cts_forms/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1189,6 +1189,10 @@ msgstr "您的记录号码是："
 msgid "Print report"
 msgstr "打印报告"
 
+#: templates/forms/confirmation.html:62
+msgid "Save report"
+msgstr "了解您的权利"
+
 #: templates/forms/confirmation.html:72
 msgid "What to expect"
 msgstr "后续流程"

--- a/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
@@ -1202,7 +1202,7 @@ msgstr "打印報告"
 
 #: templates/forms/confirmation.html:62
 msgid "Save report"
-msgstr "瞭解您的權利"
+msgstr "保存報告"
 
 #: templates/forms/confirmation.html:72
 msgid "What to expect"

--- a/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/crt_portal/cts_forms/locale/zh_Hant/LC_MESSAGES/django.po
@@ -1200,6 +1200,10 @@ msgstr "您的記錄號碼是："
 msgid "Print report"
 msgstr "打印報告"
 
+#: templates/forms/confirmation.html:62
+msgid "Save report"
+msgstr "瞭解您的權利"
+
 #: templates/forms/confirmation.html:72
 msgid "What to expect"
 msgstr "後續流程"

--- a/crt_portal/cts_forms/templates/forms/confirmation.html
+++ b/crt_portal/cts_forms/templates/forms/confirmation.html
@@ -58,7 +58,10 @@
               <span class="record-number margin-left-1">{{report.public_id}}</span>
             </div>
           </div>
-          <button id="print_button" class="usa-button">{% trans "Print report" %}</button>
+          <div class="display-flex flex-row flex-align-center">
+            <button id="print_button" class="usa-button print-save-btn">{% trans "Print report" %}</button>
+            <button id="save_button" class="text-bold usa-button outline-button outline-button--blue print-save-btn">{% trans "Save report" %}</button>
+          </div>
       </div>
     </div>
   </div>
@@ -210,9 +213,11 @@
   <script src="{% static 'js/modal.min.js' %}"></script>
   <script src="{% static 'js/redirect-modal.min.js' %}"></script>
   <script nonce="{{ request.csp_nonce }}">
-   var print_el = document.getElementById('print_button');
-   print_el.onclick = function() {
+   const btns = document.querySelectorAll('.print-save-btn');
+   btns.forEach(btn => {
+    btn.onclick = function() {
      window.print();
-   };
+    };
+   })
   </script>
 {% endblock %}

--- a/crt_portal/static/sass/custom/confirmation.scss
+++ b/crt_portal/static/sass/custom/confirmation.scss
@@ -72,6 +72,16 @@
   #print_button {
     margin-top: 2rem;
   }
+
+  #save_button {
+    font-weight: 700;
+    font-size: 1rem;
+    margin-top: 2rem;
+
+    &:hover {
+      background-color: #2378c3;
+    }
+  }
 }
 
 section hr {


### PR DESCRIPTION
[#1604](https://github.com/usdoj-crt/crt-portal-management/issues/1604)

## What does this change?
This PR adds a save button to the report submission confirmation page.
## Screenshots (for front-end PR):
![Image](https://github.com/usdoj-crt/crt-portal-management/assets/18104884/8d8751a5-c4bb-478e-98d2-769cd9d6b4f8)
## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
