### PR TITLE
Show letterhead on referral mail

### DIFF
--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -313,7 +313,11 @@ class ResponseAction(APIView):
         template = get_object_or_404(ResponseTemplate, pk=template_id)
         action = request.data['action']
         recipient = request.data.get('recipient', None)
-        complainant_letter, agency_letter = build_letters(report, template)
+        complainant_letter, agency_letter = build_letters(
+            report,
+            template,
+            action=action,
+        )
 
         if action == 'preview':
             preview = build_preview(template, complainant_letter, agency_letter)

--- a/crt_portal/cts_forms/templates/forms/complaint_view/print/form_letter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/print/form_letter.html
@@ -15,25 +15,7 @@
     <p><em>Washington, DC 20530</em></p>
     <p>{% now "F j, Y" %}</p>
   </div>
-  {% if data.contact_first_name or data.contact_last_name or data.contact_address_line_1 or data.contact_city or data.contact_state or data.contact_zip or data.contact_email %}
-    <p id="form-letterhead--addressee">
-      {% if data.contact_first_name %}{{ data.contact_first_name }}{% endif %} {% if data.contact_last_name %}{{ data.contact_last_name }}{% endif %}
-      {% if data.contact_address_line_1 %}
-        <br />
-        {{ data.contact_address_line_1 }}
-      {% endif %}
-      {% if data.contact_address_line_2 %}
-        <br />
-        {{ data.contact_address_line_2 }}
-      {% endif %}
-      <br />
-      {% if data.contact_city %}{{ data.contact_city }},{% endif %} {% if data.contact_state %}{{ data.contact_state }}{% endif %} {% if data.contact_zip %}{{ data.contact_zip }}{% endif %}
-      {% if data.contact_email %}
-        <br />
-        {{ data.contact_email }}
-      {% endif %}
-    </p>
-  {% endif %}
+  {% include 'letterhead.html' with report=data %}
   <div id="form-letter--placeholder" class="form-letter">
   </div>
 </div>

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -1341,7 +1341,7 @@ class ReferralEmailContentTests(TestCase):
 
     @override_settings(RESTRICT_EMAIL_RECIPIENTS_TO=['a@example.gov', 'b@example.gov'])
     def test_build_referral_content(self):
-        complainant_letter = render_complainant_mail(report=self.report, template=self.template)
+        complainant_letter = render_complainant_mail(report=self.report, template=self.template, action='email')
 
         referral_letter = render_agency_mail(complainant_letter=complainant_letter,
                                              template=self.template,

--- a/crt_portal/templates/letterhead.html
+++ b/crt_portal/templates/letterhead.html
@@ -1,0 +1,19 @@
+{% if report.contact_first_name or report.contact_last_name or report.contact_address_line_1 or report.contact_city or report.contact_state or report.contact_zip or report.contact_email %}
+<p id="form-letterhead--addressee">
+  {% if report.contact_first_name %}{{ report.contact_first_name }}{% endif %} {% if report.contact_last_name %}{{ report.contact_last_name }}{% endif %}
+  {% if report.contact_address_line_1 %}
+    <br />
+    {{ report.contact_address_line_1 }}
+  {% endif %}
+  {% if report.contact_address_line_2 %}
+    <br />
+    {{ report.contact_address_line_2 }}
+  {% endif %}
+  <br />
+  {% if report.contact_city %}{{ report.contact_city }},{% endif %} {% if report.contact_state %}{{ report.contact_state }}{% endif %} {% if report.contact_zip %}{{ report.contact_zip }}{% endif %}
+  {% if report.contact_email %}
+    <br />
+    {{ report.contact_email }}
+  {% endif %}
+</p>
+{% endif %}

--- a/crt_portal/templates/print.html
+++ b/crt_portal/templates/print.html
@@ -1,0 +1,115 @@
+{% load i18n %}
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&family=Public+Sans:ital@0;1&display=swap"
+    rel="stylesheet">
+  <style rel="stylesheet" type="text/css">
+@page {
+  size: auto;
+  margin: 0mm;
+}
+
+body {
+  font-family: 'Public Sans','Helvetica','Arial',san-serif;
+  padding: 0;
+  margin: 0;
+  line-height: 1.5;
+}
+
+#form-letterhead {
+  height: 100%;
+  width: 100%;
+}
+
+.form-letterhead--header {
+  display: flex;
+}
+
+.form-letterhead--header img {
+  height: 100px;
+  padding-left: 3rem;
+}
+
+.form-letterhead--header-logo {
+  width: 50%;
+}
+
+.form-letterhead--header-text {
+  margin-top: 1.25rem;
+  margin-bottom: 0px;
+  font-weight: bold;
+}
+
+.form-letterhead--header-subtext {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.subheader {
+  width: 50%;
+  margin-left: 50%;
+  margin-bottom: 1rem;
+}
+
+#form-letterhead--addressee, #form-letterhead--dept-addressee {
+  margin-left: 0.75in;
+  margin-right: 0.75in;
+  margin-bottom: 4em;
+}
+
+#form-letterhead--dept-addressee {
+  white-space: pre-line;
+}
+
+#form-letter--placeholder {
+  margin-left: 0.75in;
+  margin-right: 0.75in;
+}
+
+#form-letter--placeholder.form-letter-text {
+    white-space: pre-line;
+}
+
+hr {
+  border: 2px solid #000;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+a[href]:after {
+  content: ' (' attr(href) ')';
+}
+  </style>
+</head>
+
+<body>
+  <div id="form-letterhead">
+    <div class="form-letterhead--header">
+      <div class="form-letterhead--header-logo">
+        <img src="{% static_embed "img/doj-logo-footer.png" %}" alt="" />
+      </div>
+      <div class="form-letterhead--header-textbox">
+        <h2 class="form-letterhead--header-text">U.S. Department of Justice</h2>
+        <h2 class="form-letterhead--header-subtext">Civil Rights Division</h2>
+      </div>
+    </div>
+    <hr />
+    <div class="subheader">
+      <p><em>Washington, DC 20530</em></p>
+      <p>{% now "F j, Y" %}</p>
+    </div>
+    {% include 'letterhead.html' with report=report %}
+    <div id="form-letter--placeholder" class="form-letter">
+      {{ content | safe }}
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
[Link to issue](https://github.com/usdoj-crt/crt-portal-management/issues/1642)

## What does this change?

- 🌎 Referrals rely on backend PDF generation
- ⛔ That doesn't include window mail letter head for printed letters, and includes no wrapper for HTML emails
- ✅ This commit add both

## Screenshots (for front-end PR):

[See this issue comment](https://github.com/usdoj-crt/crt-portal-management/issues/1642#issuecomment-1771222973)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
