### PR TITLE
Fix learn your rights button on mobile

### DIFF
--- a/crt_portal/static/sass/custom/landing.scss
+++ b/crt_portal/static/sass/custom/landing.scss
@@ -363,6 +363,16 @@ $arrow-height: 24px;
       background: color($theme-color-warning);
       color: black !important;
       margin-top: 0;
+
+      &.usa-button--outline.usa-button--big {
+        color: black !important;
+        box-shadow: none;
+        margin-top: 1em;
+
+        &:visited {
+          color: black  !important;
+        }
+      }
     }
 
     a,


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?
This PR fixes the mobile learn your rights button to have the correct color and margin

## Screenshots (for front-end PR):
<img width="230" alt="Screenshot 2023-10-30 at 9 55 15 AM" src="https://github.com/usdoj-crt/crt-portal/assets/18104884/ff0f7ae6-c4b3-4970-a201-0c3a70a4099c">

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
