### PR TITLE
Generate PDFs of admin walkthrough screenshots.

### DIFF
--- a/crt_portal/cts_forms/tests/integration_authed/admin_walkthroughs.py
+++ b/crt_portal/cts_forms/tests/integration_authed/admin_walkthroughs.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 
 from cts_forms.tests.integration_authed.auth import login_as_superuser
-from cts_forms.tests.integration_util import console, element
+from cts_forms.tests.integration_util import console, element, reporting
 
 
 @pytest.mark.only_browser("chromium")
@@ -28,12 +28,14 @@ def test_walkthroughs(page):
     logging.warning(f'Discovered walkthroughs: {all_tours}')
 
     for tour in all_tours:
+        report = reporting.PdfReport(f'{tour}.pdf')
         page.goto('/admin/')
-        _click_through_steps(page, tour)
+        _click_through_steps(page, tour, report)
+        report.save()
 
 
-def _click_through_steps(page, tour, *, current_step=None, total_steps=None):
-    if current_step is None:
+def _click_through_steps(page, tour, report, *, current_step=None, total_steps=None):
+    if current_step is None or total_steps is None:
         page.click(f'#content-main .tours tr[data-tour="{tour}"] th .start-tour')
         page.wait_for_selector('.shepherd-text')
 
@@ -45,10 +47,16 @@ def _click_through_steps(page, tour, *, current_step=None, total_steps=None):
 
     step = page.locator(f'.shepherd-step-number-{current_step}')
     step.wait_for()
+    header = step.locator('.shepherd-header').inner_text()
+    text = step.locator('.shepherd-text').inner_html()
+    caption = f'<h1>{header}</h1><p>{text}</p>'
+    step.evaluate('e => e.hidden = true')
+    report.screenshot(page, caption=caption)
+    step.evaluate('e => e.hidden = false')
 
     logging.warning(f'Clicking through walkthrough {tour} ({current_step}/{total_steps})')
     if current_step < total_steps:
         step.locator('.shepherd-button').filter(has_text="Next").click()
-        return _click_through_steps(page, tour, current_step=current_step + 1, total_steps=total_steps)
+        return _click_through_steps(page, tour, report, current_step=current_step + 1, total_steps=total_steps)
 
     step.locator('.shepherd-button').filter(has_text="Done").click()

--- a/crt_portal/cts_forms/tests/integration_util/reporting.py
+++ b/crt_portal/cts_forms/tests/integration_util/reporting.py
@@ -1,0 +1,77 @@
+import weasyprint
+import tempfile
+import pathlib
+
+
+class PdfReport:
+    """Captures multiple screenshots over time and aggregates them into a PDF."""
+
+    def __init__(self, path_to_pdf):
+        self.path_to_pdf = f'e2e-screenshots/{path_to_pdf}'
+        self.screenshots = []
+
+    def screenshot(self, page, caption=''):
+        self.screenshots.append({
+            'file': page.screenshot(),
+            'caption': caption,
+        })
+
+    def _prepare_screenshots_for_save(self):
+        temp = tempfile.mkdtemp()
+        for index, screenshot in enumerate(self.screenshots):
+            path = f'{temp}/{index}.png'
+            screenshot['path'] = path
+            with open(path, 'wb') as f:
+                f.write(screenshot['file'])
+
+    def _screenshot_to_html(self, screenshot):
+        path = screenshot['path']
+        caption = screenshot['caption']
+        return f'''
+            <div class="page">
+                <img src="file://{path}" />
+                <div class="caption">{caption}</div>
+            </div>
+        '''
+
+    def save(self):
+        self._prepare_screenshots_for_save()
+
+        directory = pathlib.Path(self.path_to_pdf).parent
+        directory.mkdir(parents=True, exist_ok=True)
+
+        stylesheet = weasyprint.CSS(
+            string='''
+                @page {
+                    size: letter;
+                    margin: 0;
+                }
+                body {
+                    margin: 0;
+                    padding: 0;
+                }
+                div.page {
+                    page: page;
+                    page-break-after: always;
+                    margin-top: 0.5in;
+                    width: 8.5in;
+                }
+                div.page > * {
+                    width: 7.5in;
+                    margin-left: 0.5in;
+                }
+                img {
+                    margin-bottom: 1em;
+                    border: 1px solid black;
+                }
+            '''
+        )
+
+        weasyprint.HTML(
+            string=''.join([
+                self._screenshot_to_html(screenshot)
+                for screenshot
+                in self.screenshots
+            ])
+        ).write_pdf(self.path_to_pdf,
+                    stylesheets=[stylesheet])


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1686

## What does this change?

- 🌎 It'd be nice to have admin walkthroughs in a PDF
- ⛔ PDFs are annoying to build and keep up-to-date
- ✅ This commit generates them from the walkthrough e2e tests

## Screenshots (for front-end PR):

Example PDFs:

[Setting up a referral contact](https://github.com/usdoj-crt/crt-portal-management/files/13674800/setup-referral-contact.pdf)

[Example tour (proof of concept)](https://github.com/usdoj-crt/crt-portal-management/files/13674802/example.pdf)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
