### PR TITLE
Add VOT tags

### DIFF
--- a/crt_portal/cts_forms/management/commands/create_mock_reports.py
+++ b/crt_portal/cts_forms/management/commands/create_mock_reports.py
@@ -14,7 +14,7 @@ from cts_forms.forms import add_activity
 from django.contrib.auth.models import User
 from random import randrange
 from datetime import timedelta
-from .migrate_tags import SPL_TAGS
+from .migrate_tags import ALL_TAGS
 
 
 SECTIONS = ['ADM', 'APP', 'CRM', 'DRS', 'ELS', 'EOS', 'FCS', 'HCE', 'IER', 'POL', 'SPL', 'VOT']
@@ -100,7 +100,7 @@ class Command(BaseCommand):  # pragma: no cover
             old_style_tag_chance = random.randint(1, 100)  # nosec
             if old_style_tag_chance > 75:
                 tags = ', '.join([
-                    random.choice(SPL_TAGS)[0]   # nosec
+                    random.choice(ALL_TAGS)[0]   # nosec
                     for _ in range(random.randint(1, 5))  # nosec
                 ])
                 summary = CommentAndSummary.objects.create(note=f'this summary contains old-style tags: {tags}', is_summary=True)


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1656

## What does this change?

- 🌎 VOT uses tags in summaries
- ⛔ There are a lot of them and we want to pull them from past reports
- ✅ This commit adds VOT to the backfill logic for migrate_tags
- 🔮 Future commits may tweak these tags

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
