### PR TITLE
Handle relative URLs in markdown rendering.

### DIFF
--- a/crt_portal/utils/markdown_extensions.py
+++ b/crt_portal/utils/markdown_extensions.py
@@ -1,0 +1,53 @@
+import os
+from markdown import Extension
+from markdown.inlinepatterns import LinkInlineProcessor
+from markdown.inlinepatterns import LINK_RE
+from urllib.parse import urlparse, urljoin
+
+
+def _get_site_prefix(for_intake: bool):
+    environment = os.environ.get('ENV', 'UNDEFINED')
+    production_url = ('https://crt-portal-django-prod.app.cloud.gov'
+                      if for_intake
+                      else 'https://civilrights.justice.gov')
+    return {
+        'PRODUCTION': production_url,
+        'STAGE': 'https://crt-portal-django-stage.app.cloud.gov',
+        'DEVELOP': 'https://crt-portal-django-dev.app.cloud.gov',
+    }.get(environment, 'http://localhost:8000')
+
+
+class RelativeToAbsoluteLinkProcessor(LinkInlineProcessor):
+
+    def __init__(self, *args, for_intake=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._site_prefix = _get_site_prefix(for_intake)
+
+    def getLink(self, *args, **kwargs):
+        (href, title, index, handled) = super().getLink(*args, **kwargs)
+
+        parsed = urlparse(href)
+
+        if parsed.netloc:
+            return (href, title, index, handled)
+
+        return urljoin(self._site_prefix, href), title, index, handled
+
+
+class RelativeToAbsoluteLinkExtension(Extension):
+
+    def __init__(self, *args, for_intake=False, **kwargs):
+        self._for_intake = for_intake
+        super().__init__(*args, **kwargs)
+
+    def extendMarkdown(self, md):
+        priority = next(
+            p.priority
+            for p in md.inlinePatterns._priority
+            if p.name == 'link'
+        )
+
+        md.inlinePatterns.deregister('link')
+
+        pattern = RelativeToAbsoluteLinkProcessor(LINK_RE, md, for_intake=self._for_intake)
+        md.inlinePatterns.register(pattern, 'link', priority)

--- a/crt_portal/utils/tests/test_markdown_extensions.py
+++ b/crt_portal/utils/tests/test_markdown_extensions.py
@@ -1,0 +1,60 @@
+from django.test import TestCase
+from unittest import mock
+from utils import markdown_extensions
+import markdown
+import os
+
+
+class MarkdownExtensionsTests(TestCase):
+    def test_html_converts_prod_internal(self):
+        content = "Go to [the link](/some/target)"
+        extension = markdown_extensions.RelativeToAbsoluteLinkExtension(for_intake=True)
+
+        with mock.patch.dict(os.environ, {'ENV': 'PRODUCTION'}):
+            rendered = markdown.markdown(content, extensions=[extension])
+
+        self.assertIn('Go to <a href="https://crt-portal-django-prod.app.cloud.gov/some/target">the link</a>', rendered)
+
+    def test_html_converts_prod_external(self):
+        content = "Go to [the link](/some/target)"
+        extension = markdown_extensions.RelativeToAbsoluteLinkExtension()
+
+        with mock.patch.dict(os.environ, {'ENV': 'PRODUCTION'}):
+            rendered = markdown.markdown(content, extensions=[extension])
+
+        self.assertIn('Go to <a href="https://civilrights.justice.gov/some/target">the link</a>', rendered)
+
+    def test_html_converts_dev(self):
+        content = "Go to [the link](/some/target)"
+        extension = markdown_extensions.RelativeToAbsoluteLinkExtension()
+
+        with mock.patch.dict(os.environ, {'ENV': 'DEVELOP'}):
+            rendered = markdown.markdown(content, extensions=[extension])
+
+        self.assertIn('Go to <a href="https://crt-portal-django-dev.app.cloud.gov/some/target">the link</a>', rendered)
+
+    def test_html_converts_stage(self):
+        content = "Go to [the link](/some/target)"
+        extension = markdown_extensions.RelativeToAbsoluteLinkExtension()
+
+        with mock.patch.dict(os.environ, {'ENV': 'STAGE'}):
+            rendered = markdown.markdown(content, extensions=[extension])
+
+        self.assertIn('Go to <a href="https://crt-portal-django-stage.app.cloud.gov/some/target">the link</a>', rendered)
+
+    def test_html_converts_local(self):
+        content = "Go to [the link](/some/target)"
+        extension = markdown_extensions.RelativeToAbsoluteLinkExtension()
+
+        with mock.patch.dict(os.environ, {'ENV': 'LOCAL'}):
+            rendered = markdown.markdown(content, extensions=[extension])
+
+        self.assertIn('Go to <a href="http://localhost:8000/some/target">the link</a>', rendered)
+
+    def test_html_ignores_absolute(self):
+        content = "Go to [the link](https://justice.gov/crt)"
+        extension = markdown_extensions.RelativeToAbsoluteLinkExtension()
+
+        rendered = markdown.markdown(content, extensions=[extension])
+
+        self.assertIn('Go to <a href="https://justice.gov/crt">the link</a>', rendered)


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1655

## What does this change?

- 🌎 For notifications, we want to link to pages on the site.
- ⛔ Because it's an email, those links need to be absolute (not relative) urls.
- ✅ This commit adds a markdown processor that can convert from /form/view to civilrights.justice.gov/form/view, etc, appropriately
- 🔮 Future commits will use this to render notification email content (although it can also be used with non-notification content)

## Screenshots (for front-end PR):

N/A - utility class

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
