### PR TITLE
Allow exporting disposition batches as a PDF

### DIFF
--- a/crt_portal/utils/pdf.py
+++ b/crt_portal/utils/pdf.py
@@ -1,14 +1,20 @@
+from typing import Any
+from collections.abc import Callable
 import io
+import logging
 
 from django.forms.models import model_to_dict
+from django.http import HttpResponse
 from django.template.loader import render_to_string
 import markdown
 import pypdf
 import weasyprint
+import zipfile
 
-from cts_forms.models import Report
+from cts_forms.models import Report, ReportDispositionBatch
 from cts_forms.mail import CustomHTMLExtension
 from tms.models import TMSEmail
+from django.contrib.postgres.aggregates import ArrayAgg
 
 
 class FailedToGeneratePDF(RuntimeError):
@@ -88,6 +94,56 @@ def convert_tms_to_pdf(email: TMSEmail) -> io.BytesIO:
     return out
 
 
+def convert_disposed_to_pdf(batch: ReportDispositionBatch) -> io.BytesIO:
+    raw_reports_by_schedule = (
+        batch.disposed_reports
+        .values('schedule__name')
+        .order_by('schedule__name')
+        .annotate(public_ids=ArrayAgg('public_id'))
+    )
+    reports_by_schedule = {
+        schedule['schedule__name']: schedule['public_ids']
+        for schedule in raw_reports_by_schedule
+    }
+
+    meta = {
+        'Batch ID': str(batch.uuid),
+        'Disposed by': batch.disposed_by.get_username(),
+        'Date of destruction': batch.disposed_date,
+        '# Disposed Reports': batch.disposed_reports.count(),
+        **{
+            f'Disposed Reports ({schedule})': ', '.join(public_ids)
+            for schedule, public_ids in reports_by_schedule.items()
+        },
+    }
+
+    meta_template = '\n'.join([
+        '|        | Message Details |',
+        '|--------|--------|',
+        *[f'| {key} | {value} |' for key, value in meta.items()],
+    ])
+
+    page = _render_markdown(f"""
+The following reports were disposed by the Civil Rights Division on {batch.disposed_date} as part of batch {batch.uuid}:
+
+{meta_template}
+    """)
+
+    header_style = weasyprint.CSS(string=f"""
+     @page {{
+         @top-right{{
+             content: "Disposition Batch {batch.uuid}";
+         }}
+     }}
+    """)
+
+    pdf = pypdf.PdfMerger()
+    pdf.append(convert_html_to_pdf(page, stylesheets=[header_style]))
+    out = io.BytesIO()
+    pdf.write(out)
+    return out
+
+
 def convert_report_to_pdf(report: Report) -> io.BytesIO:
     """Exports a report as a pdf."""
     data = {
@@ -98,3 +154,37 @@ def convert_report_to_pdf(report: Report) -> io.BytesIO:
     }
     html = render_to_string('referral_info.html', data)
     return convert_html_to_pdf(html)
+
+
+def admin_export_pdf(queryset, *,
+                     pdf_filename: Callable[[Any], str],
+                     zip_filename: str,
+                     converter: Callable[[Any], io.BytesIO]) -> HttpResponse:
+    """Exports a queryset as a pdf."""
+    buffer = io.BytesIO()
+    archive = zipfile.ZipFile(buffer, "w")
+
+    if queryset.count() == 1:
+        try:
+            content = convert_report_to_pdf(queryset.first())
+            return HttpResponse(content.getvalue(), content_type="application/pdf")
+        except FailedToGeneratePDF as error:
+            logging.exception(error)
+            return HttpResponse(f'{error}', status=500)
+
+    errors = []
+    for report in queryset:
+        try:
+            content = convert_report_to_pdf(report)
+            archive.writestr(f'{report.public_id}.pdf', content.getvalue())
+        except FailedToGeneratePDF as error:
+            logging.exception(error)
+            errors.append(f'{report.public_id}: {error}')
+    if errors:
+        archive.writestr("errors.txt", "\n".join(errors))
+    archive.close()
+
+    response = HttpResponse(buffer.getvalue(), content_type="application/zip")
+    response["Content-Disposition"] = 'attachment; filename="reports_export.zip"'
+
+    return response

--- a/crt_portal/utils/tests/test_pdf.py
+++ b/crt_portal/utils/tests/test_pdf.py
@@ -1,9 +1,10 @@
 import datetime
 from django.test import TestCase
 from utils import pdf
+from unittest import mock
 import pypdf
 from tms.models import TMSEmail
-from cts_forms.models import Report
+from cts_forms.models import Report, ReportDispositionBatch, User, RetentionSchedule
 from cts_forms.tests.test_data import SAMPLE_REPORT_1
 
 
@@ -21,7 +22,7 @@ class PdfTests(TestCase):
     def test_tms_converts(self):
         self.maxDiff = 9999999999
         report = Report(**SAMPLE_REPORT_1)
-        report.pk = 123
+        report.public_id = 123
         email = TMSEmail(tms_id=456,
                          report=report,
                          subject='Foo subject',
@@ -50,3 +51,40 @@ class PdfTests(TestCase):
         self.assertIn('Purpose manual', cover)
         self.assertIn('Error message oh no bad thing', cover)
         self.assertIn('Foo body', contents)
+
+    test_user = User(username='pdf_test_user')
+
+    @classmethod
+    def setUpTestData(cls):
+        User.objects.filter(username='pdf_test_user').delete()
+        cls.test_user.save()
+        test_data = {
+            **SAMPLE_REPORT_1.copy(),
+            'retention_schedule': RetentionSchedule.objects.get(name='1 Year'),
+            'location_name': 'batch disposition tests',
+        }
+        for i, schedule in enumerate(['1 Year', '3 Year', '3 Year']):
+            kwargs = {
+                **test_data,
+                'retention_schedule': RetentionSchedule.objects.get(name=schedule)
+            }
+            Report.objects.create(**kwargs, public_id=f'{i}-ABC')
+
+    @mock.patch('crequest.middleware.CrequestMiddleware.get_request',
+                return_value=mock.Mock(user=test_user))
+    def test_disposition_batch_converts(self, mock_get_request):
+        del mock_get_request  # unused
+        self.maxDiff = 9999999999
+
+        queryset = Report.objects.filter(location_name='batch disposition tests')
+        batch = ReportDispositionBatch.dispose(queryset)
+        converted = pdf.convert_disposed_to_pdf(batch)
+
+        reader = pypdf.PdfReader(converted)
+        self.assertEqual(len(reader.pages), 1)
+        contents = reader.pages[0].extract_text()
+        self.assertIn('Civil Rights Division', contents)
+        self.assertIn('Disposed Reports (1 Year) 0-ABC', contents)
+        self.assertIn('Disposed Reports (3 Year) 1-ABC, 2-ABC', contents)
+        self.assertIn('Disposed by pdf_test_user', contents)
+        self.assertIn(f'Date of destruction {batch.disposed_date}', contents)


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1689

## What does this change?

- 🌎 Previous commits added a way to keep track of disposed reports in batches
- ⛔ Historical disposition batches will need to be downloaded as pdfs
- ✅ This commit adds the ability to export them as PDFs
- 🔮 Because it's not currently possible to trigger disposition in the app yet, future commits will handle actually exposing this feature. For now, unit tests prove that it's working.

## Screenshots (for front-end PR):

N/A - see unit tests, feature is not reachable from the application yet.

## Checklist:


### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
