### PR TITLE
Create a wrapper for actstream action creation

### DIFF
--- a/crt_portal/cts_forms/migrations/0085_remove-assignee_20200716.py
+++ b/crt_portal/cts_forms/migrations/0085_remove-assignee_20200716.py
@@ -3,7 +3,7 @@
 from django.db import migrations
 from datetime import datetime
 import pytz
-from actstream import action
+from utils import activity
 from django.contrib.auth import get_user_model
 from actstream import registry
 
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
                         report.assigned_to = None
                         report.save()
                         # Add the closed activity to activity stream
-                        action.send(superuser, verb='Assignee Removed: ',
+                        activity.send_action(superuser, verb='Assignee Removed: ',
                                     description='Removed assignee for closed record before July 1, 2020',
                                     target=report)
     operations = [

--- a/crt_portal/utils/activity.py
+++ b/crt_portal/utils/activity.py
@@ -1,11 +1,11 @@
 from actstream import action
 
 
-def send_action(user, verb, description, target):
+def send_action(user, *, verb, description, target):
     """Send all actions to activity stream"""
     action.send(
         user,
-        verb,
-        description,
-        target,
+        verb=verb,
+        description=description,
+        target=target,
     )

--- a/crt_portal/utils/activity.py
+++ b/crt_portal/utils/activity.py
@@ -1,0 +1,11 @@
+from actstream import action
+
+
+def send_action(user, verb, description, target):
+    """Send all actions to activity stream"""
+    action.send(
+        user,
+        verb,
+        description,
+        target,
+    )


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1655

## What does this change?

- 🌎 We want to send notifications to users based on things that happen in the app.
- ⛔ We don't have a good place to do that right now - reports can be updated in multiple ways, and django signals don't provide an efficient utility for "has something changed"
- ✅ This commit prepares the activity stream "send action" to be this signal, by making a wrapper function for the places where we create activity log entries. The activity stream is an interesting enough source of "things have changed" to power most notifications.
- 🔮 Future commits will use this function to decide to send notifications, etc.

## Screenshots (for front-end PR):

N/A - this does not change functionality (yet)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
