### PR TITLE
Fix e2e tests for voting mode

### DIFF
--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -75,7 +75,7 @@ def test_report_complete_and_valid_submission(page):
     assert page.title() == "Step 2: Primary concern - Contact the Civil Rights Division | Department of Justice"
 
     # Check voting
-    page.check("#id_1-primary_complaint_4")
+    page.check('[name="1-primary_complaint"][value="voting"]')
 
     # Check footer exist
     content = page.text_content("footer")


### PR DESCRIPTION
(No issue link - quick fix to address e2e failure for voting mode)

## What does this change?

- 🌎 Voting mode changes the order of the primary complaint choices.
- ⛔ The end to end tests depend on this order, and fail when it's switched.
- ✅ This commit changes the tests to not depend on the order.

## Screenshots (for front-end PR):

N/A - see tests

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
