### PR TITLE
Fix fuzzy matching for long incident locations.

### DIFF
--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -552,6 +552,8 @@ class SimilarityFilterTests(TestCase):
                                  'location_name': 'fayk lokayshun'})
         Report.objects.create(**{**SAMPLE_REPORT_4,
                                  'location_name': 'no do not match this'})
+        Report.objects.create(**{**SAMPLE_REPORT_1,
+                                 'location_name': 225 * "🚨"})
 
     def test_matches(self):
         reports = filter_by_similar(


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1727

## What does this change?

- 🌎 Some incident locations have more than 255 bytes of data. This is because some characters take up more than one byte.
- ⛔ This breaks fuzzy search, which only works on up to 255 bytes.
- ✅ This commit fixes the issue by truncating where possible, and filtering where the truncated version is still too long

## Screenshots (for front-end PR):

N/A - see tests for example. The incident location field allows 225 characters, but each "🚨" character has 4 bytes - so 225 🚨 characters is 900 bytes.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
