### PR TITLE
Keep track of the filter chips to be cleared

### DIFF
--- a/crt_portal/static/js/filters.js
+++ b/crt_portal/static/js/filters.js
@@ -187,6 +187,7 @@
    */
   root.CRT.filterTagView = function(props) {
     var filters = props.el;
+    root.CRT.filterTagViewFilters = filters;
     var onClickHandler = props.onClick;
 
     filters.addEventListener('click', function handleFilterTagClick(event) {
@@ -398,7 +399,7 @@
   };
 
   root.CRT.clearAllFilters = function() {
-    const activeFilters = toArray(root.CRT.filterTagView.el.children);
+    const activeFilters = toArray(root.CRT.filterTagViewFilters.children);
 
     var updates = activeFilters.reduce(function(updates, node) {
       var filterName = node.getAttribute('data-filter-name');


### PR DESCRIPTION
No issue, quick fix

## What does this change?

- 🌎 We recently refactored the filters to work on multiple pages.
- ⛔ A side effect of that was the loss of this class structure for storing the element value in a function.
- ✅ This commit makes that value an explicit variable, so that the clear all button can figure out which filters to clear.

## Screenshots (for front-end PR):

![clearall](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/4c90bc9b-d551-46b6-afd2-96dc8caacb33)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
