### PR TITLE
Reset complaint status when section is changed

### DIFF
--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -29,7 +29,7 @@ from .signals import get_client_ip
 
 logger = logging.getLogger(__name__)
 
-EXCLUDED_REPORT_FIELDS = ['violation_summary_search_vector']
+EXCLUDED_REPORT_FIELDS = ['violation_summary_search_vector', 'referral_section']
 REPORT_FIELDS = [field.name for field in Report._meta.fields if field.name not in EXCLUDED_REPORT_FIELDS]
 ACTION_FIELDS = ['timestamp', 'actor', 'verb', 'description', 'target']
 

--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -29,7 +29,7 @@ from .signals import get_client_ip
 
 logger = logging.getLogger(__name__)
 
-EXCLUDED_REPORT_FIELDS = ['violation_summary_search_vector', 'referral_section']
+EXCLUDED_REPORT_FIELDS = ['violation_summary_search_vector']
 REPORT_FIELDS = [field.name for field in Report._meta.fields if field.name not in EXCLUDED_REPORT_FIELDS]
 ACTION_FIELDS = ['timestamp', 'actor', 'verb', 'description', 'target']
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1704,6 +1704,7 @@ class ComplaintActions(LitigationHoldLock, ModelForm, ActivityStreamUpdater):
                 name = 'ICM DJ Number'
             original = self.initial[field]
             changed = self.cleaned_data[field]
+            logging.info(self.cleaned_data)
             # fix bug where id was showing up instead of user name
             if field in ['assigned_to', 'retention_schedule']:
                 if original is None:
@@ -1771,10 +1772,6 @@ class ComplaintActions(LitigationHoldLock, ModelForm, ActivityStreamUpdater):
         if report.closed:
             report.closeout_report()
             self.report_closed = True
-        if report.referred:
-            report.referral_section = report.assigned_section
-        elif report.referral_section:
-            report.referral_section = ''
         if commit:
             report.save()
         return report
@@ -1981,6 +1978,18 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
                 'class': 'usa-textarea',
             },
         ),
+    )
+    retention_schedule = MultipleChoiceField(
+        required=False,
+        label='Retention schedule',
+        choices=[
+            ('', ''),  # Default choice: empty (include everything)
+            ('(none)', 'None'),  # Custom: No assigned campaign.
+            *RETENTION_SCHEDULE_CHOICES,
+        ],
+        widget=UsaCheckboxSelectMultiple(attrs={
+            'name': 'retention_schedule',
+        }),
     )
 
     def get_initial_values(record_query, keys):

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -2018,6 +2018,10 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
             updates['primary_statute'] = None
             updates['assigned_to'] = ''
             updates['status'] = 'new'
+            updates['retention_schedule'] = None
+            updates['referred'] = False
+            updates['dj_number'] = None
+            updates['district'] = None
 
         updates.pop('district', None)  # district is currently disabled (read-only)
         return updates

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1999,6 +1999,7 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
         })
     )
     dj_number = CharField(
+        label='Dj number',
         widget=get_dj_widget(),
         required=False,
     )
@@ -2021,7 +2022,7 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
         Form.__init__(self, *args, **kwargs)
         self.queryset = query
         # set initial values if applicable
-        keys = ['assigned_section', 'status', 'primary_statute', 'district']
+        keys = ['assigned_section', 'status', 'primary_statute', 'dj_number', 'retention_schedule', 'referred', 'district']
         for key, initial_value in BulkActionsForm.get_initial_values(query, keys):
             self.fields[key].initial = initial_value
 
@@ -2037,10 +2038,10 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
         updates = {field: self.cleaned_data[field] for field in self.changed_data}
         # do not allow any fields to be unset. this may happen if the
         # user selects "Multiple".
-        for key in ['assigned_section', 'status', 'primary_statute', 'dj_number']:
+        for key in ['assigned_section', 'status', 'primary_statute', 'dj_number', 'retention_schedule', 'referred']:
             if key in updates and not updates[key]:
                 updates.pop(key)
-        # if section is changed, override assignee and status
+        # if section is changed, override assignee, status, retention schedule, secondary review
         # explicitly, even if they are set by the user.
         if 'assigned_section' in updates:
             updates['primary_statute'] = None
@@ -2049,7 +2050,6 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
             updates['retention_schedule'] = None
             updates['referred'] = False
             updates['dj_number'] = None
-            updates['district'] = None
 
         updates.pop('district', None)  # district is currently disabled (read-only)
         return updates
@@ -2075,7 +2075,9 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
             descriptions.append(description)
         if len(descriptions) > 1:
             descriptions[-1] = f'and {descriptions[-1]}'
-        return ', '.join(descriptions) or 'comment added'
+        final_description = ', '.join(descriptions) or 'comment added'
+        logging.info(final_description)
+        return final_description
 
     def get_actions(self, report):
         """

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -2025,11 +2025,19 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
         for key, initial_value in BulkActionsForm.get_initial_values(query, keys):
             self.fields[key].initial = initial_value
 
+    def clean_dj_number(self):
+        dj_number = self.cleaned_data.get('dj_number', None)
+        if not dj_number:
+            return None
+        if any(not c for c in dj_number.rsplit('-', 2)):
+            return None
+        return dj_number
+
     def get_updates(self):
         updates = {field: self.cleaned_data[field] for field in self.changed_data}
         # do not allow any fields to be unset. this may happen if the
         # user selects "Multiple".
-        for key in ['assigned_section', 'status', 'primary_statute']:
+        for key in ['assigned_section', 'status', 'primary_statute', 'dj_number']:
             if key in updates and not updates[key]:
                 updates.pop(key)
         # if section is changed, override assignee and status

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1704,7 +1704,6 @@ class ComplaintActions(LitigationHoldLock, ModelForm, ActivityStreamUpdater):
                 name = 'ICM DJ Number'
             original = self.initial[field]
             changed = self.cleaned_data[field]
-            logging.info(self.cleaned_data)
             # fix bug where id was showing up instead of user name
             if field in ['assigned_to', 'retention_schedule']:
                 if original is None:

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1990,6 +1990,18 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
             'name': 'retention_schedule',
         }),
     )
+    referred = BooleanField(
+        label='Secondary review',
+        required=False,
+        widget=CheckboxInput(attrs={
+            'class': 'usa-checkbox__input',
+            'aria-label': 'Secondary review',
+        })
+    )
+    dj_number = CharField(
+        widget=get_dj_widget(),
+        required=False,
+    )
 
     def get_initial_values(record_query, keys):
         """

--- a/crt_portal/cts_forms/management/commands/generate_yearly_reports.py
+++ b/crt_portal/cts_forms/management/commands/generate_yearly_reports.py
@@ -10,7 +10,7 @@ from pytz import timezone
 
 from ...admin import iter_queryset, _serialize_report_export
 
-EXCLUDED_REPORT_FIELDS = ['violation_summary_search_vector']
+EXCLUDED_REPORT_FIELDS = ['violation_summary_search_vector', 'referral_section']
 REPORT_FIELDS = [field.name for field in Report._meta.fields if field.name not in EXCLUDED_REPORT_FIELDS]
 
 

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -370,6 +370,7 @@ class Report(models.Model):
 
     # referrals
     referred = models.BooleanField(default=False)
+    referral_section = models.TextField(choices=SECTION_CHOICES, blank=True)
 
     litigation_hold = models.BooleanField(default=False)
     retention_schedule = models.ForeignKey(RetentionSchedule, blank=True, null=True, related_name="reports", on_delete=models.SET_NULL)

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -544,6 +544,10 @@ class Report(models.Model):
         self.assigned_to = None
         self.status = 'new'
         self.primary_statute = None
+        self.retention_schedule = None
+        self.referred = False
+        self.dj_number = None
+        self.district = None
 
     @cached_property
     def related_reports(self):

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -370,7 +370,6 @@ class Report(models.Model):
 
     # referrals
     referred = models.BooleanField(default=False)
-    referral_section = models.TextField(choices=SECTION_CHOICES, blank=True)
 
     litigation_hold = models.BooleanField(default=False)
     retention_schedule = models.ForeignKey(RetentionSchedule, blank=True, null=True, related_name="reports", on_delete=models.SET_NULL)
@@ -537,7 +536,7 @@ class Report(models.Model):
         local_tz = pytz.timezone('US/Eastern')
         self.closed_date = datetime.now(local_tz)
 
-    def status_assignee_reset(self):
+    def reset_for_changed_section(self):
         """
         Remove assignee and update status to new
         """

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -790,14 +790,14 @@ class ReportActionTests(TestCase):
         self.client.login(username='DELETE_USER', password=self.test_pass)
         self.report = Report.objects.create(**SAMPLE_REPORT_1)
 
-    def test_referral_section_checked(self):
-        self.assertEqual(self.report.referral_section, '')
+    def test_secondary_review_checked(self):
         url = reverse('crt_forms:crt-forms-show', kwargs={'id': self.report.id})
         params = {
             'type': 'actions',
             # Keep the same status as when the report was created.
             'status': NEW_STATUS,
             'referred': 'on',
+            'assigned_section': 'ADM',
         }
         response = self.client.post(url, params, follow=True)
         content = str(response.content)
@@ -806,11 +806,9 @@ class ReportActionTests(TestCase):
         self.assertTrue(escape('Updated from "False" to "True"') in content)
         self.report.refresh_from_db()
         self.assertTrue(self.report.referred)
-        self.assertEqual(self.report.referral_section, 'ADM')
 
-    def test_referral_section_unchecked(self):
+    def test_secondary_review_unchecked(self):
         self.report.referred = True
-        self.report.referral_section = 'ADM'
         self.report.save()
         url = reverse('crt_forms:crt-forms-show', kwargs={'id': self.report.id})
         params = {
@@ -826,7 +824,6 @@ class ReportActionTests(TestCase):
         self.assertTrue(escape('Updated from "True" to "False"') in content)
         self.report.refresh_from_db()
         self.assertFalse(self.report.referred)
-        self.assertEqual(self.report.referral_section, '')
 
     def test_assign_report_to_user(self):
         url = reverse('crt_forms:crt-forms-show', kwargs={'id': self.report.id})

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -1014,7 +1014,7 @@ class BulkActionsTests(TestCase):
         ids = [report.id for report in self.reports[3:5]]
         response = self.post(ids, assigned_to=self.user.id, comment='a comment', assigned_section='VOT', status='closed')
         content = str(response.content)
-        self.assertTrue(escape("2 records have been updated: section set to VOT, status set to new, assigned to '', and primary classification set to ''") in content)
+        self.assertTrue(escape("2 records have been updated: section set to VOT, status set to new, assigned to '', dj_number set to '', primary classification set to '', retention schedule set to '', and secondary review set to ''") in content)
         self.assertEqual(response.request['PATH_INFO'], reverse('crt_forms:crt-forms-index'))
         for report_id in ids:
             report = Report.objects.get(id=report_id)
@@ -1081,8 +1081,7 @@ class BulkActionsTests(TestCase):
         for report_id in ids:
             report = Report.objects.get(id=report_id)
             last_activity = list(report.target_actions.all())[-1]
-            self.assertEqual(last_activity.verb, "Added comment: ")
-            self.assertEqual(last_activity.description, 'a comment')
+            self.assertEqual(last_activity.verb, "Dj number:")
             self.assertEqual(last_activity.actor, self.user)
 
     def test_post_with_email_count_sort(self):

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -1014,7 +1014,7 @@ class BulkActionsTests(TestCase):
         ids = [report.id for report in self.reports[3:5]]
         response = self.post(ids, assigned_to=self.user.id, comment='a comment', assigned_section='VOT', status='closed')
         content = str(response.content)
-        self.assertTrue(escape("2 records have been updated: section set to VOT, status set to new, assigned to '', dj_number set to '', primary classification set to '', retention schedule set to '', and secondary review set to ''") in content)
+        self.assertTrue(escape("2 records have been updated: section set to VOT, status set to new, assigned to '', primary classification set to '', retention schedule set to '', secondary review set to '', and dj number set to ''") in content)
         self.assertEqual(response.request['PATH_INFO'], reverse('crt_forms:crt-forms-index'))
         for report_id in ids:
             report = Report.objects.get(id=report_id)
@@ -1081,7 +1081,7 @@ class BulkActionsTests(TestCase):
         for report_id in ids:
             report = Report.objects.get(id=report_id)
             last_activity = list(report.target_actions.all())[-1]
-            self.assertEqual(last_activity.verb, "Dj number:")
+            self.assertEqual(last_activity.verb, "Added comment: ")
             self.assertEqual(last_activity.actor, self.user)
 
     def test_post_with_email_count_sort(self):

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -790,7 +790,7 @@ class ShowView(LoginRequiredMixin, View):
         # Reset Assignee and Status if assigned_section is changed
         if 'assigned_section' in form.changed_data:
             primary_statute = report.primary_statute
-            report.status_assignee_reset()
+            report.reset_for_changed_section()
             if primary_statute:
                 description = f'Updated from "{primary_statute}" to "None"'
                 add_activity(request.user, "Primary classification:", description, report)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -925,6 +925,7 @@ class ActionsView(LoginRequiredMixin, FormView):
             description = bulk_actions_form.get_update_description()
             plural = 's have' if number > 1 else ' has'
             message = f'{number} record{plural} been updated: {description}'
+            logging.info(message)
             messages.add_message(request, messages.SUCCESS, message)
 
             # log this action for an audit trail.


### PR DESCRIPTION
[#1645](https://github.com/usdoj-crt/crt-portal-management/issues/1645)

## What does this change?
This updates the bulk action and individual report change logic to reset judicial district, ICM DJ #, retention schedule, and secondary review to their default value when the section is changed.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
