### PR TITLE
Split the bulk actions menu

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/actions/index.html
@@ -26,12 +26,17 @@
       </div>
 
       <div class="complaint-page grid-row grid-gap-4">
+        {% if not action %}
         <div class="complaint-actions tablet:grid-col-5 grid-offset-1">
           {% include 'forms/complaint_view/actions/bulk_actions.html' %}
         </div>
-        <div class="complaint-actions tablet:grid-col-5 margin-top-2">
+        {% endif %}
+
+        {% if action == 'print' %}
+        <div class="complaint-actions tablet:grid-col-5 grid-offset-1 margin-top-2">
           {% include 'forms/complaint_view/actions/bulk_print.html' with reports=print_reports %}
         </div>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/complaints_table.html
@@ -164,7 +164,10 @@
         <span id="selection-action-count" class="selection-action-count">1 record</span> selected
       </h2>
       <div class="selection-submit">
-        <button type="submit" id="actions" label="actions" class="usa-button">Actions</button>
+        <button data-ga-event-name="complaints bulk actions" type="submit" name="action" id="actions" label="actions" class="usa-button bulk-submit-ga">Actions</button>
+        <button data-ga-event-name="complaints bulk print" type="submit" name="action" value="print" id="actions" label="actions" class="usa-button bulk-submit-ga">
+          <span class="usa-tooltip" data-position="right" data-classes="display-inline" title="This may take a while if many reports are selected.">Print</span>
+        </button>
       </div>
     </div>
   </div>

--- a/crt_portal/cts_forms/tests/test_crt_forms.py
+++ b/crt_portal/cts_forms/tests/test_crt_forms.py
@@ -1131,6 +1131,7 @@ class BulkActionsTests(TestCase):
             'next': '?per_page=8',
             'id': ids,
             'all': 'all',
+            'action': 'print',
         }
         response = self.client.get(reverse('crt_forms:crt-forms-actions'), params)
         self.assertEqual(response.status_code, 200)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -926,6 +926,7 @@ class ActionsView(LoginRequiredMixin, FormView):
         selected_all = selected_all and all_ids_count != ids_count
 
         output = {
+            'action': request.GET.get('action', ''),
             'return_url_args': return_url_args,
             'selected_all': 'all' if selected_all else '',
             'ids': ','.join(ids),

--- a/crt_portal/static/js/bulk_actions.js
+++ b/crt_portal/static/js/bulk_actions.js
@@ -3,6 +3,9 @@
   AriaAutocomplete(select, {});
 
   var comment_field = document.getElementById('id_comment');
+  if (!comment_field) {
+    return; // This is the print view, no actions are shown.
+  }
   comment_field.oninput = function(event) {
     var buttons = document.querySelectorAll('.complaint-page .usa-button');
     for (var i = 0; i < buttons.length; i++) {

--- a/crt_portal/static/js/ga_util.js
+++ b/crt_portal/static/js/ga_util.js
@@ -49,6 +49,9 @@ function sendGAClickEvent(e) {
     if (groupingButton !== null) {
       groupingButton.addEventListener('change', sendGAClickEvent);
     }
+    Array.from(document.querySelectorAll('.bulk-submit-ga')).forEach(button => {
+      button.addEventListener('click', sendGAClickEvent);
+    });
   }
   window.addEventListener('DOMContentLoaded', init);
 })(window, document);

--- a/crt_portal/static/js/print_report.js
+++ b/crt_portal/static/js/print_report.js
@@ -55,10 +55,10 @@
   };
 
   const report = document.getElementById('printout_report');
-  report.addEventListener('click', showModal);
+  report?.addEventListener('click', showModal);
 
   const cancelModal = document.getElementById('print_report_cancel');
-  root.CRT.cancelModal(modal, cancelModal);
+  if (cancelModal) root.CRT.cancelModal(modal, cancelModal);
 
   const printButtons = document.querySelectorAll('.print-report-button');
   Object.keys(OPTION_MAPPING_TO_SECTION).forEach(optionId => {


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1723

## What does this change?

- The bulk actions menu performs poorly
- This is because of the print menu loading all of the selected reports into it for printing
- This PR splits the menu in "Print" and "Actions", which makes the actions workflow faster
- Future PRs should explore more efficient ways to manage "Print"

## Screenshots (for front-end PR):

(See: https://github.com/usdoj-crt/crt-portal-management/issues/1723)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
