### PR TITLE
Explicitly set group claim to None

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,9 +595,12 @@ workflows:
               only: develop
 
       - deploy-stage:
+          requires:
+            - owasp-scan-dev
+            - build_and_test
           filters:
             branches:
-              only: kk/1646/adfs-group-removal-fix
+              only: /^release.*/
 
       - deploy-prod:
           requires:
@@ -614,12 +617,12 @@ workflows:
             branches:
               only: develop
 
-#       - e2e-test-stage:
-#           requires:
-#             - deploy-stage
-#           filters:
-#             branches:
-#               only: /^release.*/
+      - e2e-test-stage:
+          requires:
+            - deploy-stage
+          filters:
+            branches:
+              only: /^release.*/
 
   # Scheduled maintenance jobs for portal
   # Dev scheduled jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,12 +595,9 @@ workflows:
               only: develop
 
       - deploy-stage:
-          requires:
-            - owasp-scan-dev
-            - build_and_test
           filters:
             branches:
-              only: /^release.*/
+              only: kk/1646/adfs-group-removal-fix
 
       - deploy-prod:
           requires:
@@ -617,12 +614,12 @@ workflows:
             branches:
               only: develop
 
-      - e2e-test-stage:
-          requires:
-            - deploy-stage
-          filters:
-            branches:
-              only: /^release.*/
+#       - e2e-test-stage:
+#           requires:
+#             - deploy-stage
+#           filters:
+#             branches:
+#               only: /^release.*/
 
   # Scheduled maintenance jobs for portal
   # Dev scheduled jobs

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -306,7 +306,7 @@ if environment in ['PRODUCTION', 'STAGE']:
                           "email": "emailaddress"},
         "USERNAME_CLAIM": AUTH_USERNAME_CLAIM,
         # Explicitly DON'T set a group claim, as it will undo our native groups.
-        # "GROUP_CLAIM": AUTH_GROUP_CLAIM,
+        "GROUP_CLAIM": None,
         'LOGIN_EXEMPT_URLS': [
             '^$',
             '^report',
@@ -514,7 +514,7 @@ if environment == 'LOCAL':
     except ImportError:
         pass
 
-if os.environ.get('ENV', 'UNDEFINED') in ['LOCAL', 'DEVELOP']:
+if os.environ.get('ENV', 'UNDEFINED') in ['LOCAL', 'DEVELOP', 'STAGE']:
     DATABASES['analytics'] = {  # This must happen after importing local_settings
         **DATABASES['default'],
         'USER': os.environ['POSTGRES_ANALYTICS_USER'],

--- a/docs/maintenance_or_infrequent_tasks.md
+++ b/docs/maintenance_or_infrequent_tasks.md
@@ -320,6 +320,8 @@ cf set-env crt-portal-django POSTGRES_ANALYTICS_USER {secret username}
 cf set-env crt-portal-django POSTGRES_ANALYTICS_PASSWORD {secret password}
 ```
 
+Make sure to also update settings.py to set `DATABASES['analytics']` on the instance you're deploying to.
+
 If migrations have already been run, you can either migrate down and up (**which will drop all analytics data**) or add a new migration to create the user.
 
 To migrate down and up, run:


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1646

## What does this change?

- 🌎 We don't set a group claim in order to prevent ADFS from overwriting user groups.
- ⛔ Leaving it blank defaults to a claim of 'group'
- ✅ This commit sets it to `None`, which (tested on staging) prevents resetting the groups

📝 This also includes a quick change settings that would have caused a deployment error for Jupyter.

## Screenshots (for front-end PR):

N/A - tested on staging by:
- Setting the group for my user
- Logging out
- Logging in
- Confirmed the group wasn't removed

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
