### PR TITLE
Prevent closing unviewed with bulk actions

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -2105,6 +2105,15 @@ class BulkActionsForm(LitigationHoldLock, Form, ActivityStreamUpdater):
         if not self.fields['dj_number'].initial:
             self.fields['dj_number'].initial = '--'
 
+    def clean(self, *args, **kwargs):
+        cleaned_data = super().clean(*args, **kwargs)
+        is_closing = cleaned_data.get('status') == 'closed'
+        all_viewed = not self.queryset.filter(viewed=False).exists()
+        if is_closing and not all_viewed:
+            raise ValidationError('Not all reports in the queryset have been viewed. Each report must be viewed before it can be closed.')
+
+        return cleaned_data
+
     def can_assign_schedule(self):
         if not self.user:
             return False

--- a/crt_portal/cts_forms/tests/integration_authed/intake_close_report.py
+++ b/crt_portal/cts_forms/tests/integration_authed/intake_close_report.py
@@ -23,6 +23,9 @@ def test_close_report_via_bulk_actions(page):
     with page.expect_navigation():
         page.evaluate("document.getElementById('apply-filters-button').click()")
 
+    # We can't bulk-close if reports are not viewed:
+    page.locator('.td-toggle-all').click()
+
     # This should be the bulk action checkbox:
     page.evaluate("document.querySelector('.tr-status-new input[type=\"checkbox\"]').click()")
 

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from cts_forms.mail import render_complainant_mail, render_agency_mail
 
 from ..forms import BulkActionsForm, ComplaintActions, ComplaintOutreach, ContactEditForm, Filters, ReportEditForm
-from ..model_variables import PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES, NEW_STATUS
+from ..model_variables import CLOSED_STATUS, PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES, NEW_STATUS
 from ..models import CommentAndSummary, NotificationPreference, ReferralContact, Report, ResponseTemplate, EmailReportCount, RetentionSchedule
 from .factories import ReportFactory
 from .test_data import SAMPLE_REFERRAL_CONTACT, SAMPLE_REPORT_1, SAMPLE_RESPONSE_TEMPLATE
@@ -187,6 +187,23 @@ class ActionTests(TestCase):
         # So, we're just asserting there's no retention_schedule change here:
         self.assertCountEqual(form.get_actions(a), [])
         self.assertCountEqual(form.get_actions(b), [])
+
+    def test_unviewed_reports_raises_error(self):
+        unviewed = Report.objects.create(**SAMPLE_REPORT_1, public_id='a', retention_schedule=self.schedule1, viewed=False)
+        viewed = Report.objects.create(**SAMPLE_REPORT_1, public_id='b', retention_schedule=self.schedule1, viewed=True)
+        queryset = Report.objects.all().filter(pk__in=[viewed.pk, unviewed.pk])
+
+        form = BulkActionsForm(queryset, {
+            'status': CLOSED_STATUS,
+            'comment': 'Test bulk change',
+        })
+        form.full_clean()
+
+        self.assertDictEqual(form.errors, {
+            '__all__': [
+                'Not all reports in the queryset have been viewed. Each report must be viewed before it can be closed.'
+            ],
+        })
 
     def test_litigation_hold_turns_on(self):
         instance = Report.objects.create(**SAMPLE_REPORT_1,

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -1035,7 +1035,7 @@ class BulkActionsTests(TestCase):
         self.test_pass = secrets.token_hex(32)
         self.user = User.objects.create_user('DELETE_USER', 'ringo@thebeatles.com', self.test_pass)
         self.client.login(username='DELETE_USER', password=self.test_pass)
-        self.reports = ReportFactory.create_batch(16, assigned_section='ADM', status='new')
+        self.reports = ReportFactory.create_batch(16, assigned_section='ADM', status='new', viewed=True)
 
     def get(self, ids, all_ids=False):
         params = {


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1720

## What does this change?

- 🌎 Bulk actions allows reports to be closed
- ⛔ This includes unviewed reports
- ✅ This commit prevents that with a validation error

## Screenshots (for front-end PR):

Here's the error:

<img width="647" alt="image" src="https://github.com/usdoj-crt/crt-portal-management/assets/15126660/493b401c-2762-4431-93f1-db70efe09f9e">

Here's triggering the error (the "New" report is unviewed)

![bulk](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/ec5a7670-66f4-42b8-a5f1-724c816962f2)

Here's it working when the report is viewed.

![bulk_good](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/ce79198b-6c54-448c-af68-7033165fef53)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
