### PR TITLE
Add lit hold to bulk actions menu

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -2084,6 +2084,31 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
             if values.count() == 1:
                 yield key, values[0]
 
+    def setup_litigation_hold(self, query):
+        litigation_hold_states = query.order_by().values_list('litigation_hold', flat=True).distinct()
+        if litigation_hold_states.count() == 1:
+            initial = 'on' if litigation_hold_states[0] else 'off'
+        else:
+            initial = ''
+        self.fields['litigation_hold'] = ChoiceField(
+            label='Litigation hold',
+            widget=ComplaintSelect(
+                attrs={'class': 'crt-dropdown__data'},
+            ),
+            choices=(('on', 'On'), ('off', 'Off'), ('', self.EMPTY_CHOICE)),
+            required=False,
+            initial=initial,
+        )
+
+    def clean_litigation_hold(self):
+        if 'litigation_hold' not in self.changed_data:
+            return ''
+        if self.cleaned_data['litigation_hold'] == 'on':
+            return True
+        if self.cleaned_data['litigation_hold'] == 'off':
+            return False
+        return ''
+
     def __init__(self, query, *args, user=None, **kwargs):
         self.user = user
         Form.__init__(self, *args, **kwargs)
@@ -2097,6 +2122,8 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
             disabled=not self.can_assign_schedule(),
             widget=get_retention_schedule_widget(),
         )
+
+        self.setup_litigation_hold(query)
 
         # set initial values if applicable
         keys = ['assigned_section', 'status', 'primary_statute', 'dj_number', 'retention_schedule', 'referred', 'district']
@@ -2129,7 +2156,7 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
         updates = {field: self.cleaned_data[field] for field in self.changed_data}
         # do not allow any fields to be unset. this may happen if the
         # user selects "Multiple".
-        for key in ['assigned_section', 'status', 'primary_statute', 'dj_number', 'retention_schedule', 'referred']:
+        for key in ['assigned_section', 'status', 'primary_statute', 'dj_number', 'retention_schedule', 'referred', 'litigation_hold']:
             if key in updates and updates[key] in [None, '']:
                 updates.pop(key)
         # if section is changed, override assignee, status, retention schedule, secondary review

--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/bulk_actions.html
@@ -38,6 +38,7 @@
           <li>Assigned to</li>
           {% if ENABLED_FEATURES.disposition %}
           <li>Retention schedule</li>
+          <li>Litigation hold</li>
           {% endif %}
         </ul>
         <p>
@@ -73,6 +74,12 @@
             {{ bulk_actions_form.retention_schedule.label }}
           </label>
           {{ bulk_actions_form.retention_schedule }}
+        </div>
+        <div class="margin-bottom-2 crt-checkbox">
+          <label for="id_litigation_hold" class="intake-label">
+            {{ bulk_actions_form.litigation_hold.label }}
+          </label>
+          {{ bulk_actions_form.litigation_hold }}
         </div>
         {% endif %}
         <div class="margin-bottom-2 crt-textarea">


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1694

## What does this change?

Adds lit hold to the bulk actions menu (see ticket for details)

## Screenshots (for front-end PR):

<img width="486" alt="image" src="https://github.com/usdoj-crt/crt-portal-management/assets/15126660/d7b27c2f-0d40-4afb-b65c-e726079c0ca0">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
