### PR TITLE
Persist tags on Reports

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -6,7 +6,7 @@ from django.core.validators import ValidationError
 from django.forms import (BooleanField, CharField, CheckboxInput, ChoiceField,
                           ClearableFileInput, DateField,
                           EmailInput, HiddenInput, IntegerField,
-                          ModelChoiceField, ModelForm, Form,
+                          MultipleHiddenInput, ModelChoiceField, ModelForm, Form,
                           ModelMultipleChoiceField, MultipleChoiceField,
                           Select, SelectMultiple, Textarea, TextInput,
                           TypedChoiceField)
@@ -2286,12 +2286,18 @@ class TagsField(ModelMultipleChoiceField):
     def __init__(self, *args, **kwargs):
         queryset = Tag.objects.filter(show_in_lists=True).order_by('section', 'name')
         super().__init__(queryset=queryset,
-                         widget=UsaTagSelectMultiple(),
+                         widget=get_tags_widget(),
                          required=False,
                          *args, **kwargs)
 
     def label_from_instance(self, obj: Tag):
         return f"<span class='section'>{obj.section or 'ALL'}</span> <span class='name'>{obj.name}</span>"
+
+
+def get_tags_widget():
+    if not Feature.is_feature_enabled('tags'):
+        return MultipleHiddenInput()
+    return UsaTagSelectMultiple()
 
 
 class ReportEditForm(LitigationHoldLock, ProForm, ActivityStreamUpdater):
@@ -2305,8 +2311,6 @@ class ReportEditForm(LitigationHoldLock, ProForm, ActivityStreamUpdater):
     # Summary fields
     summary = CharField(required=False, strip=True, widget=Textarea(attrs={'class': 'usa-textarea', 'data-soft-valid': 'true', 'data-soft-maxlength': 7000}))
     summary_id = IntegerField(required=False, widget=HiddenInput())
-
-    tags = TagsField()
 
     class Meta(ProForm.Meta):
         """
@@ -2333,6 +2337,8 @@ class ReportEditForm(LitigationHoldLock, ProForm, ActivityStreamUpdater):
             'violation_summary',
         ]
 
+        fields = ProForm.Meta.fields + ['tags']
+
     def success_message(self):
         return self.SUCCESS_MESSAGE
 
@@ -2350,6 +2356,8 @@ class ReportEditForm(LitigationHoldLock, ProForm, ActivityStreamUpdater):
         """
         self.user = user
         ModelForm.__init__(self, *args, **kwargs)
+
+        self.fields['tags'] = TagsField()
 
         #  We're handling old hatecrimes_trafficking data with separate boolean fields
         self.fields['hatecrime'].initial = self.instance.hatecrimes_trafficking.filter(value='physical_harm').exists()

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -51,6 +51,8 @@
         {% endwith %}
         </td>
       </tr>
+      {% else %}
+        {{ details_form.tags }} {# Renders a hidden input to not lose tags. #}
       {% endif %}
       <tr>
         <th><label for="{{details_form.primary_complaint.id_for_label}}">Primary issue</label></th>


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1656

## What does this change?

- 🌎 We have a tag widget to assign tags to Reports.
- ⛔ The widget UI is functional, but it doesn't save tags yet.
- ✅ This commit makes tags persist when save is clicked, and prevents them from being removed when the tag feature is off.

## Screenshots (for front-end PR):

![tags](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/a07d27c1-318f-46f7-af33-573aef722e4b)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
