### PR TITLE
Process exported reports in SQL

### DIFF
--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -10,10 +10,11 @@ from django.contrib import admin
 from django.contrib.admin.widgets import AdminTextareaWidget
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
+from django.contrib.postgres.aggregates import StringAgg
 from django.contrib import messages
 from django.http import HttpResponseRedirect, HttpRequest
 from django.core.paginator import Paginator
-from django.db.models import Prefetch
+from django.db.models import Subquery, OuterRef
 from django import forms
 from django.http import HttpResponse, StreamingHttpResponse
 from django.shortcuts import render
@@ -105,21 +106,29 @@ def iter_queryset(queryset, headers, *, pagination=settings.DEFAULT_EXPORT_PAGIN
         yield from paginator.get_page(i + 1)
 
 
-def _serialize_report_export(data):
+def _prepare_report_csv_queryset(queryset):
     """
     Customize the rendering of protected_class and summary instances
     while rendering headers as-is
     """
-    if isinstance(data, Report):
-        row = [getattr(data, field) for field in REPORT_FIELDS]
-        row.append('; '.join([str(pc) for pc in data.protected_class.all()]))
-        if data.internal_summary:
-            # incoming summaries are sorted by descending modified_date the first is the most recent
-            row.append(data.internal_summary[0].note)
-        else:
-            row.append('')
-        return row
-    return data
+
+    summaries = (
+        CommentAndSummary.objects
+        .filter(is_summary=True, report=OuterRef('pk'))
+        .order_by('-modified_date')
+        .only('note')
+    )
+
+    return (
+        queryset
+        .prefetch_related('protected_class')
+        .annotate(_exportable_protected_class=StringAgg('protected_class__protected_class', delimiter='; '))
+        .annotate(_exportable_summary=Subquery(summaries.values('note')[:1]))
+        .order_by('id')
+        .values_list(*REPORT_FIELDS,
+                     '_exportable_protected_class',
+                     '_exportable_summary')
+    )
 
 
 def _serialize_action(data):
@@ -139,13 +148,9 @@ def export_reports_as_csv(modeladmin, request, queryset):
     writer = csv.writer(Echo(), quoting=csv.QUOTE_ALL)
     headers = REPORT_FIELDS + ['protected_class', 'internal_summary']
 
-    summaries = CommentAndSummary.objects.filter(is_summary=True).order_by('-modified_date')
-    queryset = queryset.prefetch_related('protected_class',
-                                         Prefetch('internal_comments', queryset=summaries, to_attr='internal_summary')
-                                         ).order_by('id')
-    iterator = iter_queryset(queryset, headers)
+    iterator = iter_queryset(_prepare_report_csv_queryset(queryset), headers)
 
-    response = StreamingHttpResponse((writer.writerow(_serialize_report_export(report)) for report in iterator),
+    response = StreamingHttpResponse((writer.writerow(report) for report in iterator),
                                      content_type="text/csv")
     response['Content-Disposition'] = 'attachment; filename="report_export.csv"'
 

--- a/crt_portal/cts_forms/admin.py
+++ b/crt_portal/cts_forms/admin.py
@@ -106,7 +106,7 @@ def iter_queryset(queryset, headers, *, pagination=settings.DEFAULT_EXPORT_PAGIN
         yield from paginator.get_page(i + 1)
 
 
-def _prepare_report_csv_queryset(queryset):
+def prepare_report_csv_queryset(queryset):
     """
     Customize the rendering of protected_class and summary instances
     while rendering headers as-is
@@ -148,7 +148,7 @@ def export_reports_as_csv(modeladmin, request, queryset):
     writer = csv.writer(Echo(), quoting=csv.QUOTE_ALL)
     headers = REPORT_FIELDS + ['protected_class', 'internal_summary']
 
-    iterator = iter_queryset(_prepare_report_csv_queryset(queryset), headers)
+    iterator = iter_queryset(prepare_report_csv_queryset(queryset), headers)
 
     response = StreamingHttpResponse((writer.writerow(report) for report in iterator),
                                      content_type="text/csv")

--- a/crt_portal/cts_forms/management/commands/generate_yearly_reports.py
+++ b/crt_portal/cts_forms/management/commands/generate_yearly_reports.py
@@ -8,7 +8,7 @@ from io import StringIO
 from django.core.files.base import ContentFile
 from pytz import timezone
 
-from ...admin import iter_queryset, _serialize_report_export
+from ...admin import iter_queryset, prepare_report_csv_queryset
 
 EXCLUDED_REPORT_FIELDS = ['violation_summary_search_vector', 'referral_section']
 REPORT_FIELDS = [field.name for field in Report._meta.fields if field.name not in EXCLUDED_REPORT_FIELDS]
@@ -38,12 +38,10 @@ class Command(BaseCommand):  # pragma: no cover
                                                               to_attr='internal_summary')
                                                      ).order_by('id')
                 total_count += queryset.count()
-                iterator = iter_queryset(queryset, headers)
+                iterator = iter_queryset(prepare_report_csv_queryset(queryset), headers)
                 csv_buffer = StringIO()
                 csv_writer = csv.writer(csv_buffer, quoting=csv.QUOTE_ALL)
-
-                for report in iterator:
-                    csv_writer.writerow(_serialize_report_export(report))
+                csv_writer.writerows(iterator)
                 csv_file = ContentFile(csv_buffer.getvalue().encode('utf-8'))
                 # Check to see if a report of the given filename exists, if so, update.  If not, create a new one.
                 try:


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1659

## What does this change?

- 🌎 Right now, when exporting Report data, we stream report data to the portal, then modify it, then stream it to the user.
- ⛔ This is very flexible, but causes us to pull more data than necessary between SQL and python. SQL is also more efficient at processing the records than python.
- ✅ This commit puts the load of fetching related objects / formatting data onto SQL

## Screenshots (for front-end PR):

Locally, the transfer rate for the streaming request increased by ~3x (600kbps to 2mbps). This indicates the Python code becoming less of a bottleneck in streaming the data. Actual performance on dev/staging/prod will, of course, vary based on the size and speed of the instances.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
