### PR TITLE
Update save warning logic for combo boxes

### DIFF
--- a/crt_portal/static/js/save_warning.js
+++ b/crt_portal/static/js/save_warning.js
@@ -1,18 +1,29 @@
 (function() {
   let showWarning = false;
+  const maybeAddWarning = function(e) {
+    if (
+      e.target.classList.contains('usa-combo-box__select') &&
+      !e.target.classList.contains('combobox-loaded')
+    ) {
+      e.target.classList.add('combobox-loaded');
+    } else {
+      showWarning = true;
+    }
+  };
+
   const commentForm = document.querySelector('#comment-actions-comment');
-  commentForm.addEventListener('change', () => (showWarning = true));
+  commentForm.addEventListener('change', maybeAddWarning);
   const actionForm = document.querySelector('#complaint-view-actions');
   actionForm
     .querySelectorAll('input')
-    .forEach(input => input.addEventListener('change', () => (showWarning = true)));
+    .forEach(input => input.addEventListener('change', maybeAddWarning));
   actionForm
     .querySelectorAll('select')
-    .forEach(input => input.addEventListener('change', () => (showWarning = true)));
+    .forEach(select => select.addEventListener('change', maybeAddWarning));
   const contactForm = document.querySelector('#contact-edit-form');
-  contactForm.addEventListener('change', () => (showWarning = true));
+  contactForm.addEventListener('change', maybeAddWarning);
   const detailsForm = document.querySelector('#details-edit-form');
-  detailsForm.addEventListener('change', () => (showWarning = true));
+  detailsForm.addEventListener('change', maybeAddWarning);
   const btns = document.querySelectorAll('[type="submit"]');
   btns.forEach(btn => {
     btn.addEventListener('click', () => (showWarning = false));


### PR DESCRIPTION
## What does this change?

Currently there is a bug with the save warning where a change is registered on the form combo boxes before the user interacts with them triggering the save warning. This PR changes the logic to only trigger the warning when those inputs are truly updated.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
