### PR TITLE
Add a view all link to datatables

### DIFF
--- a/crt_portal/static/js/data-tables.js
+++ b/crt_portal/static/js/data-tables.js
@@ -5,6 +5,62 @@
     return JSON.parse(atob(b64));
   }
 
+  function getFilters(tableOrApi) {
+    const filters = [];
+    if (tableOrApi instanceof DataTable.Api) {
+      tableOrApi.columns().every(function() {
+        if (!this.visible()) {
+          filters.push(null);
+          return;
+        }
+        const filter = this.header().dataset.filter;
+        filters.push(filter);
+      });
+      return filters;
+    }
+
+    const headers = [...tableOrApi.querySelectorAll('thead th')];
+    return headers.map(th => th.dataset.filter);
+  }
+
+  const SECTIONS =
+    '&assigned_section=ADM&assigned_section=APP&assigned_section=CRM&assigned_section=DRS&assigned_section=ELS&assigned_section=EOS&assigned_section=FCS&assigned_section=HCE&assigned_section=IER&assigned_section=POL&assigned_section=SPL&assigned_section=VOT';
+
+  function buildRowLink(filters, row) {
+    const filterMap = filters.reduce((soFar, filter, columnIndex) => {
+      if (!filter) return soFar;
+      soFar[filter] = row[columnIndex];
+      return soFar;
+    }, {});
+
+    const queryString = new URLSearchParams(filterMap).toString();
+    const sections = filterMap['assigned_section'] ? '' : SECTIONS;
+    return `/form/view/?${queryString}${sections}`;
+  }
+
+  function maybeAddViewAllHeader(tableOrApi) {
+    const table = $(tableOrApi instanceof DataTable.Api ? tableOrApi.table().node() : tableOrApi);
+    if (table.find('thead th.view-all').length) return;
+    table.find('thead tr').append('<th class="view-all">View all</th>');
+  }
+
+  function addViewAll(tableOrApi, rows) {
+    const filters = getFilters(tableOrApi);
+    if (filters.every(filter => !filter)) {
+      rows.forEach(row => {
+        row.push('N/A');
+      });
+      return;
+    }
+
+    maybeAddViewAllHeader(tableOrApi, filters);
+
+    rows.forEach(row => {
+      const link = buildRowLink(filters, row);
+      row.push(`<a class="view-all" href="${link}">View all</a>`);
+    });
+  }
+
   function getOptions(table) {
     const options = {
       colReorder: true,
@@ -29,11 +85,12 @@
       dom: 'Bfrtip'
     };
 
-    columns = getData(table, 'columns');
-    if (columns) options.columns = columns;
-
-    rows = getData(table, 'rows');
-    if (rows) options.data = rows;
+    const rows = getData(table, 'rows');
+    if (rows) {
+      saveRows(rows);
+      addViewAll(table, rows);
+      options.data = rows;
+    }
 
     return options;
   }
@@ -110,15 +167,12 @@
       });
   }
 
-  function saveRows(dataTable) {
-    const content = JSON.stringify(dataTable.data().toArray());
-    sessionStorage.setItem('dataDashboardContent', content);
-    return dataTable;
+  function saveRows(rows) {
+    sessionStorage.setItem('dataDashboardContent', JSON.stringify(rows));
   }
 
-  function readRows(dataTable) {
-    const data = JSON.parse(sessionStorage.getItem('dataDashboardContent'));
-    return dataTable.clear().rows.add(data);
+  function readRows() {
+    return JSON.parse(sessionStorage.getItem('dataDashboardContent'));
   }
 
   /**
@@ -127,7 +181,7 @@
    * If a row's name includes "(sum)",
    * it will be added to other rows that are otherwise the same
    */
-  function aggregate(dataTable) {
+  function aggregate(rows, dataTable) {
     const aggregates = {};
 
     const allColumnIndices = dataTable.columns().indexes();
@@ -146,22 +200,28 @@
     const sum = Array.from(visibleColumns.filter(c => c.toLowerCase().includes('(sum)')));
     const sumIndices = sum.map(col => allColumns.indexOf(col));
 
-    dataTable.rows().every(function() {
-      const key = groupByIndices.reduce((soFar, col) => `${soFar}|${this.data()[col]}`, '');
+    rows.forEach(row => {
+      const key = groupByIndices.reduce((soFar, col) => `${soFar}|${row[col]}`, '');
       if (!aggregates.hasOwnProperty(key)) {
         aggregates[key] = groupByIndices.reduce((soFar, col) => {
-          soFar[col] = this.data()[col];
+          soFar[col] = row[col];
           return soFar;
         }, {});
       }
       sumIndices.forEach(col => {
-        aggregates[key][col] = (aggregates[key][col] || 0) + Number(this.data()[col]);
+        aggregates[key][col] = (aggregates[key][col] || 0) + Number(row[col]);
       });
     });
+
+    if (allColumns[allColumns.length - 1].toLowerCase() === 'view all') {
+      allColumnIndices.pop();
+    }
 
     const groupedRows = Object.values(aggregates).map(row => {
       return allColumnIndices.map(col => (row.hasOwnProperty(col) ? row[col] : ''));
     });
+
+    addViewAll(dataTable, groupedRows);
 
     dataTable.clear();
     dataTable.rows.add(groupedRows);
@@ -173,12 +233,11 @@
       options = getOptions(table);
 
       const dataTable = $(table).DataTable(options);
-      saveRows(dataTable);
-
       setupFilters(table, dataTable);
+      dataTable.draw();
 
       $(table).on('column-visibility.dt', function() {
-        aggregate(readRows(dataTable)).draw();
+        aggregate(readRows(), dataTable).draw();
       });
     });
   });

--- a/jupyterhub/helpers/transformers.py
+++ b/jupyterhub/helpers/transformers.py
@@ -2,10 +2,97 @@ import base64
 import json
 from sql.run.resultset import ResultSet
 
+DISPLAY_NAMES = {
+    'cts_forms_report': {
+        'status': 'Status',
+        'assigned_section': 'Routed',
+        'contact_first_name': 'Contact first name',
+        'contact_last_name': 'Contact last name',
+        'dj_number': 'DJ number',
+        'location_city_town': 'Incident city',
+        'location_name': 'Organization name',
+        'location_state': 'Incident state',
+        'assigned_to': 'Assignee',
+        'origination_utm_campaign': 'Campaign',
+        'public_id': 'Complaint ID',
+        'primary_statute': 'Classification',
+        'district': 'District number',
+        'violation_summary': 'Personal description',
+        'primary_complaint': 'Primary issue',
+        'servicemember': 'Servicemember',
+        'hate_crime': 'Hate crime',
+        'intake_format': 'Intake type',
+        'commercial_or_public_place': 'Relevant details',
+        'reported_reason': 'Reported reason',
+        'summary': 'CRT summary',
+        'contact_email': 'Contact email',
+        'referred': 'Secondary review',
+        'language': 'Report language',
+        'correctional_facility_type': 'Prison type',
+        'create_date': 'Submission date',
+        'litigation_hold': 'Litigation hold',
+        'retention_schedule': 'Retention schedule',
+        'tags': 'Tag',
+    }
+}
 
-def result_to_html_table(result: ResultSet, **kwargs) -> str:
+# Add values to this set to enable filtering on a column
+FILTERS = {
+    'cts_forms_report': {
+        'actions',
+        'assigned_section',
+        'status',
+        'contact_first_name',
+        'contact_last_name',
+        'public_id',
+        'assigned_to',
+        'origination_utm_campaign',
+        'tags',
+        'litigation_hold',
+        'location_address_line_1',
+        'location_address_line_2',
+        'location_city_town',
+        'location_state',
+        'retention_schedule',
+        'contact_email',
+        'contact_phone',
+        'create_date',
+        'closed_date',
+        'modified_date',
+        'primary_statute',
+        'district',
+        'primary_complaint',
+        'dj_number',
+        'reported_reason',
+        'commercial_or_public_place',
+        'servicemember',
+        'intake_format',
+        'referred',
+        'language',
+        'hate_crime',
+        'correctional_facility_type',
+        'violation_summary',
+        'summary',
+        'location_name',
+        'other_class',
+        'disposition_status',
+    }
+}
+
+
+def column_to_html(table_name, key) -> str:
+    display_names = DISPLAY_NAMES.get(table_name, {})
+    display = display_names.get(key, key.replace('_', ' ').title())
+
+    filters = FILTERS.get(table_name, {})
+    filter_arg = f' data-filter="{key}"' if key in filters else ''
+
+    return f'<th{filter_arg}>{display}</th>'
+
+
+def result_to_html_table(result: ResultSet, table_name, **kwargs) -> str:
     columns = ''.join([
-        f'<th>{key}</th>'
+        column_to_html(table_name, key)
         for key in result.keys
     ])
 


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1731

## What does this change?

- 🌎 It's useful to be able to see what reports match a given table
- ⛔ That's currently not possible
- ✅ This commit adds a "view all" link automatically where possible

## Screenshots (for front-end PR):

![view-all](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/dce885da-ec97-449b-990f-7fbabd104e4d)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
