### PR TITLE
Bulk Notify Template Tweaks

### DIFF
--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -116,10 +116,10 @@ def render_complainant_mail(*, report, template, action) -> Mail:
 
 
 def _render_notification_mail(*,
-                              report: Optional[Report],
                               template: ResponseTemplate,
                               recipients: List[str],
-                              reports: Optional[List[Report]],
+                              report: Optional[Report] = None,
+                              reports: Optional[List[Report]] = None,
                               **kwargs) -> Mail:
 
     if reports:

--- a/crt_portal/cts_forms/response_templates/assigned_to_bulk.md
+++ b/crt_portal/cts_forms/response_templates/assigned_to_bulk.md
@@ -10,9 +10,9 @@ Hello,
 
 You have been assigned {{reports|length}} reports in the CRT Reporting Portal, which takes in reports from the public at civilrights.justice.gov:
 
- {% for r in reports %}
-     - [Report {{r.id}}](/form/view/{{r.id}})
- {% endfor %}
+{% for r in reports %}
+- [Report {{r.id}}](/form/view/{{r.id}})
+{% endfor %}
 
 After reviewing the links above, you can:
 
@@ -24,8 +24,3 @@ After reviewing the links above, you can:
 
 If you need training on how to process these reports, please reach out to [Bill.Laughman@usdoj.gov](mailto:bill.laughman@usdoj.gov).
 
-Sincerely,
-
-Portal Team
-
-_please do not reply to this message_


### PR DESCRIPTION
Quick fix, no issue ticket

## What does this change?

- 🌎 Notification markdown treats indented text as a code block.
- ⛔ This means it won't render lists and links within them.
- ✅ This commit de-indents to fix the rendering

- 🌎 notification.html includes a standard "Sincerely"
- ⛔ assigned_to_bulk also includes one, meaning it's displayed twice
- ✅ This commit removes assigned_to_bulk's to deduplicate that block

## Screenshots (for front-end PR):

<img width="970" alt="image" src="https://github.com/usdoj-crt/crt-portal-management/assets/15126660/ba24d64c-74c4-43c3-b58a-a329a33561d1">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
