### PR TITLE
Update expiration date calc and add tooltips

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -210,8 +210,8 @@ def report_filter(querydict):
             disposition_status = querydict.getlist(field)[0]
             today = datetime.today().date()
             qs = qs.annotate(retention_year=F('retention_schedule__retention_years'),
-                             expiration_year=F('retention_year') + ExtractYear('closed_date'),
-                             expiration_date=Cast(Concat(F('expiration_year'), Value('-'), ExtractMonth('closed_date'), Value('-'), ExtractDay('closed_date'), output_field=CharField()), output_field=DateField()),
+                             expiration_year=F('retention_year') + ExtractYear('closed_date') + 1,
+                             expiration_date=Cast(Concat(F('expiration_year'), Value('-'), Value('01'), Value('-'), Value('01'), output_field=CharField()), output_field=DateField()),
                              eligible_date=ExpressionWrapper(F('expiration_date') - timedelta(days=30), output_field=DateField()))
             if disposition_status == 'past':
                 kwargs['expiration_date__lt'] = today

--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from django.core.validators import ValidationError
 
 from django.db.models import ExpressionWrapper, Count, Min, F, Value, CharField, DateField
-from django.db.models.functions import ExtractDay, ExtractMonth, ExtractYear, Concat, Cast
+from django.db.models.functions import ExtractYear, Concat, Cast
 from django.contrib.postgres.search import SearchQuery
 from django.db import connection
 from django.http.request import QueryDict, MultiValueDict

--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/complaints_table.html
@@ -51,7 +51,7 @@
               </td>
               <td><a class="td-link display-block" href="view/{{datum.url}}">{{ datum.report.assigned_section }}</a></td>
               <td><a class="td-link display-block" href="view/{{datum.url}}">{{ datum.report.retention_schedule }}</a></td>
-              <td><a class="td-link display-block" href="view/{{datum.url}}">{{ datum.report.expiration_date|date:"SHORT_DATE_FORMAT"|default:"-" }}</a></td>
+              <td><a class="td-link display-block" href="view/{{datum.url}}">{{ datum.report.expiration_date|date:"SHORT_DATE_FORMAT" }}</a></td>
               <td><a class="td-link display-block" href="view/{{datum.url}}">{{ datum.report.closed_date|date:"SHORT_DATE_FORMAT" }}</a></td>
               <td>
                 <a class="td-link display-block" href="view/{{datum.url}}">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/table-title.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/table-title.html
@@ -2,7 +2,7 @@
     {% if disposition_status == 'past' %}
         Past disposition
     {% elif disposition_status == 'eligible' %}
-        Eligible for expiration
+        Eligible for disposition
     {% elif disposition_status == 'other' %}
         Other scheduled reports
     {% endif %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/tabs.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/tabs.html
@@ -1,19 +1,25 @@
 <div class="title">
     <ul class="usa-nav__primary usa-accordion display-flex flex-row">
       <li class="usa-nav__primary-item past-disposition" data-ga-event-name="nav item past disposition">
+        <span class="usa-tooltip" data-position="right" data-classes="display-inline" title="Reports that are past their expiration date">
         <a class="border-base text-semibold border-bottom-05 text-base-dark crt-landing--menu_link reporting-header {% if disposition_status == 'past' %} selected {% endif %}" href="/form/disposition?disposition_status=past">
           Past disposition
         </a>
+        </span>
       </li>
-      <li class="usa-nav__primary-item eligible-expiration" data-ga-event-name="nav item eligible for expiration">
+      <li class="usa-nav__primary-item eligible-expiration" data-ga-event-name="nav item eligible for disposition">
+        <span class="usa-tooltip" data-position="right" data-classes="display-inline" title="Reports that are within 30 days of or on their expiration date">
         <a class="border-base text-semibold border-bottom-05 text-base-dark crt-landing--menu_link reporting-header {% if disposition_status == 'eligible' %} selected {% endif %}" href="/form/disposition?disposition_status=eligible">
-          Eligible for expiration
+          Eligible for disposition
         </a>
+        </span>
       </li>
       <li class="usa-nav__primary-item other-scheduled" data-ga-event-name="nav item other scheduled reports">
+        <span class="usa-tooltip" data-position="right" data-classes="display-inline" title="Reports that have expiration dates more than 30 days in the future">
         <a class="border-base text-semibold border-bottom-05 text-base-dark crt-landing--menu_link reporting-header {% if disposition_status == 'other' %} selected {% endif %}" href="/form/disposition?disposition_status=other">
           Other scheduled reports
         </a>
+        </span>
       </li>
     </ul>
   </div>

--- a/crt_portal/cts_forms/tests/test_views.py
+++ b/crt_portal/cts_forms/tests/test_views.py
@@ -883,29 +883,22 @@ class CRTDispositionTests(TestCase):
         self.superuser = User.objects.create_superuser('superduperuser', 'a@a.com', '')
         self.other_report_data = SAMPLE_REPORT_1.copy()
         self.other_report_data.update({'status': 'closed'})
-        closed_date = "2022-02-01 18:17:52.74131+00"
-        self.other_report_data.update({'closed_date': closed_date})
+        self.other_report_data.update({'closed_date': date.today()})
         other_retention_schedule = RetentionSchedule.objects.get(retention_years=10)
         self.other_report_data.update({'retention_schedule': other_retention_schedule})
         Report.objects.create(**self.other_report_data)
         self.other_report_data_2 = SAMPLE_REPORT_1.copy()
         self.other_report_data_2.update({'status': 'closed'})
-        self.other_report_data_2.update({'closed_date': closed_date})
+        self.other_report_data_2.update({'closed_date': date.today()})
         other_retention_schedule_2 = RetentionSchedule.objects.get(retention_years=3)
         self.other_report_data_2.update({'retention_schedule': other_retention_schedule_2})
         Report.objects.create(**self.other_report_data_2)
         self.expired_report_data = SAMPLE_REPORT_1.copy()
         self.expired_report_data.update({'status': 'closed'})
-        self.expired_report_data.update({'closed_date': closed_date})
+        self.expired_report_data.update({'closed_date': "2020-02-01 18:17:52.74131+00"})
         expired_retention_schedule = RetentionSchedule.objects.get(retention_years=1)
         self.expired_report_data.update({'retention_schedule': expired_retention_schedule})
         Report.objects.create(**self.expired_report_data)
-        self.eligible_report_data = SAMPLE_REPORT_1.copy()
-        self.eligible_report_data.update({'status': 'closed'})
-        self.eligible_report_data.update({'closed_date': date.today() - timedelta(weeks=51)})
-        eligible_retention_schedule = RetentionSchedule.objects.get(retention_years=1)
-        self.eligible_report_data.update({'retention_schedule': eligible_retention_schedule})
-        Report.objects.create(**self.eligible_report_data)
         self.url = reverse('crt_forms:disposition')
 
     def test_view_disposition_unauthenticated(self):
@@ -928,16 +921,6 @@ class CRTDispositionTests(TestCase):
         report_len = len(reports)
         self.assertEqual(report_len, 1)
         self.assertIn('1 Year', str(response.content))
-
-    def test_eligible_for_expiration(self):
-        """Should only return one report"""
-        url = f'{self.url}?disposition_status=eligible'
-        self.client.force_login(self.superuser)
-        response = self.client.get(url)
-        reports = response.context['data_dict']
-        report_len = len(reports)
-        self.assertEqual(report_len, 1)
-        self.assertIn('3 Year', str(response.content))
 
     def test_other_scheduled_reports(self):
         """Should only return two reports"""

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -430,7 +430,7 @@ def get_report_data(requested_reports, report_url_args, paginated_offset):
         if report.contact_email:
             report.related_reports_count = _related_reports_count(report)
         if report.retention_schedule and report.closed_date:
-            report.expiration_date = datetime(report.closed_date.year + report.retention_schedule.retention_years, report.closed_date.month, report.closed_date.day).date()
+            report.expiration_date = datetime(report.closed_date.year + report.retention_schedule.retention_years + 1, 1, 1).date()
         if report.other_class:
             p_class_list.append(report.other_class)
         if len(p_class_list) > 3:

--- a/crt_portal/static/js/tour.js
+++ b/crt_portal/static/js/tour.js
@@ -48,7 +48,7 @@
   tour.addStep({
     id: 'third-step',
     text:
-      'The <strong>eligible for expiration</strong> tab shows reports that are within 30 days of or on their Expiration date.',
+      'The <strong>eligible for disposition</strong> tab shows reports that are within 30 days of or on their Expiration date.',
     attachTo: {
       element: '.eligible-expiration',
       on: 'top'


### PR DESCRIPTION
[Update disposition date calculations (temporary)#1676](https://github.com/usdoj-crt/crt-portal-management/issues/1676)

## What does this change?

This PR updates the expiration date calculation to be the 1st day of the year after the close date + # of years in retention schedule.
It also adds tooltips explaining the tabs in the new disposition view

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
