### PR TITLE
Add warning when complaint status is updated without saving

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/index.html
@@ -127,4 +127,5 @@
 <script src="{% static 'js/show_count.min.js'%}"></script>
 <script src="{% static 'js/activity_stream.min.js'%}"></script>
 <script src="{% static 'js/discard_button.min.js'%}"></script>
+<script src="{% static 'js/save_warning.min.js'%}"></script>
 {%endblock%}

--- a/crt_portal/static/js/save_warning.js
+++ b/crt_portal/static/js/save_warning.js
@@ -1,0 +1,10 @@
+(function() {
+    let formChanged = false;
+    const statusForm = document.querySelector("#complaint-view-actions");
+    statusForm.addEventListener('change', () => formChanged = true);
+    window.addEventListener('beforeunload', (e) => {
+      if (formChanged) {
+        e.returnValue = 'Changes you made may not be saved.';
+      }
+    });
+  })();

--- a/crt_portal/static/js/save_warning.js
+++ b/crt_portal/static/js/save_warning.js
@@ -1,9 +1,15 @@
 (function() {
-  let formChanged = false;
-  const statusForm = document.querySelector('#complaint-view-actions');
-  statusForm.addEventListener('change', () => (formChanged = true));
+  let showWarning = false;
+  const forms = document.querySelectorAll('.usa-form');
+  forms.forEach(form => {
+    form.addEventListener('change', () => (showWarning = true));
+  });
+  const btns = document.querySelectorAll('.usa-button');
+  btns.forEach(btn => {
+    btn.addEventListener('click', () => (showWarning = false));
+  });
   window.addEventListener('beforeunload', e => {
-    if (formChanged) {
+    if (showWarning) {
       e.returnValue = 'Changes you made may not be saved.';
     }
   });

--- a/crt_portal/static/js/save_warning.js
+++ b/crt_portal/static/js/save_warning.js
@@ -4,7 +4,7 @@
   forms.forEach(form => {
     form.addEventListener('change', () => (showWarning = true));
   });
-  const btns = document.querySelectorAll('.usa-button');
+  const btns = document.querySelectorAll('[type="submit"]');
   btns.forEach(btn => {
     btn.addEventListener('click', () => (showWarning = false));
   });

--- a/crt_portal/static/js/save_warning.js
+++ b/crt_portal/static/js/save_warning.js
@@ -1,10 +1,10 @@
 (function() {
-    let formChanged = false;
-    const statusForm = document.querySelector("#complaint-view-actions");
-    statusForm.addEventListener('change', () => formChanged = true);
-    window.addEventListener('beforeunload', (e) => {
-      if (formChanged) {
-        e.returnValue = 'Changes you made may not be saved.';
-      }
-    });
-  })();
+  let formChanged = false;
+  const statusForm = document.querySelector('#complaint-view-actions');
+  statusForm.addEventListener('change', () => (formChanged = true));
+  window.addEventListener('beforeunload', e => {
+    if (formChanged) {
+      e.returnValue = 'Changes you made may not be saved.';
+    }
+  });
+})();


### PR DESCRIPTION
## What does this change?
This PR adds an alert when a user makes a change to the complaint actions card and doesn't save before trying to leave the page. Note that we cannot customize the alert because it's default to the browser.
## Screenshots (for front-end PR):
![Image](https://github.com/usdoj-crt/crt-portal-management/assets/18104884/b053bd42-98ad-4051-80ea-568b43e2dc80)
## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
