### PR TITLE
Fix two notification bug

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1717,13 +1717,10 @@ class ComplaintActions(LitigationHoldLock, ModelForm, ActivityStreamUpdater):
             original = self.initial[field]
             changed = self.cleaned_data[field]
             # fix bug where id was showing up instead of user name
-            if field in ['assigned_to', 'retention_schedule']:
-                if original is None:
-                    yield f"{name}:", f'"{changed}"'
-                elif field == 'assigned_to':
-                    original = User.objects.get(id=original)
-                elif field == 'retention_schedule':
-                    original = RetentionSchedule.objects.get(id=original)
+            if field == 'assigned_to':
+                original = User.objects.get(id=original)
+            if field == 'retention_schedule':
+                original = RetentionSchedule.objects.get(id=original)
             yield f"{name}:", f'Updated from "{original}" to "{changed}"'
         if self.report_closed:
             yield "Report closed and Assignee removed", f"Date closed updated to {self.instance.closed_date.strftime('%m/%d/%y %H:%M:%M %p')}"

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1717,10 +1717,13 @@ class ComplaintActions(LitigationHoldLock, ModelForm, ActivityStreamUpdater):
             original = self.initial[field]
             changed = self.cleaned_data[field]
             # fix bug where id was showing up instead of user name
-            if field == 'assigned_to':
-                original = User.objects.get(id=original)
-            if field == 'retention_schedule':
-                original = RetentionSchedule.objects.get(id=original)
+            if field in ['assigned_to', 'retention_schedule']:
+                if original is None:
+                    original = 'None'
+                elif field == 'assigned_to':
+                    original = User.objects.get(id=original)
+                elif field == 'retention_schedule':
+                    original = RetentionSchedule.objects.get(id=original)
             yield f"{name}:", f'Updated from "{original}" to "{changed}"'
         if self.report_closed:
             yield "Report closed and Assignee removed", f"Date closed updated to {self.instance.closed_date.strftime('%m/%d/%y %H:%M:%M %p')}"

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -73,10 +73,10 @@ class ActionTests(TestCase):
         )
 
         self.assertEqual(form.errors, {})
-        self.assertCountEqual(form.get_actions(), [
-            ('Assigned to:', f'"{self.user2.username}"'),
-            ('Assigned to:', f'Updated from "None" to "{self.user2.username}"'),
-        ])
+        self.assertCountEqual(form.get_actions(), [(
+            'Assigned to:',
+            f'Updated from "None" to "{self.user2.username}"',
+        )])
 
     def test_section_change(self):
         """Changes to section are recorded in activity log"""


### PR DESCRIPTION
[Two system notifications sent when assigning a report to a user.#1670](https://github.com/usdoj-crt/crt-portal-management/issues/1670)

## What does this change?
This PR fixes a bug where there are two activities and consequently two notifications associated with assigning a report from None to another user.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
