### PR TITLE
System notification messages

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1758,6 +1758,18 @@ class ComplaintActions(LitigationHoldLock, ModelForm, ActivityStreamUpdater):
             fields = ', '.join(updated_fields[:-1])
             fields += f', and {updated_fields[-1]}'
             message = f"Successfully updated {fields}."
+        if 'Assigned to' in updated_fields and 'Section' not in updated_fields:
+            assigned_user = self.cleaned_data['assigned_to']
+            if not assigned_user:
+                return message
+            if not hasattr(assigned_user, 'notification_preference'):
+                message += ' Assignee will not be notified because they have not set notification preferences.'
+            elif not assigned_user.notification_preference.assigned_to:
+                message += ' Assignee will not be notified because they have opted out of notifications.'
+            elif not assigned_user.email:
+                message += ' Assignee will not be notified because they do not have an email address listed.'
+            else:
+                message += ' Assignee will be notified via email.'
         return message
 
     def clean_dj_number(self):

--- a/crt_portal/utils/activity.py
+++ b/crt_portal/utils/activity.py
@@ -2,7 +2,6 @@ import logging
 from actstream import action
 from cts_forms.models import Report
 from cts_forms.mail import notify
-from django.contrib import messages
 
 
 def send_action(user, *, verb, description, target, send_notification=False):
@@ -31,15 +30,12 @@ def _handle_notify_assigned_to(*, user, verb, description, target):
         logging.info(f'Not notifying assignee (no assignee) (report {report.id})')
         return
     if not hasattr(report.assigned_to, 'notification_preference'):
-        messages.add_message()
         logging.info(f'Not notifying assignee (no notification preference) (report {report.id})')
         return
     if not report.assigned_to.notification_preference.assigned_to:
-        messages.add_message()
         logging.info(f'Not notifying assignee (opted out of notification) (report {report.id})')
         return
     if not report.assigned_to.email:
-        messages.add_message()
         logging.warning(f'Not notifying assignee (User {report.assigned_to.id} is opted in, but has no email address)')
         return
     notify(template_title='assigned_to',

--- a/crt_portal/utils/activity.py
+++ b/crt_portal/utils/activity.py
@@ -2,6 +2,7 @@ import logging
 from actstream import action
 from cts_forms.models import Report
 from cts_forms.mail import notify
+from django.contrib import messages
 
 
 def send_action(user, *, verb, description, target, send_notification=False):
@@ -30,12 +31,15 @@ def _handle_notify_assigned_to(*, user, verb, description, target):
         logging.info(f'Not notifying assignee (no assignee) (report {report.id})')
         return
     if not hasattr(report.assigned_to, 'notification_preference'):
+        messages.add_message()
         logging.info(f'Not notifying assignee (no notification preference) (report {report.id})')
         return
     if not report.assigned_to.notification_preference.assigned_to:
+        messages.add_message()
         logging.info(f'Not notifying assignee (opted out of notification) (report {report.id})')
         return
     if not report.assigned_to.email:
+        messages.add_message()
         logging.warning(f'Not notifying assignee (User {report.assigned_to.id} is opted in, but has no email address)')
         return
     notify(template_title='assigned_to',


### PR DESCRIPTION
[Add messaging for system notifications#1664](https://github.com/usdoj-crt/crt-portal-management/issues/1664)

## What does this change?

This PR adds messaging for system notifications when assignee is changed.
![Image](https://github.com/usdoj-crt/crt-portal-management/assets/18104884/b7432568-662f-4f1f-ad0d-430e393279a6)

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
