### PR TITLE
Unset GROUP_CLAIM

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -305,7 +305,8 @@ if environment in ['PRODUCTION', 'STAGE']:
                           "last_name": "surname",
                           "email": "emailaddress"},
         "USERNAME_CLAIM": AUTH_USERNAME_CLAIM,
-        "GROUP_CLAIM": AUTH_GROUP_CLAIM,
+        # Explicitly DON'T set a group claim, as it will undo our native groups.
+        # "GROUP_CLAIM": AUTH_GROUP_CLAIM,
         'LOGIN_EXEMPT_URLS': [
             '^$',
             '^report',


### PR DESCRIPTION
[Link to issue](https://github.com/usdoj-crt/crt-portal-management/issues/1646)

## What does this change?

- 🌎 We have started using Django groups
- ⛔ The app is configured to overwrite those with ADFS groups on user login
- ✅ This commit configures ADFS to [not check groups](https://github.com/snok/django-auth-adfs/blob/master/django_auth_adfs/backend.py#L324)

## Screenshots (for front-end PR):

n/a. This can only be checked / proven to work on staging, but I haven't found another way this issue might be happening (diagnosis by exclusion)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
