### PR TITLE
Silence the touchpoints footer flag not loading.

### DIFF
--- a/crt_portal/cts_forms/templates/forms/report_base.html
+++ b/crt_portal/cts_forms/templates/forms/report_base.html
@@ -143,7 +143,7 @@
 <script src="{% static 'js/unsupported_browsers.min.js' %}"></script>
 <script src="{% static 'js/contact_info_confirmation_modal.min.js' %}"></script>
 <script src="{% static 'js/omb.min.js' %}"></script>
-    <script nonce="{{request.csp_nonce}}">
+<script nonce="{{request.csp_nonce}}">
   (function(root) {
     if (root.CRT.isUnsupportedBrowser()) {
       var unsupportedBrowserModal = document.getElementById('unsupported_browser_modal');

--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -32,7 +32,11 @@ def test_error_if_form_refreshed(page, base_url):
 
 
 @pytest.mark.only_browser("chromium")
-@console.raise_errors()
+@console.raise_errors(ignore=[
+    # The touchpoints script tries to embed a flag image.
+    # We don't support data URIs, so this fails:
+    'data:image/png;base64,iVBOR'
+])
 def test_report_complete_and_valid_submission(page):
 
     def next_step():


### PR DESCRIPTION
## What does this change?

- 🌎 A recent [touchpoints change](https://github.com/GSA/touchpoints/pull/1268) embeds a flag image instead of linking to it.
- ⛔ This causes the flag not to load for us, because we don't allow data uris for security reasons
- ✅ This commit silences the failure to load
- 🔮 Future commits should fix the image so it does load.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
