### PR TITLE
Allow unsubscribing from notifications.

### DIFF
--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -16,6 +16,7 @@ from django.template.loader import render_to_string
 from cts_forms.models import Report, ResponseTemplate
 from tms.models import TMSEmail
 from utils.markdown_extensions import RelativeToAbsoluteLinkExtension
+from utils.site_prefix import get_site_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +124,10 @@ def _render_notification_mail(*,
     message = template.render_body(report, **kwargs)
 
     md = markdown.markdown(message, extensions=['extra', 'sane_lists', 'admonition', 'nl2br', CustomHTMLExtension(), RelativeToAbsoluteLinkExtension(for_intake=True)])
-    html_message = render_to_string('notification.html', {'content': md})
+    html_message = render_to_string('notification.html', {
+        'content': md,
+        'unsubscribe_link': '/'.join([get_site_prefix(for_intake=True), 'form/notifications/unsubscribe'])
+    })
 
     allowed_recipients = remove_disallowed_recipients(recipients)
     disallowed_recipients = list(set(recipients) - set(allowed_recipients))

--- a/crt_portal/cts_forms/response_templates/assigned_to.md
+++ b/crt_portal/cts_forms/response_templates/assigned_to.md
@@ -13,8 +13,3 @@ You have been assigned to take a look at [Report {{record_locator}}](/form/view/
 
 Please take a look at the link above or, if you think this was in error, please add a comment and reassign the report as appropriate.
 
-Sincerely,
-
-Portal Team
-
-_please do not reply to this message_

--- a/crt_portal/cts_forms/templates/notification.html
+++ b/crt_portal/cts_forms/templates/notification.html
@@ -59,6 +59,13 @@
 
     <div style="margin-left:1rem; margin-right: 1rem">
       {{ content | safe }}
+
+      <p>Sincerely,</p>
+
+      <p>Portal Team</p>
+
+      <p><em>please do not reply to this message - click <a href="{{ unsubscribe_link }}">here</a> to unsubscribe</em></p>
+
     </div>
   </body>
 </html>

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -6,8 +6,10 @@ import secrets
 import urllib.parse
 
 from unittest import mock
+from botocore.docs.method import types
 
 from django.contrib.auth.models import User
+from django.contrib.messages import get_messages
 from django.http import QueryDict
 from django.test import TestCase, override_settings
 from django.test.client import Client
@@ -20,7 +22,7 @@ from cts_forms.mail import render_complainant_mail, render_agency_mail
 
 from ..forms import BulkActionsForm, ComplaintActions, ComplaintOutreach, ContactEditForm, Filters, ReportEditForm
 from ..model_variables import PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES, NEW_STATUS
-from ..models import CommentAndSummary, ReferralContact, Report, ResponseTemplate, EmailReportCount, RetentionSchedule
+from ..models import CommentAndSummary, NotificationPreference, ReferralContact, Report, ResponseTemplate, EmailReportCount, RetentionSchedule
 from .factories import ReportFactory
 from .test_data import SAMPLE_REFERRAL_CONTACT, SAMPLE_REPORT_1, SAMPLE_RESPONSE_TEMPLATE
 
@@ -312,6 +314,74 @@ class ActionTests(TestCase):
         self.assertCountEqual(form.get_actions(), [
             ('Secondary review:', 'Updated from "False" to "True"'),
         ])
+
+
+class NotificationPreferencesTests(TestCase):
+    unsubscribe = reverse('crt_forms:crt-forms-notifications-unsubscribe')
+
+    def setUp(self):
+        self.client = Client()
+        self.users = types.SimpleNamespace(
+            subscribed=User.objects.create_user('SUBSCRIBED_USER', 'subscribed@example.com', 'password'),
+            unsubscribed=User.objects.create_user('UNSUBSCRIBED_USER', 'unsubscribed@example.com', 'password'),
+            noprefs=User.objects.create_user('NOPREFS_USER', 'noprefs@example.com', 'password'),
+        )
+        NotificationPreference.objects.create(
+            user=self.users.subscribed,
+            assigned_to=True,
+        )
+        NotificationPreference.objects.create(
+            user=self.users.unsubscribed,
+            assigned_to=False,
+        )
+
+    def test_unsubscribe_unsubscribes(self):
+        """The comment shows up in the report's activity log"""
+        user = self.users.subscribed
+        self.client.login(username=user.username,
+                          password='password')
+
+        response = self.client.get(self.unsubscribe)
+
+        self.assertRedirects(response,
+                             reverse('crt_forms:crt-forms-index'),
+                             fetch_redirect_response=True)
+        self.assertIn('You have been unsubscribed from all portal notifications',
+                      [m.message for m in get_messages(response.wsgi_request)])
+        user.refresh_from_db()
+        self.assertFalse(user.notification_preference.assigned_to)
+
+    def test_unsubscribe_safe_for_no_prefs(self):
+        """The comment shows up in the report's activity log"""
+        user = self.users.noprefs
+        self.client.login(username=user.username,
+                          password='password')
+
+        response = self.client.get(self.unsubscribe)
+
+        self.assertRedirects(response,
+                             reverse('crt_forms:crt-forms-index'),
+                             fetch_redirect_response=True)
+        self.assertIn('You are not subscribed to notifications',
+                      [m.message for m in get_messages(response.wsgi_request)])
+        user.refresh_from_db()
+        self.assertFalse(hasattr(user, 'notification_preference'))
+
+    def test_unsubscribe_safe_for_not_subscribed(self):
+        """The comment shows up in the report's activity log"""
+        user = self.users.unsubscribed
+        self.client.login(username=user.username,
+                          password='password')
+
+        response = self.client.get(self.unsubscribe)
+
+        self.assertRedirects(response,
+                             reverse('crt_forms:crt-forms-index'),
+                             fetch_redirect_response=True)
+        self.assertIn('You are not subscribed to notifications',
+                      [m.message for m in get_messages(response.wsgi_request)])
+        user.refresh_from_db()
+        self.assertFalse(user.notification_preference.assigned_to)
 
 
 class CommentActionTests(TestCase):

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from .views import (ActionsView, index_view, data_view, dashboard_view, dashboard_activity_log_view, RoutingGuideView, ShowView, ProFormView,
                     SaveCommentView, TrendView, ResponseView, SearchHelperView,
-                    PrintView, ProfileView, ReportAttachmentView, ReportDataView, DataExport, RemoveReportAttachmentView)
+                    PrintView, ProfileView, ReportAttachmentView, ReportDataView, DataExport, RemoveReportAttachmentView, unsubscribe_view)
 from .forms import ProForm
 
 app_name = 'crt_forms'
@@ -28,5 +28,6 @@ urlpatterns = [
     path('trends/', TrendView.as_view(), name='trends'),
     path('dashboard/', dashboard_view, name='dashboard'),
     path('data/', data_view, name='data'),
-    path('dashboard/activity', dashboard_activity_log_view, name='activity-log')
+    path('dashboard/activity', dashboard_activity_log_view, name='activity-log'),
+    path('notifications/unsubscribe', unsubscribe_view, name='crt-forms-notifications-unsubscribe'),
 ]

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -605,6 +605,29 @@ def serialize_data(report, request, report_id):
     return output
 
 
+@login_required
+def unsubscribe_view(request):
+    if not hasattr(request.user, 'notification_preference'):
+        messages.add_message(request,
+                             messages.ERROR,
+                             mark_safe("You are not subscribed to notifications"))
+        return redirect(reverse('crt_forms:crt-forms-index'))
+    preferences = request.user.notification_preference
+
+    if not preferences.assigned_to:
+        messages.add_message(request,
+                             messages.ERROR,
+                             mark_safe("You are not subscribed to notifications"))
+        return redirect(reverse('crt_forms:crt-forms-index'))
+
+    preferences.assigned_to = False
+    preferences.save()
+    messages.add_message(request,
+                         messages.SUCCESS,
+                         mark_safe("You have been unsubscribed from all portal notifications"))
+    return redirect(reverse('crt_forms:crt-forms-index'))
+
+
 class ProfileView(LoginRequiredMixin, FormView):
     # Can be used for updating section filter for a profile
     form_class = ProfileForm

--- a/crt_portal/utils/markdown_extensions.py
+++ b/crt_portal/utils/markdown_extensions.py
@@ -1,27 +1,16 @@
-import os
 from markdown import Extension
 from markdown.inlinepatterns import LinkInlineProcessor
 from markdown.inlinepatterns import LINK_RE
 from urllib.parse import urlparse, urljoin
 
-
-def _get_site_prefix(for_intake: bool):
-    environment = os.environ.get('ENV', 'UNDEFINED')
-    production_url = ('https://crt-portal-django-prod.app.cloud.gov'
-                      if for_intake
-                      else 'https://civilrights.justice.gov')
-    return {
-        'PRODUCTION': production_url,
-        'STAGE': 'https://crt-portal-django-stage.app.cloud.gov',
-        'DEVELOP': 'https://crt-portal-django-dev.app.cloud.gov',
-    }.get(environment, 'http://localhost:8000')
+from .site_prefix import get_site_prefix
 
 
 class RelativeToAbsoluteLinkProcessor(LinkInlineProcessor):
 
     def __init__(self, *args, for_intake=False, **kwargs):
         super().__init__(*args, **kwargs)
-        self._site_prefix = _get_site_prefix(for_intake)
+        self._site_prefix = get_site_prefix(for_intake)
 
     def getLink(self, *args, **kwargs):
         (href, title, index, handled) = super().getLink(*args, **kwargs)

--- a/crt_portal/utils/site_prefix.py
+++ b/crt_portal/utils/site_prefix.py
@@ -1,0 +1,13 @@
+import os
+
+
+def get_site_prefix(for_intake: bool):
+    environment = os.environ.get('ENV', 'UNDEFINED')
+    production_url = ('https://crt-portal-django-prod.app.cloud.gov'
+                      if for_intake
+                      else 'https://civilrights.justice.gov')
+    return {
+        'PRODUCTION': production_url,
+        'STAGE': 'https://crt-portal-django-stage.app.cloud.gov',
+        'DEVELOP': 'https://crt-portal-django-dev.app.cloud.gov',
+    }.get(environment, 'http://localhost:8000')

--- a/crt_portal/utils/tests/test_site_prefix.py
+++ b/crt_portal/utils/tests/test_site_prefix.py
@@ -1,0 +1,25 @@
+from utils import site_prefix
+import os
+from unittest import TestCase, mock
+
+
+class SitePrefixTests(TestCase):
+    def test_local_prefix(self):
+        with mock.patch.dict(os.environ, {'ENV': 'LOCAL'}):
+            self.assertEqual(site_prefix.get_site_prefix(False), 'http://localhost:8000')
+            self.assertEqual(site_prefix.get_site_prefix(True), 'http://localhost:8000')
+
+    def test_dev_prefix(self):
+        with mock.patch.dict(os.environ, {'ENV': 'DEVELOP'}):
+            self.assertEqual(site_prefix.get_site_prefix(False), 'https://crt-portal-django-dev.app.cloud.gov')
+            self.assertEqual(site_prefix.get_site_prefix(True), 'https://crt-portal-django-dev.app.cloud.gov')
+
+    def test_stage_prefix(self):
+        with mock.patch.dict(os.environ, {'ENV': 'STAGE'}):
+            self.assertEqual(site_prefix.get_site_prefix(False), 'https://crt-portal-django-stage.app.cloud.gov')
+            self.assertEqual(site_prefix.get_site_prefix(True), 'https://crt-portal-django-stage.app.cloud.gov')
+
+    def test_prod_prefix(self):
+        with mock.patch.dict(os.environ, {'ENV': 'PRODUCTION'}):
+            self.assertEqual(site_prefix.get_site_prefix(False), 'https://civilrights.justice.gov')
+            self.assertEqual(site_prefix.get_site_prefix(True), 'https://crt-portal-django-prod.app.cloud.gov')


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1673

## What does this change?

- 🌎 Admins can turn on notifications
- ⛔ Users can't turn them off!
- ✅ This commit adds a link to email footers to turn off notifications
- 🔮 Future tickets may build this out into a full-fledged preferences page, but not now.

## Screenshots (for front-end PR):

![Image](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/b55c7b15-49ea-4b93-93a8-5f972f7d7129)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
