### PR TITLE
Allow filtering by tags

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,7 +27,7 @@ function check_flake8() {
     echo
   fi
 
-  docker --log-level ERROR compose run --interactive --no-TTY web flake8
+  docker --log-level ERROR compose run --rm --interactive --no-TTY web flake8
   return $?
 }
 
@@ -39,7 +39,7 @@ function check_prettier() {
 
 function check_missing_migrations() {
   echo 'Running pre-commit to check for unprocessed migrations (run again with --no-verify to skip)...'
-  docker --log-level ERROR compose run --interactive --no-TTY web \
+  docker --log-level ERROR compose run --rm --interactive --no-TTY web \
     /code/crt_portal/manage.py makemigrations --check --dry-run
   return $?
 }

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -104,6 +104,24 @@ def get_dj_widget():
     })
 
 
+class TagsField(ModelMultipleChoiceField):
+    def __init__(self, *args, **kwargs):
+        queryset = Tag.objects.filter(show_in_lists=True).order_by('section', 'name')
+        super().__init__(queryset=queryset,
+                         widget=get_tags_widget(),
+                         required=False,
+                         *args, **kwargs)
+
+    def label_from_instance(self, obj: Tag):
+        return f"<span class='section'>{obj.section or 'ALL'}</span> <span class='name'>{obj.name}</span>"
+
+
+def get_tags_widget():
+    if not Feature.is_feature_enabled('tags'):
+        return MultipleHiddenInput()
+    return UsaTagSelectMultiple()
+
+
 def get_retention_schedule_widget():
     if not Feature.is_feature_enabled('disposition'):
         return HiddenInput()
@@ -1214,6 +1232,8 @@ class Filters(ModelForm):
             })
         )
 
+        self.fields['tags'] = TagsField()
+
         campaigns = {
             campaign.uuid: campaign
             for campaign in
@@ -1468,6 +1488,7 @@ class Filters(ModelForm):
             'language',
             'correctional_facility_type',
             'dj_number',
+            'tags',
             'litigation_hold',
             'retention_schedule',
         ]
@@ -2310,24 +2331,6 @@ class ContactEditForm(LitigationHoldLock, ModelForm, ActivityStreamUpdater):
 
     def success_message(self):
         return self.SUCCESS_MESSAGE
-
-
-class TagsField(ModelMultipleChoiceField):
-    def __init__(self, *args, **kwargs):
-        queryset = Tag.objects.filter(show_in_lists=True).order_by('section', 'name')
-        super().__init__(queryset=queryset,
-                         widget=get_tags_widget(),
-                         required=False,
-                         *args, **kwargs)
-
-    def label_from_instance(self, obj: Tag):
-        return f"<span class='section'>{obj.section or 'ALL'}</span> <span class='name'>{obj.name}</span>"
-
-
-def get_tags_widget():
-    if not Feature.is_feature_enabled('tags'):
-        return MultipleHiddenInput()
-    return UsaTagSelectMultiple()
 
 
 class ReportEditForm(LitigationHoldLock, ProForm, ActivityStreamUpdater):

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -113,7 +113,14 @@ class TagsField(ModelMultipleChoiceField):
                          *args, **kwargs)
 
     def label_from_instance(self, obj: Tag):
-        return f"<span class='section'>{obj.section or 'ALL'}</span> <span class='name'>{obj.name}</span>"
+        chip = f"<span class='section'>{obj.section or 'ALL'}</span> <span class='name'>{obj.name}</span>"
+
+        tag = f"<span class='usa-tag usa-tag--big'>{chip}</span>"
+
+        if obj.tooltip:
+            return f"<span class='usa-tooltip' data-position='right' data-classes='display-inline' title='{obj.tooltip}'>{tag}</span>"
+
+        return tag
 
 
 def get_tags_widget():

--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -14,7 +14,7 @@ from cts_forms.forms import add_activity
 from django.contrib.auth.models import User
 from random import randrange
 from datetime import timedelta
-from .migrate_tags import SPL_TAGS
+from .migrate_tags import ALL_TAGS
 
 
 SECTIONS = ['ADM', 'APP', 'CRM', 'DRS', 'ELS', 'EOS', 'FCS', 'HCE', 'IER', 'POL', 'SPL', 'VOT']
@@ -100,7 +100,7 @@ class Command(BaseCommand):  # pragma: no cover
             old_style_tag_chance = random.randint(1, 100)  # nosec
             if old_style_tag_chance > 75:
                 tags = ', '.join([
-                    random.choice(SPL_TAGS)[0]   # nosec
+                    random.choice(ALL_TAGS)[0]   # nosec
                     for _ in range(random.randint(1, 5))  # nosec
                 ])
                 summary = CommentAndSummary.objects.create(note=f'this summary contains old-style tags: {tags}', is_summary=True)

--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -8,12 +8,13 @@ from datetime import datetime
 from pytz import timezone
 import random
 from cts_forms.signals import salt
-from cts_forms.models import EmailReportCount, ProtectedClass, Campaign, ResponseTemplate
+from cts_forms.models import EmailReportCount, ProtectedClass, Campaign, ResponseTemplate, CommentAndSummary
 from cts_forms.model_variables import PROTECTED_MODEL_CHOICES, DISTRICT_CHOICES, STATUTE_CHOICES
 from cts_forms.forms import add_activity
 from django.contrib.auth.models import User
 from random import randrange
 from datetime import timedelta
+from .migrate_tags import SPL_TAGS
 
 
 SECTIONS = ['ADM', 'APP', 'CRM', 'DRS', 'ELS', 'EOS', 'FCS', 'HCE', 'IER', 'POL', 'SPL', 'VOT']
@@ -96,6 +97,15 @@ class Command(BaseCommand):  # pragma: no cover
             campaign_chance = random.randint(1, 100)  # nosec
             if campaign_chance > 75:
                 report.origination_utm_campaign = random.choice(campaigns)  # nosec
+            old_style_tag_chance = random.randint(1, 100)  # nosec
+            if old_style_tag_chance > 75:
+                tags = ', '.join([
+                    random.choice(SPL_TAGS)[0]   # nosec
+                    for _ in range(random.randint(1, 5))  # nosec
+                ])
+                summary = CommentAndSummary.objects.create(note=f'this summary contains old-style tags: {tags}', is_summary=True)
+                summary.save()
+                report.internal_comments.add(summary)
 
             # Code to replicate bad data that can occur in prod when there are database errors.
             # report.intake_format = None

--- a/crt_portal/cts_forms/management/commands/migrate_tags.py
+++ b/crt_portal/cts_forms/management/commands/migrate_tags.py
@@ -1,0 +1,185 @@
+from typing import List, Tuple
+from django.core.management.base import BaseCommand
+from cts_forms.models import Tag, Report, CommentAndSummary
+from django.db.models import Q
+from operator import or_, and_
+from django.core.paginator import Paginator
+from functools import reduce
+
+
+class Command(BaseCommand):  # pragma: no cover
+    help = "Load and migrate section tags"
+
+    def _fetch_spl_tags(self) -> Tuple[List[Tag], int]:
+        tags, did_create = zip(*[
+            Tag.objects.update_or_create(
+                name=name,
+                section='SPL',
+                defaults={
+                    'description': f'{description_1} ({description_2})',
+                    'tooltip': f'{description_1} ({description_2})',
+                    'show_in_lists': True,
+                }
+            )
+            for name, description_1, description_2 in SPL_TAGS
+        ])
+
+        return tags, sum(did_create)
+
+    def _create_or_update_tags(self) -> List[Tag]:
+        tags, number_created = self._fetch_spl_tags()
+        number_updated = len(tags) - number_created
+
+        self.stdout.write(self.style.SUCCESS(f'Created {number_created} tags, updated {number_updated} tags'))
+
+        return tags
+
+    def handle(self, *args, **options):
+        del args, options  # unused
+        tags = self._create_or_update_tags()
+        self._match_tags_from_summary(tags)
+
+    def _match_tags_from_summary(self, tags: List[Tag]):
+        all_terms = SPL_SEARCH_TERMS
+
+        tags_by_name = {
+            tag.name: tag
+            for tag in tags
+        }
+
+        comments_with_tags = CommentAndSummary.objects.filter(
+            and_(
+                Q(is_summary=True),
+                reduce(or_, [
+                    Q(note__contains=search_term)
+                    for search_term, _
+                    in all_terms
+                ])
+            )
+        )
+
+        reports_with_tags = Report.objects.filter(
+            internal_comments__in=comments_with_tags
+        )
+
+        changes = 0
+        for report in _paginate(reports_with_tags.order_by('name').prefetch_related('tags', 'internal_comments')):
+            changed = False
+            for search_term, tag_name in all_terms:
+                summary = report.internal_comments.order_by('-modified_date').filter(is_summary=True).first()
+                if search_term not in summary.note:
+                    continue
+
+                tag = tags_by_name[tag_name]
+                if report.tags.filter(pk=tag.pk).exists():
+                    continue
+
+                report.tags.add(tag)
+                changed = True
+
+            if changed:
+                changes += 1
+                report.save()
+
+        self.stdout.write(self.style.SUCCESS(f'Added {changes} tags to reports'))
+
+
+def _paginate(queryset):
+    paginator = Paginator(queryset, 2000)
+    for page_number in range(paginator.num_pages):
+        yield from paginator.get_page(page_number + 1)
+
+
+SPL_TAGS = [
+    ('ABNG', 'Abuse/Neglect', '168 - CRIPA'),
+    ('ACCR', 'Access To Courts', '168 - CRIPA'),
+    ('ACCS', 'Accessibility (Ada)', '204 - ADA'),
+    ('AGDS', 'Discrimination-Age', '168 - CRIPA'),
+    ('AGNG', 'Aging', '168 - CRIPA'),
+    ('ALSD', 'Access To Legal Services/Due Process', '168 - CRIPA'),
+    ('AMDA', 'Americans With Disabilities Act', '204 - ADA INMATES ONLY'),
+    ('CMPL', 'Community Placement', '168 - CRIPA'),
+    ('CRIP', 'Cripa Request', '168 - CRIPA'),
+    ('DETH', 'Death', '168 - CRIPA'),
+    ('DIGN', 'Discrimination-Gender', '168 - CRIPA'),
+    ('DILG', 'Discrimination-Lgbt', '168 - CRIPA'),
+    ('DINO', 'Discrimination-Imm/No/Lep', '168 - CRIPA'),
+    ('DINU', 'Diet/Nutrition', '168 - CRIPA'),
+    ('DIRE', 'Discrimination-Race/Ethnicity', '168 - CRIPA'),
+    ('DIRL', 'Discrimination-Religion', '210 - RLUIPA'),
+    ('DNTL', 'Dental', '168 - CRIPA'),
+    ('EVSA', 'Environmental Safety/Sanitation', '168 - CRIPA'),
+    ('EXER', 'Exercise', '168 - CRIPA'),
+    ('EXFC', 'Excessive Force', '168 - CRIPA'),
+    ('FAFS', 'First Amendment-Freedom Of Speech', '168 - CRIPA'),
+    ('FAOT', 'First Amendment-Other', '168 - CRIPA'),
+    ('FARF', 'First Amendment-Religious Freedom', '210 - RLUIPA'),
+    ('FEPR', 'Feeding Practices', '168 - CRIPA'),
+    ('FOAC', 'Face-Obstructive Activities', '206 - FACE'),
+    ('FPRD', 'Face-Property Damage', '206 - FACE'),
+    ('FTIN', 'Failure to Investigate', '207 - POLICE'),
+    ('FVLT', 'Face-Violence/Threats', '206 - FACE'),
+    ('GANG', 'Gang Related Activities', '168 - CRIPA'),
+    ('GRVN', 'Grievances', '168 - CRIPA'),
+    ('IMPB', 'Improper Pedestrian/Bike Stops', '207 - POLICE'),
+    ('IMVS', 'Improper Vehicle Stop Searches', '207 - POLICE'),
+    ('ISSE', 'Isolation/Seclusion', '168 - CRIPA'),
+    ('JVDM', 'Juvenile Justice Administration', '168 - CRIPA'),
+    ('JVFC', 'Juvenile Facility', '168 - CRIPA'),
+    ('JVIS', 'Juvenile Isolation', '168 - CRIPA'),
+    ('LOHP', 'Lack Of Hygiene Products', '168 - CRIPA'),
+    ('MAIL', 'Mail', '168 - CRIPA'),
+    ('MDCR', 'Medical Care', '168 - CRIPA'),
+    ('MNHC', 'Mental Health Care', '168 - CRIPA'),
+    ('MTGS', 'Most Integrated Setting (Ada)', '204 - ADA'),
+    ('NOJR', 'No Jurisdiction', '168 - CRIPA'),
+    ('OCTH', 'Occupational Therapy', '168 - CRIPA'),
+    ('OVCW', 'Overcrowding', '168 - CRIPA'),
+    ('PCSC', 'Police-Civilian Complaint System And Discipline', '207 - POLICE'),
+    ('PCCS', 'Police-Coercive Sexual Conduct', '207 - POLICE'),
+    ('PDHG', 'Police-Discriminatory Highway Stops', '207 - POLICE'),
+    ('PDPD', 'Police-Discriminatory Pedestrian Stops', '207 - POLICE'),
+    ('PDUT', 'Police-Discriminatory Urban Traffic Stops', '207 - POLICE'),
+    ('PEXF', 'Police-Excessive Force', '207 - POLICE'),
+    ('PFAR', 'Police-False Arrest', '207 - POLICE'),
+    ('PFHO', 'Protection From Harm-Other', '168 - CRIPA'),
+    ('PHIV', 'Protection From Harm-Inmate Violence', '168 - CRIPA'),
+    ('PHSP', 'Protection From Harm-Suicide Prevention', '168 - CRIPA'),
+    ('PHSR', 'Psychiatric Services', '168 - CRIPA'),
+    ('PLCA', 'Police-Canine', '207 - POLICE'),
+    ('PLCY', 'Policy And Procedures', '207 - POLICE'),
+    ('PLSI', 'Police/School Interaction', '207 - POLICE'),
+    ('PMEE', 'Police-Improper Searches/Seizures', '207 - POLICE'),
+    ('PMHI', 'Police/Mental Health Interaction', '207 - POLICE'),
+    ('PODP', 'Discrimination Policing-Other', '207 - POLICE'),
+    ('PRAC', 'Police-Racial Profiling', '207 - POLICE'),
+    ('PREA', 'Prison Rape Elimination Act', '168 - CRIPA'),
+    ('PRTL', 'Police-Retaliation', '207 - POLICE'),
+    ('RAPE', 'Rape', '168 - CRIPA'),
+    ('RCPR', 'Racial Profiling', '168 - CRIPA'),
+    ('RECR', 'Recreation', '168 - CRIPA'),
+    ('RETL', 'Retaliation', '168 - CRIPA'),
+    ('RHBL', 'Rehabilitation/Habilitation Services', '168 - CRIPA'),
+    ('RSCH', 'Restraints-Chemical', '168 - CRIPA'),
+    ('RSPH', 'Restraints-Physical', '168 - CRIPA'),
+    ('RSTR', 'Restraints', '168 - CRIPA'),
+    ('RWTR', 'Repeat Writer', 'ANY CODE'),
+    ('SBAT', 'Substance Abuse Treatment', '168 - CRIPA'),
+    ('SCPR', 'Suicide Prevention', '168 - CRIPA'),
+    ('SEXD', 'Sexual Discrimination', '168 - CRIPA'),
+    ('SEXM', 'Sexual Misconduct', '168 - CRIPA'),
+    ('SNTN', 'Sanitation', '168 - CRIPA'),
+    ('SPED', 'Special Education/Idea', '168 - CRIPA'),
+    ('STFF', 'Staffing', '168 - CRIPA'),
+    ('TASR', 'Taser', '168 - CRIPA'),
+    ('THCO', 'Theft/Corruption', '168 - CRIPA'),
+    ('THRT', 'Threats', '168 - CRIPA'),
+    ('VENT', 'Ventilation', '168 - CRIPA'),
+    ('VIST', 'Visitation', '168 - CRIPA'),
+]
+
+SPL_SEARCH_TERMS = [
+    (name, name)
+    for name, _, _
+    in SPL_TAGS
+]

--- a/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/active-filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/dashboard/active-filters.html
@@ -1,4 +1,4 @@
-{% load get_field_label %}
+{% load field_formatting %}
 
 <div id="active-filters" data-active-filters>
   {% for key, value in filters.items %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/active-filters.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/active-filters.html
@@ -1,20 +1,23 @@
-{% load get_field_label %}
+{% load field_formatting %}
 
 <div id="active-filters" data-active-filters>
-  {% for key, value in filters.items %}
-    {% for item in value %}
-      {% if key != "assigned_section" %}
-        <span class="usa-sr-only">{{key}}: {{item}}</span>
-        <button
-          class="filter-tag"
-          aria-label="Remove filter {{'Report'|get_field_label:key}}: {{item}} from the list"
-          data-filter-name="{{key}}"
-          data-filter-value="{{item}}"
-        >
-          <span>{{ 'Report'|get_field_label:key }}: {{item}}</span>
-          <img src="{% static 'img/intake-icons/ic_close.svg' %}" class="icon right" alt="close">
-        </button>
-      {% endif %}
-    {% endfor %}
-  {% endfor %}
+{% for key, value in filters.items %}
+{% for item in value %}
+{% if key == "assigned_section" %}
+{% else %}
+{% with plaintext=item|get_field_plaintext:key markup=item|get_field_markup:key %}
+  <span class="usa-sr-only">{{key}}: {{plaintext}}</span>
+  <button
+    class="filter-tag"
+    aria-label="Remove filter {{'Report'|get_field_label:key}}: {{plaintext}} from the list"
+    data-filter-name="{{key}}"
+    data-filter-value="{{item}}"
+  >
+    <span>{{ 'Report'|get_field_label:key }}: {{markup | safe}}</span>
+    <img src="{% static 'img/intake-icons/ic_close.svg' %}" class="icon right" alt="close">
+  </button>
+{% endwith %}
+{% endif %}
+{% endfor %}
+{% endfor %}
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filter-controls.html
@@ -40,6 +40,9 @@
       {% if ENABLED_FEATURES.dj_number %}
         {% include 'forms/complaint_view/index/filters/dj_number.html' %}
       {% endif %}
+      {% if ENABLED_FEATURES.tags %}
+        {% include 'forms/complaint_view/index/filters/tags.html' %}
+      {% endif %}
       {% if ENABLED_FEATURES.disposition %}
         {% include 'forms/complaint_view/index/filters/litigation_hold.html' %}
         {% include 'forms/complaint_view/index/filters/retention_schedule.html' %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/tags.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/tags.html
@@ -1,0 +1,11 @@
+{% extends "forms/complaint_view/index/filter.html" %}
+
+{% block controls %}tags{% endblock %}
+{% block label %}Tags{% endblock %}
+{% block id %}tags{% endblock %}
+{% block content %}
+  <label for="id_tags">
+    <span class="usa-sr-only">tags</span>
+  </label>
+  {{ form.tags }}
+{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/complaint_details.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block card_content %}
-<form id="details-edit-form" class="usa-form " method="post" novalidate>
+<form id="details-edit-form" class="usa-form {% if details_form.errors %}details-form-edit{% else %}details-form-view{% endif %}" method="post" novalidate>
 
 <div class="crt-current-summary blue-background usa-prose">
   <div id="current-summary" class="details">

--- a/crt_portal/cts_forms/templates/forms/widgets/usa_tag_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/usa_tag_option.html
@@ -5,5 +5,5 @@
   {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
   {% include "django/forms/widgets/attrs.html" %}
 /><label tabindex="0" {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
-  <span class="usa-tag usa-tag--big">{{ widget.label | safe }}</span>
+  {{ widget.label | safe }}
 </label>

--- a/crt_portal/cts_forms/templates/forms/widgets/usa_tag_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/usa_tag_option.html
@@ -4,7 +4,6 @@
   name="{{ widget.name }}"
   {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
   {% include "django/forms/widgets/attrs.html" %}
-/>
-<label tabindex="0" {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
+/><label tabindex="0" {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
   <span class="usa-tag usa-tag--big">{{ widget.label | safe }}</span>
 </label>

--- a/crt_portal/cts_forms/templates/forms/widgets/usa_tag_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/usa_tag_select.html
@@ -20,7 +20,7 @@
     {% endfor %}
   </div>
 
-  <div class="details-edit {% if not details_form.errors %}display-none{% endif %}">
+  <div class="details-edit {% if details_form and not details_form.errors %}display-none{% endif %}">
     <label class="usa-label usa-sr-only" for="{{id}}-assign-tag">Assign a tag</label>
     <div class="usa-combo-box assign-tag"
          title="Type to select a tag for this report"

--- a/crt_portal/cts_forms/templates/forms/widgets/usa_tag_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/usa_tag_select.html
@@ -4,20 +4,20 @@
   class="usa-tags-container {% if widget.attrs.class %}{{ widget.attrs.class }}{% endif %}">
 
   <div class="usa-selected-tags">
+    {% spaceless %}
     {% for group, options, index in widget.optgroups %}
     {% if group %}
     <div>
       <label>{{ group }}</label>
     {% endif %}
       {% for option in options %}
-      <div class="tag-option">
-      {% include option.template_name with widget=option %}
-      </div>
+      <div class="tag-option">{% include option.template_name with widget=option %}</div>
       {% endfor %}
     {% if group %}
     </div>
     {% endif %}
     {% endfor %}
+    {% endspaceless %}
   </div>
 
   <div class="details-edit {% if details_form and not details_form.errors %}display-none{% endif %}">

--- a/crt_portal/cts_forms/templatetags/field_formatting.py
+++ b/crt_portal/cts_forms/templatetags/field_formatting.py
@@ -54,20 +54,22 @@ def get_field_label(value, arg):
     return variable_rename.get(field.name, field.verbose_name)
 
 
-def _get_tag_section_and_name(tag_id):
+def _get_tag_attrs(tag_id, *attrs):
     Tag = apps.get_model('cts_forms', 'Tag')
-    tags = Tag.objects.filter(id=tag_id).values('name', 'section')
+    tags = Tag.objects.filter(id=tag_id).values(*attrs)
     if not tags:
-        return '', ''
-    return tags[0]['section'], tags[0]['name']
+        return [''] * len(attrs)
+    return tuple([tags[0][attr] for attr in attrs])
 
 
 def _get_tags_markup(field_content):
-    section, name = _get_tag_section_and_name(field_content)
+    section, name, tooltip = _get_tag_attrs(field_content, 'section', 'name', 'tooltip')
     return f'''
-    <span class="usa-tag usa-tag--big">
-        <span class="section">{section}</span>
-        <span class="name">{name}</span>
+    <span class="usa-tooltip" data-position="right" data-classes="display-inline" title="{tooltip}">
+        <span class="usa-tag usa-tag--big">
+            <span class="section">{section}</span>
+            <span class="name">{name}</span>
+        </span>
     </span>
     '''
 
@@ -80,7 +82,7 @@ def get_field_markup(field_content, field_name) -> str:
 
 
 def _get_tags_plaintext(field_content):
-    section, name = _get_tag_section_and_name(field_content)
+    section, name = _get_tag_attrs(field_content, 'section', 'name')
     return f'{section} - {name}'
 
 

--- a/crt_portal/cts_forms/templatetags/field_formatting.py
+++ b/crt_portal/cts_forms/templatetags/field_formatting.py
@@ -34,6 +34,7 @@ variable_rename = {
     'actions': 'Actions',
     'litigation_hold': 'Litigation hold',
     'retention_schedule': 'Retention schedule',
+    'tags': 'Tag',
 }
 
 
@@ -51,3 +52,40 @@ def get_field_label(value, arg):
         return variable_rename.get(arg, arg.replace('_', ' '))
 
     return variable_rename.get(field.name, field.verbose_name)
+
+
+def _get_tag_section_and_name(tag_id):
+    Tag = apps.get_model('cts_forms', 'Tag')
+    tags = Tag.objects.filter(id=tag_id).values('name', 'section')
+    if not tags:
+        return '', ''
+    return tags[0]['section'], tags[0]['name']
+
+
+def _get_tags_markup(field_content):
+    section, name = _get_tag_section_and_name(field_content)
+    return f'''
+    <span class="usa-tag usa-tag--big">
+        <span class="section">{section}</span>
+        <span class="name">{name}</span>
+    </span>
+    '''
+
+
+@register.filter(name='get_field_markup')
+def get_field_markup(field_content, field_name) -> str:
+    if field_name == 'tags':
+        return _get_tags_markup(field_content)
+    return field_content
+
+
+def _get_tags_plaintext(field_content):
+    section, name = _get_tag_section_and_name(field_content)
+    return f'{section} - {name}'
+
+
+@register.filter(name='get_field_plaintext')
+def get_field_plaintext(field_content, field_name) -> str:
+    if field_name == 'tags':
+        return _get_tags_plaintext(field_content)
+    return field_content

--- a/crt_portal/static/js/complaint_view_filters.js
+++ b/crt_portal/static/js/complaint_view_filters.js
@@ -22,6 +22,7 @@
     assigned_to: '',
     origination_utm_campaign: '',
     dj_number: '',
+    tags: [],
     public_id: '',
     primary_statute: '',
     district: '',
@@ -46,39 +47,42 @@
 
   function filterController() {
     root.CRT.formEl = dom.getElementById('filters-form');
-    var firstNameEl = root.CRT.formEl.querySelector('input[name="contact_first_name"]');
-    var lastNameEl = root.CRT.formEl.querySelector('input[name="contact_last_name"]');
-    var locationCityEl = root.CRT.formEl.querySelector('input[name="location_city_town"]');
-    var locationNameEl = root.CRT.formEl.querySelector('input[name="location_name"]');
-    var locationStateEl = dom.getElementsByName('location_state');
-    var activeFiltersEl = dom.querySelector('[data-active-filters]');
-    var clearAllEl = dom.querySelector('[data-clear-filters]');
-    var statusEl = dom.getElementsByName('status');
-    var summaryEl = root.CRT.formEl.querySelector('input[name="summary"]');
-    var createdatestartEl = root.CRT.formEl.querySelector('input[name="create_date_start"]');
-    var createdateendEl = root.CRT.formEl.querySelector('input[name="create_date_end"]');
-    var assigneeEl = root.CRT.formEl.querySelector('#id_assigned_to');
-    var campaignEl = root.CRT.formEl.querySelector('#id_origination_utm_campaign');
-    var djNumberEl = root.CRT.formEl.querySelectorAll('.crt-dj-number input');
-    var complaintIDEl = root.CRT.formEl.querySelector('input[name="public_id"]');
-    var statuteEl = root.CRT.formEl.querySelector('select[name="primary_statute"]');
-    var districtEl = root.CRT.formEl.querySelector('select[name="district"]');
-    var perPageEl = dom.getElementsByName('per_page');
-    var groupingEl = dom.querySelector('select[name="grouping"]');
-    var personalDescriptionEl = root.CRT.formEl.querySelector('textarea[name="violation_summary"]');
-    var primaryIssueEl = dom.getElementsByName('primary_complaint');
-    var reportedReasonEl = dom.getElementsByName('reported_reason');
-    var relevantDetailsEl = dom.getElementsByName('commercial_or_public_place');
-    var intakeFormatEl = dom.getElementsByName('intake_format');
-    var hateCrimeEl = dom.getElementsByName('hate_crime');
-    var servicememberEl = dom.getElementsByName('servicemember');
-    var contactEmailEl = dom.querySelector('input[name="contact_email"]');
-    var referredEl = dom.getElementsByName('referred');
-    var languageEl = dom.getElementsByName('language');
-    var contactPhoneEL = dom.getElementsByName('contact_phone')[0];
-    var correctionalFacilityTypeEl = dom.getElementsByName('correctional_facility_type');
-    var litigationHoldEl = dom.getElementsByName('litigation_hold');
-    var retentionScheduleEl = dom.getElementsByName('retention_schedule');
+    const firstNameEl = root.CRT.formEl.querySelector('input[name="contact_first_name"]');
+    const lastNameEl = root.CRT.formEl.querySelector('input[name="contact_last_name"]');
+    const locationCityEl = root.CRT.formEl.querySelector('input[name="location_city_town"]');
+    const locationNameEl = root.CRT.formEl.querySelector('input[name="location_name"]');
+    const locationStateEl = dom.getElementsByName('location_state');
+    const activeFiltersEl = dom.querySelector('[data-active-filters]');
+    const clearAllEl = dom.querySelector('[data-clear-filters]');
+    const statusEl = dom.getElementsByName('status');
+    const summaryEl = root.CRT.formEl.querySelector('input[name="summary"]');
+    const createdatestartEl = root.CRT.formEl.querySelector('input[name="create_date_start"]');
+    const createdateendEl = root.CRT.formEl.querySelector('input[name="create_date_end"]');
+    const assigneeEl = root.CRT.formEl.querySelector('#id_assigned_to');
+    const campaignEl = root.CRT.formEl.querySelector('#id_origination_utm_campaign');
+    const djNumberEl = root.CRT.formEl.querySelectorAll('.crt-dj-number input');
+    const complaintIDEl = root.CRT.formEl.querySelector('input[name="public_id"]');
+    const statuteEl = root.CRT.formEl.querySelector('select[name="primary_statute"]');
+    const districtEl = root.CRT.formEl.querySelector('select[name="district"]');
+    const perPageEl = dom.getElementsByName('per_page');
+    const groupingEl = dom.querySelector('select[name="grouping"]');
+    const personalDescriptionEl = root.CRT.formEl.querySelector(
+      'textarea[name="violation_summary"]'
+    );
+    const primaryIssueEl = dom.getElementsByName('primary_complaint');
+    const tagsEl = dom.getElementsByName('tags');
+    const reportedReasonEl = dom.getElementsByName('reported_reason');
+    const relevantDetailsEl = dom.getElementsByName('commercial_or_public_place');
+    const intakeFormatEl = dom.getElementsByName('intake_format');
+    const hateCrimeEl = dom.getElementsByName('hate_crime');
+    const servicememberEl = dom.getElementsByName('servicemember');
+    const contactEmailEl = dom.querySelector('input[name="contact_email"]');
+    const referredEl = dom.getElementsByName('referred');
+    const languageEl = dom.getElementsByName('language');
+    const contactPhoneEL = dom.getElementsByName('contact_phone')[0];
+    const correctionalFacilityTypeEl = dom.getElementsByName('correctional_facility_type');
+    const litigationHoldEl = dom.getElementsByName('litigation_hold');
+    const retentionScheduleEl = dom.getElementsByName('retention_schedule');
 
     root.CRT.formView({
       el: root.CRT.formEl
@@ -168,6 +172,10 @@
       name: 'primary_complaint'
     });
     root.CRT.checkBoxView({
+      el: tagsEl,
+      name: 'tags'
+    });
+    root.CRT.checkBoxView({
       el: reportedReasonEl,
       name: 'reported_reason'
     });
@@ -222,7 +230,7 @@
     if (root.location.search === '') {
       root.location.search = '?status=new&status=open&no_status=false&grouping=default';
     }
-    var filterUpdates = root.CRT.getQueryParams(
+    const filterUpdates = root.CRT.getQueryParams(
       root.location.search,
       Object.keys(root.CRT.initialFilterState)
     );

--- a/crt_portal/static/js/filters.js
+++ b/crt_portal/static/js/filters.js
@@ -372,21 +372,8 @@
   root.CRT.onFilterTagClick = function(node) {
     var filterName = node.getAttribute('data-filter-name');
 
-    // see if we have to process multiple select elements first
-    var multiSelectElements = [
-      'status',
-      'location_state',
-      'violation_summary',
-      'primary_complaint',
-      'intake_format',
-      'commercial_or_public_place',
-      'reported_reason',
-      'language',
-      'correctional_facility_type',
-      'retention_schedule'
-    ];
-    var filterIndex = multiSelectElements.indexOf(filterName);
-    if (filterIndex !== -1) {
+    const isMultiSelect = root.CRT.filterDataModel[filterName] instanceof Array;
+    if (isMultiSelect) {
       var selections = root.CRT.filterDataModel[filterName];
       var selectionData = node.getAttribute('data-filter-value');
       selections.splice(selections.indexOf(selectionData), 1);

--- a/crt_portal/static/js/usa_tag_select.js
+++ b/crt_portal/static/js/usa_tag_select.js
@@ -10,6 +10,12 @@
     });
   }
 
+  function checkAndChange(checkbox, shouldBeChecked) {
+    checkbox.checked = shouldBeChecked;
+    checkbox.dispatchEvent(new Event('click'));
+    checkbox.dispatchEvent(new Event('change'));
+  }
+
   function listenForSelect(wrapper) {
     const select = wrapper.querySelector('.usa-combo-box.assign-tag select');
     const checkboxes = wrapper.querySelectorAll('.usa-selected-tags input[type="checkbox"]');
@@ -18,7 +24,7 @@
       if (!event.target.value) return;
       const tagId = event.target.value;
       select.value = '';
-      selectedTags.querySelector(`input[value="${tagId}"]`).checked = true;
+      checkAndChange(selectedTags.querySelector(`input[value="${tagId}"]`), true);
       updateComboOptions(select, checkboxes);
       setTimeout(() => {
         wrapper.querySelector('.usa-combo-box__clear-input').click();
@@ -57,7 +63,7 @@
       const label = checkbox.nextElementSibling;
       label.addEventListener('keypress', function(event) {
         if (!['Enter', ' '].includes(event.key)) return;
-        checkbox.click();
+        checkAndChange(checkbox, false);
       });
       checkbox.addEventListener('change', event => {
         if (!wrapper.closest('.details-form-edit')) {

--- a/crt_portal/static/js/usa_tag_select.js
+++ b/crt_portal/static/js/usa_tag_select.js
@@ -66,7 +66,7 @@
         checkAndChange(checkbox, false);
       });
       checkbox.addEventListener('change', event => {
-        if (!wrapper.closest('.details-form-edit')) {
+        if (wrapper.closest('.details-form-view')) {
           // Edit mode is off.
           checkbox.checked = true;
           event.preventDefault();

--- a/crt_portal/static/js/usa_tag_select.js
+++ b/crt_portal/static/js/usa_tag_select.js
@@ -46,14 +46,13 @@
 
   function styleExpandedDropdown(comboBoxItem) {
     if (!comboBoxItem.classList.contains('usa-combo-box__list-option')) return;
-    const sectionTag = comboBoxItem.innerText.split(' ');
-    if (sectionTag.length !== 2) return;
-    const [section, tag] = sectionTag;
-    comboBoxItem.innerHTML = `
-      <span class="usa-tag usa-tag--big">
-        <span class="section">${section}</span> <span class="name">${tag}</span>
-      </span>
-    `;
+
+    const tagId = comboBoxItem.dataset.value;
+    const checkbox = comboBoxItem
+      .closest('.usa-tags-container')
+      .querySelector(`.usa-selected-tags input[value="${tagId}"]`);
+
+    comboBoxItem.innerHTML = checkbox.dataset.label;
   }
 
   function listenForDeselect(wrapper) {

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -1040,29 +1040,30 @@ form#cts-forms-profile {
       display: inline-block;
     }
   }
+}
 
-  .usa-tag {
-    background-color: #e1e7f1;
-    color: #162e51;
-    padding-left: 0;
-    padding-top: 0;
-    padding-bottom: 0;
+.usa-tag {
+  font-weight: normal;
+  background-color: #e1e7f1;
+  color: #162e51;
+  padding-left: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  padding-right: 5px;
+
+  .section {
+    border-radius: 3px;
+    margin-right: 0;
+    padding-left: 5px;
     padding-right: 5px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    background-color: #2378c3;
+    color: white;
+  }
 
-    .section {
-      border-radius: 3px;
-      margin-right: 0;
-      padding-left: 5px;
-      padding-right: 5px;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-      background-color: #2378c3;
-      color: white;
-    }
-
-    .name {
-      text-transform: none;
-    }
+  .name {
+    text-transform: none;
   }
 }
 

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -887,6 +887,10 @@ form#cts-forms-profile {
     font-weight: 700;
     line-height: 1.6; /* Prevent text from being clipped */
   }
+
+  &[data-filter-name="tags"] > span {
+    overflow: visible;
+  }
 }
 
 .intake-table {
@@ -1060,6 +1064,10 @@ form#cts-forms-profile {
   padding-top: 0;
   padding-bottom: 0;
   padding-right: 5px;
+
+  .usa-tooltip__body {
+    text-transform: none;
+  }
 
   .section {
     border-radius: 3px;

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -1002,19 +1002,29 @@ form#cts-forms-profile {
   }
 }
 
-.details-form-edit .usa-selected-tags .usa-tag {
+.usa-selected-tags .usa-tag {
   cursor: pointer;
-  padding-right: 0;
+  padding-right: 2;
 
   &:after {
     content: "";
     height: 1rem;
     width: 1.25rem;
-    margin-left: 4px;
+    margin-left: 0px;
     display: inline-block;
     background-image: url(../../img/usa-icons/close.svg);
     background-repeat: no-repeat;
     background-size: cover;
+  }
+}
+
+.details-form-view {
+  .usa-tag:after {
+    display: none;
+  }
+
+  div.usa-combo-box {
+    display: none;
   }
 }
 
@@ -1037,7 +1047,7 @@ form#cts-forms-profile {
 
   .usa-selected-tags {
     .tag-option {
-      display: inline-block;
+      display: block;
     }
   }
 }
@@ -1063,6 +1073,7 @@ form#cts-forms-profile {
   }
 
   .name {
+    padding-left: 3px;
     text-transform: none;
   }
 }


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1656

## What does this change?

- 🌎 The tags feature preview allows assigning tags to reports.
- ⛔ We can't currently search by those tags.
- ✅ This commit allows this by adding a tags filter control.

## Screenshots (for front-end PR):

![filter-by-tags](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/8ecf42d1-3c56-43a6-9cdd-8405feebeb06)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
