### PR TITLE
Silence warning when filtering to no reports.

### DIFF
--- a/crt_portal/api/filters.py
+++ b/crt_portal/api/filters.py
@@ -155,7 +155,7 @@ def report_cws(reports):
         "reports": {},
     }
     emails = tuple(set(reports.values()))
-    if emails is None:
+    if not emails:
         return report_cws_payload
     with connection.cursor() as cursor:
         try:


### PR DESCRIPTION
No issue, quick fix

## What does this change?

- 🌎 This view gives a list of constant writers for reports on the list page.
- ⛔ When the list is empty, the query fails and gives a error like: "syntax error at or near ... LINE 5: AND r.contact_email IN ()
- ✅ This commit silences the error by checking if the list is empty versus just None

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
