### PR TITLE
Add a component for selecting tags.

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -50,7 +50,7 @@ from .model_variables import (ACTION_CHOICES, CLOSED_STATUS, COMMERCIAL_OR_PUBLI
                               VIOLATION_SUMMARY_ERROR, WHERE_ERRORS,
                               HATE_CRIME_CHOICES, GROUPING, RETENTION_SCHEDULE_CHOICES)
 from .models import (CommentAndSummary,
-                     ProtectedClass, Report, ResponseTemplate, Profile, ReportAttachment, Campaign, RetentionSchedule, SavedSearch, get_system_user)
+                     ProtectedClass, Report, ResponseTemplate, Profile, ReportAttachment, Campaign, RetentionSchedule, SavedSearch, get_system_user, Tag)
 from .phone_regex import phone_validation_regex
 from .question_group import QuestionGroup
 from .question_text import (CONTACT_QUESTIONS, DATE_QUESTIONS,
@@ -62,7 +62,7 @@ from .question_text import (CONTACT_QUESTIONS, DATE_QUESTIONS,
                             WORKPLACE_QUESTIONS, HATE_CRIME_HELP_TEXT,
                             HATE_CRIME_QUESTION)
 from .widgets import (ComplaintSelect, CrtMultiSelect,
-                      CrtPrimaryIssueRadioGroup, DjNumberWidget, UsaCheckboxSelectMultiple,
+                      CrtPrimaryIssueRadioGroup, DjNumberWidget, UsaCheckboxSelectMultiple, UsaTagSelectMultiple,
                       UsaRadioSelect, DataAttributesSelect, CrtDateInput, add_empty_choice)
 from utils.voting_mode import is_voting_mode
 from utils import activity
@@ -2294,6 +2294,12 @@ class ReportEditForm(LitigationHoldLock, ProForm, ActivityStreamUpdater):
     summary = CharField(required=False, strip=True, widget=Textarea(attrs={'class': 'usa-textarea', 'data-soft-valid': 'true', 'data-soft-maxlength': 7000}))
     summary_id = IntegerField(required=False, widget=HiddenInput())
 
+    tags = ModelMultipleChoiceField(
+        queryset=Tag.objects.filter(show_in_lists=True),
+        widget=UsaTagSelectMultiple(),
+        required=False,
+    )
+
     class Meta(ProForm.Meta):
         """
         Extend ProForm to capture field definitions from component forms, excluding those which should not be editable here
@@ -2310,7 +2316,6 @@ class ReportEditForm(LitigationHoldLock, ProForm, ActivityStreamUpdater):
             'contact_zip',
             'election_details',
             'intake_format',
-            'tags',
             'origination_utm_campaign',
             'origination_utm_content',
             'origination_utm_medium',

--- a/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
@@ -12,6 +12,7 @@
 {% block page_js %}
 {{ block.super }}
 <script src="{% static 'js/dropdown.min.js' %}"></script>
+<script src="{% static 'js/usa_tag_select.min.js' %}"></script>
 {%endblock%}
 {# no google analytics on backend #}
 {% block analytics %}{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -42,6 +42,14 @@
     <input type="hidden" value="{{ return_url_args }}" name="next" id="next-{{ id_name }}" />
     <input type="hidden" value="{{ index }}" name="index" id="index-{{ id_name }}" />
     <table class="usa-table usa-table--borderless complaint-card-table">
+      {% if ENABLED_FEATURES.tags %}
+      <tr>
+        <th>Tags</th>
+        <td>
+        {{ details_form.tags }}
+        </td>
+      </tr>
+      {% endif %}
       <tr>
         <th><label for="{{details_form.primary_complaint.id_for_label}}">Primary issue</label></th>
         <td>

--- a/crt_portal/cts_forms/templates/forms/widgets/usa_tag_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/usa_tag_option.html
@@ -1,0 +1,10 @@
+<input
+  type="checkbox"
+  data-label="{{ widget.label }}"
+  name="{{ widget.name }}"
+  {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
+  {% include "django/forms/widgets/attrs.html" %}
+/>
+<label {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
+  <span class="usa-tag usa-tag--big">{{ widget.label }}</span>
+</label>

--- a/crt_portal/cts_forms/templates/forms/widgets/usa_tag_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/usa_tag_select.html
@@ -1,0 +1,36 @@
+{% with id=widget.attrs.id %}
+<div
+  {% if id %} id="{{ id }}"{% endif %}
+  class="usa-tags-container {% if widget.attrs.class %}{{ widget.attrs.class }}{% endif %}">
+
+  <div class="usa-selected-tags">
+    {% for group, options, index in widget.optgroups %}
+    {% if group %}
+    <div>
+      <label>{{ group }}</label>
+    {% endif %}
+      {% for option in options %}
+      <div class="tag-option">
+      {% include option.template_name with widget=option %}
+      </div>
+      {% endfor %}
+    {% if group %}
+    </div>
+    {% endif %}
+    {% endfor %}
+  </div>
+
+  <label class="usa-label usa-sr-only" for="{{id}}-assign-tag">Assign a tag</label>
+  <div class="usa-combo-box assign-tag"
+       title="Type to select a tag for this report"
+       data-placeholder="Add tags...">
+    <select class="usa-select" id="{{id}}-assign-tag">
+    {% for group, options, index in widget.optgroups %}
+    {% for option in options %}
+      <option value="{{ option.value }}">{{ option.label }}</option>
+    {% endfor %}
+    {% endfor %}
+    </select>
+  </div>
+</div>
+{% endwith %}

--- a/crt_portal/cts_forms/widgets.py
+++ b/crt_portal/cts_forms/widgets.py
@@ -142,6 +142,11 @@ class UsaCheckboxSelectMultiple(ChoiceWidget):
         return super().id_for_label(id_, index)
 
 
+class UsaTagSelectMultiple(UsaCheckboxSelectMultiple):
+    template_name = 'forms/widgets/usa_tag_select.html'
+    option_template_name = 'forms/widgets/usa_tag_option.html'
+
+
 class DataAttributesSelect(ChoiceWidget):
     input_type = 'select'
     template_name = 'django/forms/widgets/select.html'

--- a/crt_portal/static/js/usa_tag_select.js
+++ b/crt_portal/static/js/usa_tag_select.js
@@ -1,0 +1,53 @@
+(function(root, dom) {
+  function updateComboOptions(select, checkboxes) {
+    select.innerHTML = '';
+    checkboxes.forEach(checkbox => {
+      if (checkbox.checked) return;
+      const option = document.createElement('option');
+      option.value = checkbox.value;
+      option.innerHTML = checkbox.dataset.label;
+      select.appendChild(option);
+    });
+  }
+
+  function listenForSelect(wrapper) {
+    const select = wrapper.querySelector('.usa-combo-box.assign-tag select');
+    const checkboxes = wrapper.querySelectorAll('.usa-selected-tags input[type="checkbox"]');
+    const selectedTags = wrapper.querySelector('.usa-selected-tags');
+    select.addEventListener('change', event => {
+      if (!event.target.value) return;
+      const tagId = event.target.value;
+      select.value = '';
+      selectedTags.querySelector(`input[value="${tagId}"]`).checked = true;
+      updateComboOptions(select, checkboxes);
+      setTimeout(() => {
+        wrapper.querySelector('.usa-combo-box__clear-input').click();
+      });
+    });
+  }
+
+  function listenForDeselect(wrapper) {
+    const select = wrapper.querySelector('.usa-combo-box.assign-tag select');
+    const checkboxes = wrapper.querySelectorAll('.usa-selected-tags input[type="checkbox"]');
+    checkboxes.forEach(checkbox => {
+      checkbox.addEventListener('change', () => {
+        updateComboOptions(select, checkboxes);
+      });
+    });
+  }
+
+  function attachListeners(wrapper) {
+    listenForSelect(wrapper);
+    listenForDeselect(wrapper);
+  }
+
+  root.addEventListener('load', () => {
+    const wrappers = dom.querySelectorAll('.usa-tags-container');
+    wrappers.forEach(wrapper => {
+      const select = wrapper.querySelector('.usa-combo-box.assign-tag select');
+      const checkboxes = wrapper.querySelectorAll('.usa-selected-tags input[type="checkbox"]');
+      updateComboOptions(select, checkboxes);
+      attachListeners(wrapper);
+    });
+  });
+})(window, document);

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -1002,6 +1002,42 @@ form#cts-forms-profile {
   }
 }
 
+.usa-tags-container {
+  input[type="checkbox"] {
+    display: none;
+  }
+
+  input[type="checkbox"] + label .usa-tag {
+    display: none;
+  }
+
+  input[type="checkbox"]:checked + label .usa-tag {
+    display: inline;
+  }
+
+  .usa-selected-tags {
+    .tag-option {
+      display: inline-block;
+    }
+  }
+
+  .usa-tag {
+    background-color: #e1e7f1;
+    color: #162e51;
+    cursor: pointer;
+    &:after {
+      content: "";
+      height: 1rem;
+      width: 1.25rem;
+      margin-left: 4px;
+      display: inline-block;
+      background-image: url(../../img/usa-icons/close.svg);
+      background-repeat: no-repeat;
+      background-size: cover;
+    }
+  }
+}
+
 .intake-label {
   @include u-font('sans', 16);
   color: color($theme-color-base-ink);


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1656

## What does this change?

- 🌎 We want to assign tags to reports
- ⛔ USWDS has the building blocks for this, but not a full-on component, and not adapted to django
- ✅ This commit adds a tag selection component.
- 🔮 It's just the front end so far. Future commits will:
  * Persist the saved values to the server
  * Add an edit mode vs view mode, in keeping with the rest of the modal

## Screenshots (for front-end PR):

<img width="599" alt="image" src="https://github.com/usdoj-crt/crt-portal/assets/15126660/2af725e9-9933-45ec-8297-f178a9e99594">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
