### PR TITLE
Assign tags to appropriate reports on migrate_tags

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,7 +27,7 @@ function check_flake8() {
     echo
   fi
 
-  docker --log-level ERROR compose run --interactive --no-TTY web flake8
+  docker --log-level ERROR compose run --rm --interactive --no-TTY web flake8
   return $?
 }
 
@@ -39,7 +39,7 @@ function check_prettier() {
 
 function check_missing_migrations() {
   echo 'Running pre-commit to check for unprocessed migrations (run again with --no-verify to skip)...'
-  docker --log-level ERROR compose run --interactive --no-TTY web \
+  docker --log-level ERROR compose run --rm --interactive --no-TTY web \
     /code/crt_portal/manage.py makemigrations --check --dry-run
   return $?
 }

--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -8,12 +8,13 @@ from datetime import datetime
 from pytz import timezone
 import random
 from cts_forms.signals import salt
-from cts_forms.models import EmailReportCount, ProtectedClass, Campaign, ResponseTemplate
+from cts_forms.models import EmailReportCount, ProtectedClass, Campaign, ResponseTemplate, CommentAndSummary
 from cts_forms.model_variables import PROTECTED_MODEL_CHOICES, DISTRICT_CHOICES, STATUTE_CHOICES
 from cts_forms.forms import add_activity
 from django.contrib.auth.models import User
 from random import randrange
 from datetime import timedelta
+from .migrate_tags import SPL_TAGS
 
 
 SECTIONS = ['ADM', 'APP', 'CRM', 'DRS', 'ELS', 'EOS', 'FCS', 'HCE', 'IER', 'POL', 'SPL', 'VOT']
@@ -96,6 +97,15 @@ class Command(BaseCommand):  # pragma: no cover
             campaign_chance = random.randint(1, 100)  # nosec
             if campaign_chance > 75:
                 report.origination_utm_campaign = random.choice(campaigns)  # nosec
+            old_style_tag_chance = random.randint(1, 100)  # nosec
+            if old_style_tag_chance > 75:
+                tags = ', '.join([
+                    random.choice(SPL_TAGS)[0]   # nosec
+                    for _ in range(random.randint(1, 5))  # nosec
+                ])
+                summary = CommentAndSummary.objects.create(note=f'this summary contains old-style tags: {tags}', is_summary=True)
+                summary.save()
+                report.internal_comments.add(summary)
 
             # Code to replicate bad data that can occur in prod when there are database errors.
             # report.intake_format = None

--- a/crt_portal/cts_forms/templates/forms/widgets/usa_tag_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/usa_tag_option.html
@@ -4,7 +4,6 @@
   name="{{ widget.name }}"
   {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
   {% include "django/forms/widgets/attrs.html" %}
-/>
-<label tabindex="0" {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
+/><label tabindex="0" {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
   <span class="usa-tag usa-tag--big">{{ widget.label | safe }}</span>
 </label>

--- a/crt_portal/cts_forms/templates/forms/widgets/usa_tag_select.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/usa_tag_select.html
@@ -4,20 +4,20 @@
   class="usa-tags-container {% if widget.attrs.class %}{{ widget.attrs.class }}{% endif %}">
 
   <div class="usa-selected-tags">
+    {% spaceless %}
     {% for group, options, index in widget.optgroups %}
     {% if group %}
     <div>
       <label>{{ group }}</label>
     {% endif %}
       {% for option in options %}
-      <div class="tag-option">
-      {% include option.template_name with widget=option %}
-      </div>
+      <div class="tag-option">{% include option.template_name with widget=option %}</div>
       {% endfor %}
     {% if group %}
     </div>
     {% endif %}
     {% endfor %}
+    {% endspaceless %}
   </div>
 
   <div class="details-edit {% if details_form and not details_form.errors %}display-none{% endif %}">

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -1010,7 +1010,7 @@ form#cts-forms-profile {
     content: "";
     height: 1rem;
     width: 1.25rem;
-    margin-left: 4px;
+    margin-left: 2px;
     display: inline-block;
     background-image: url(../../img/usa-icons/close.svg);
     background-repeat: no-repeat;
@@ -1037,7 +1037,7 @@ form#cts-forms-profile {
 
   .usa-selected-tags {
     .tag-option {
-      display: inline-block;
+      display: block;
     }
   }
 }
@@ -1063,6 +1063,7 @@ form#cts-forms-profile {
   }
 
   .name {
+    padding-left: 3px;
     text-transform: none;
   }
 }


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1656

## What does this change?

- 🌎 Migrate tags creates a list of tags based on existing summary comments.
- ⛔ It doesn't update existing reports that have the tag content in their summaries.
- ✅ This commit modifies the command to assign tags to reports as appropriate when run.

## Screenshots (for front-end PR):

<img width="622" alt="image" src="https://github.com/usdoj-crt/crt-portal-management/assets/15126660/1cca6e3a-1bcc-43bc-ab53-66a8b1e72433">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
