### PR TITLE
Autorun dashboard notebooks

### DIFF
--- a/docs/maintenance_or_infrequent_tasks.md
+++ b/docs/maintenance_or_infrequent_tasks.md
@@ -1,4 +1,5 @@
 # Maintenance or infrequent tasks
+
 [:arrow_left: Back to Documentation](../docs)
 
 ## Change protected class options
@@ -18,30 +19,34 @@ To rename existing models, change the name in model_variables.py PROTECTED_CLASS
 You should be able to reorder the form by setting the value in the database or making a data migration to update the protected classes and form_order. Do NOT use the Django admin for this task, you can [use the Django shell](#use-the-django-shell) to help figure out what the migration should be.
 
 ## Add a new optional form
+
 See example code here: https://github.com/usdoj-crt/crt-portal/pull/209/files
 
-1) Make any model changes in models.py, such as new fields. Create and then apply the migration
+1. Make any model changes in models.py, such as new fields. Create and then apply the migration
 
-2) Make a form class in forms.py. You can inherit pieces of other forms if this form is similar to another.
+2. Make a form class in forms.py. You can inherit pieces of other forms if this form is similar to another.
 
-3) make a function to determine when you want the form to show on the front end
+3. make a function to determine when you want the form to show on the front end
 
-4) Add the form class and the function to urls.py
+4. Add the form class and the function to urls.py
 
-5) In views.py
-    - add the new page name for the form page `to all_step_names`
-    - add the top-line title for the page to `ordered_step_titles`
-    - add an existing or template to the `TEMPLATES` list
+5. In views.py
+   - add the new page name for the form page `to all_step_names`
+   - add the top-line title for the page to `ordered_step_titles`
+   - add an existing or template to the `TEMPLATES` list
 
 ## Debugging tips
 
 ### Front end
+
 If you are trying to figure out what variables are getting passed to the template you can add the following code in any template:
 
     <pre> {% filter force_escape %} {% debug %} {% endfilter %} </pre>
 
 ### Back end
+
 #### Use the Django shell
+
 SSH into a docker image so you have local database access, (your image may have a different name)
 
     docker exec -it crt-portal_web_1 /bin/bash
@@ -60,16 +65,19 @@ import your models or whatever you are working with
 Start typing and try out code interactively.
 
 #### pdb
+
 The built in python debugger is good for setting traces.
 See the [pdb documentation](https://docs.python.org/3.8/library/pdb.html) for details
 
 ## Single sign on
+
 #### Setting environment variables
+
 Request the set up with JMD. When they get things set up on their side, they will be able to supply:
-    AUTH_CLIENT_ID
-    AUTH_SERVER
-    AUTH_USERNAME_CLAIM
-    AUTH_GROUP_CLAIM
+AUTH_CLIENT_ID
+AUTH_SERVER
+AUTH_USERNAME_CLAIM
+AUTH_GROUP_CLAIM
 
 Those variables need to be set, as well as the secret key if you already have VCAPSERVICES. You can check the current settings first, in case you need to revert them with:
 
@@ -119,7 +127,6 @@ crt_portal/crt_portal/settings.py
     +if environment in ['PRODUCTION', 'STAGE']:
          INSTALLED_APPS.append('django_auth_adfs')
 
-
 crt_portal/crt_portal/urls.py
 
     environment = os.environ.get('ENV', 'UNDEFINED')
@@ -137,17 +144,18 @@ crt_portal/crt_portal/urls.py
     ]
 
 # Adding mock reports
+
 To add mock reports for local testing, run the create_mock_reports command with the number of reports you want.
 
 For example, run
 
-```docker-compose run web python crt_portal/manage.py create_mock_reports 10```
+`docker-compose run web python crt_portal/manage.py create_mock_reports 10`
 
 to generate 10 reports.
 
 If you need to modify reports for individual testing needs, you can do it temporarily in the python file. For example, if you wanted to test performance of the SQL command that generates the #Total column on "view/form", uncomment
 
-```# report.contact_email = "test@test.test"```
+`# report.contact_email = "test@test.test"`
 
 in "create_mock_reports.py" to create multiple reports with the same email address.
 
@@ -157,7 +165,7 @@ We use [locust](https://docs.locust.io/en/stable/what-is-locust.html) for load t
 
 The scripts won't work on single sign on, I recommend you upgrade staging to have the same DBs and number of instances and do the test on staging without single sign on. Before you do a test on a live site reach out to cloud.gov at support@cloud.gov to give them a heads up, and check that the test will be held at a good time.
 
-Create an unique username and password in staging so that the script can test internal views. Add those values as variables locally that can be accessed as    `LOAD_TESTER` and `LOAD_PASSWORD`.
+Create an unique username and password in staging so that the script can test internal views. Add those values as variables locally that can be accessed as `LOAD_TESTER` and `LOAD_PASSWORD`.
 
 If you want to run it locally, and you have set up pipenv you can run it with:
 
@@ -174,130 +182,129 @@ After the test is done, delete the user you made for testing.
 
     pipenv shell
 
-
 # Database upgrades
 
 For staging and prod we use the `medium-psql-redundant` database service. These instructions are for updating dev to `medium-psql-redundant` and can be adapted to move prod to a `large-psql-redundant` instance. Check the [cloud.gov docs](https://cloud.gov/docs/services/relational-database/) for any updates or new recommendations.
 
 ### Here are instructions of how to upgrade the dev db
 
-1) **Install dependencies.**
+1. **Install dependencies.**
 
-    - Install [`cf-service-connect`](https://github.com/cloud-gov/cf-service-connect), a cloud.gov tool for moving data around
-    [https://github.com/cloud-gov/cf-service-connect](https://github.com/cloud-gov/cf-service-connect)
-    (Darwin is the Mac binary)
-    - If you don't already have it, install [`pgcli`](https://postgresapp.com/documentation/cli-tools.html), a command line tool for working with PostgreSQL.
+   - Install [`cf-service-connect`](https://github.com/cloud-gov/cf-service-connect), a cloud.gov tool for moving data around
+     [https://github.com/cloud-gov/cf-service-connect](https://github.com/cloud-gov/cf-service-connect)
+     (Darwin is the Mac binary)
+   - If you don't already have it, install [`pgcli`](https://postgresapp.com/documentation/cli-tools.html), a command line tool for working with PostgreSQL.
 
-2) **Sign into cloud.gov and set `cf target` to desired instance.** This gives you command line access to the instance.
+2. **Sign into cloud.gov and set `cf target` to desired instance.** This gives you command line access to the instance.
 
-    ```sh
-    cf login -a api.fr.cloud.gov --sso
-    ```
+   ```sh
+   cf login -a api.fr.cloud.gov --sso
+   ```
 
-    Enter the passcode from the URL that is given to you, and make sure you select the correct organization and space.
+   Enter the passcode from the URL that is given to you, and make sure you select the correct organization and space.
 
-    ```sh
-    cf target -s dev
-    ```
+   ```sh
+   cf target -s dev
+   ```
 
-3) **Export data from existing database.** Database dumps from dev and staging instances can be downloaded locally, but for prod it may be better to put the file in the private s3 bucket or somewhere on the DOJ network.
+3. **Export data from existing database.** Database dumps from dev and staging instances can be downloaded locally, but for prod it may be better to put the file in the private s3 bucket or somewhere on the DOJ network.
 
-    In a separate shell window, connect to the service to setup a direct SSH tunnel and leave it running. Note the credentials and connection info given in the output.
+   In a separate shell window, connect to the service to setup a direct SSH tunnel and leave it running. Note the credentials and connection info given in the output.
 
-    ```sh
-    cf connect-to-service -no-client crt-portal-django crt-db
-    ```
+   ```sh
+   cf connect-to-service -no-client crt-portal-django crt-db
+   ```
 
-    Back in the original window, dump the database outside of the project directory using the credentials provided in the SSH tab.
+   Back in the original window, dump the database outside of the project directory using the credentials provided in the SSH tab.
 
-    ```sh
-    pg_dump -f crt_dev_<date>.dump postgres://<username>:<password>@<host>:<port>/<name>
-    ```
+   ```sh
+   pg_dump -f crt_dev_<date>.dump postgres://<username>:<password>@<host>:<port>/<name>
+   ```
 
-    After the dump has finished, you can return to the SSH tab and press Control-C to close the tunnel.
+   After the dump has finished, you can return to the SSH tab and press Control-C to close the tunnel.
 
-4) **Create new database.**
+4. **Create new database.**
 
-    ```sh
-    cf create-service aws-rds medium-psql-redundant crt-db-new
-    ```
+   ```sh
+   cf create-service aws-rds medium-psql-redundant crt-db-new
+   ```
 
-    You can run `cf services` to see that the new database is being created. Wait for it to finish creating before proceeding to the next step.
+   You can run `cf services` to see that the new database is being created. Wait for it to finish creating before proceeding to the next step.
 
-5) **Load data into the new database.**
+5. **Load data into the new database.**
 
-    After the new database has been created, open a new shell window and open a SSH tunnel to the new database. Again, note the credentials and connection info in the output.
+   After the new database has been created, open a new shell window and open a SSH tunnel to the new database. Again, note the credentials and connection info in the output.
 
-    ```sh
-    cf connect-to-service -no-client crt-portal-django crt-db-new
-    ```
+   ```sh
+   cf connect-to-service -no-client crt-portal-django crt-db-new
+   ```
 
-    Back in the original window, load the database from the dumped file using the credentials for the new database.
+   Back in the original window, load the database from the dumped file using the credentials for the new database.
 
-    ```sh
-    psql postgres://<username>:<password>@<host>:<port>/<name> < crt_dev_<date>.dump
-    ```
+   ```sh
+   psql postgres://<username>:<password>@<host>:<port>/<name> < crt_dev_<date>.dump
+   ```
 
-    You may see some errors because the new database doesn't have the same roles. This is fine: roles could only be preserved by running `pg_dumpall` command on the original database, and we didn't do that because we do not have access to run that on `shared_psql` instances. The data will still be loaded just fine.
+   You may see some errors because the new database doesn't have the same roles. This is fine: roles could only be preserved by running `pg_dumpall` command on the original database, and we didn't do that because we do not have access to run that on `shared_psql` instances. The data will still be loaded just fine.
 
-    After the data has been loaded, close the SSH tunnel.
+   After the data has been loaded, close the SSH tunnel.
 
-6) **Check the new database.** This is a gut-check to make sure that the data has populated the new database.
+6. **Check the new database.** This is a gut-check to make sure that the data has populated the new database.
 
-    ```sh
-    #  Connect to the new db using pgcli
-    cf connect-to-service crt-portal-django crt-db-new
+   ```sh
+   #  Connect to the new db using pgcli
+   cf connect-to-service crt-portal-django crt-db-new
 
-    # Do some quick queries to make sure the information loaded correctly
-    # list tables
-    \dt
-    # list some report records
-    \ select * from cts_forms_report limit 50;
-    # list some user accounts
-    select * from auth_user limit 50;
-    # exit
-    \q
-    ```
+   # Do some quick queries to make sure the information loaded correctly
+   # list tables
+   \dt
+   # list some report records
+   \ select * from cts_forms_report limit 50;
+   # list some user accounts
+   select * from auth_user limit 50;
+   # exit
+   \q
+   ```
 
-7) **Rename databases.** This will allow us to try the new database and make sure we are happy with it before getting rid of the old database.
+7. **Rename databases.** This will allow us to try the new database and make sure we are happy with it before getting rid of the old database.
 
-    ```sh
-    # rename old data base
-    cf rename-service crt-db crt-db-old
+   ```sh
+   # rename old data base
+   cf rename-service crt-db crt-db-old
 
-    # rename new data base
-    cf rename-service crt-db-new crt-db
-    ```
+   # rename new data base
+   cf rename-service crt-db-new crt-db
+   ```
 
-8) **Restage or redeploy.**  The change to what database is being used won't go into effect until the app is restaged or redeployed.
+8. **Restage or redeploy.** The change to what database is being used won't go into effect until the app is restaged or redeployed.
 
-    Redeploying prevents downtime, so that is what you would want to do for production. You can go to Circle and redeploy the last successful build.
+   Redeploying prevents downtime, so that is what you would want to do for production. You can go to Circle and redeploy the last successful build.
 
-    For dev and staging, you can change the bindings manually and restage. (It's a bit quicker)
+   For dev and staging, you can change the bindings manually and restage. (It's a bit quicker)
 
-    ```sh
-    # unbind old db and bind the new one
-    cf unbind-service crt-portal-django crt-db-old
-    cf bind-service crt-portal-django crt-db
+   ```sh
+   # unbind old db and bind the new one
+   cf unbind-service crt-portal-django crt-db-old
+   cf bind-service crt-portal-django crt-db
 
-    # confirm the correct db is bound (look at the name, plan, and bound apps)
-    cf services
+   # confirm the correct db is bound (look at the name, plan, and bound apps)
+   cf services
 
-    # restage
-    cf restage crt-portal-django
-    ```
+   # restage
+   cf restage crt-portal-django
+   ```
 
-9) **Confirm app is working.** Go to the site, log out, log back in, make a distinctive sample record.
+9. **Confirm app is working.** Go to the site, log out, log back in, make a distinctive sample record.
 
-    ```sh
-    # Connect to the new db using pgcli
-    cf connect-to-service crt-portal-django crt-db
+   ```sh
+   # Connect to the new db using pgcli
+   cf connect-to-service crt-portal-django crt-db
 
-    # Look for your sample. For this one I made the description 'TESTING_NEW_DB 5/24'
-    select * from cts_forms_report where violation_summary='TESTING_NEW_DB 5/24'
-    ```
+   # Look for your sample. For this one I made the description 'TESTING_NEW_DB 5/24'
+   select * from cts_forms_report where violation_summary='TESTING_NEW_DB 5/24'
+   ```
 
-10) **Clean up.** Once everything looks good:
+10. **Clean up.** Once everything looks good:
 
     - Delete database dump file from your local machine
     - Delete `crt-db-old` from cloud.gov
@@ -346,6 +353,7 @@ class Migration(migrations.Migration):
 If you haven't deployed Jupyter to Cloud Foundry yet, this one is a bit of a chicken and egg scenario. In order to deploy Jupyter, you must have OAuth configured (or it will throw an exception on startup). However, in order to configure OAuth, Jupyter must be deployed!
 
 The solution is to:
+
 1. Deploy and get the error.
 2. Configure OAuth, and redeploy.
 
@@ -374,7 +382,8 @@ Then, copy the output it produces (`cf set-env ...`) and run it locally so that 
 cf set-env crt-portal-jupyter OAUTH_PROVIDER_CLIENT_ID some-long-generated-client-id-here && cf set-env crt-portal-jupyter OAUTH_PROVIDER_CLIENT_SECRET some-long-generated-client-secret-here
 ```
 
-You'll also need to tell it where to find the portal, using the routes from manifest_*.yaml - for example, on dev (for regular use, this codified in manifest_etc.yml, not set via cf set-env):
+You'll also need to tell it where to find the portal, using the routes from manifest\_\*.yaml - for example, on dev (for regular use, this codified in manifest_etc.yml, not set via cf set-env):
+
 ```bash
 cf set-env crt-portal-jupyter WEB_EXTERNAL_HOSTNAME "https://crt-portal-django-dev.app.cloud.gov"
 cf set-env crt-portal-jupyter WEB_INTERNAL_HOSTNAME "http://crt-portal-django-dev.app.apps.internal:8080"
@@ -414,11 +423,11 @@ This file expects a list of entries in the following format:
 
 ```json
 [
-    {
-        "path": "assignments/intake-dashboard/total_complaints.ipynb",
-        "last_executed": "2023-09-15T15:28:00.984824",
-        "interval": {"days": 2},
-    }
+  {
+    "path": "assignments/intake-dashboard/total_complaints.ipynb",
+    "last_executed": "2023-09-15T15:28:00.984824",
+    "interval": { "days": 2 }
+  }
 ]
 ```
 
@@ -427,6 +436,10 @@ Where:
 - `path` is the path to the notebook relative to the `jupyterhub/` directory
 - `last_executed` can be left blank (this will be updated after each run)
 - `interval` will be unpacked to the constructor of datetime.timedelta. Note that the interval is limited by the frequency at which the circleci/config.yml task (`periodic-tasks-jupyter-*` is run.
+
+Note that any files under `assignments/intake-dashboard` are visible from /form/data/dashboard-name. For example, if you have `assignments/intake-dashboard/test.ipynb`, you can go to `/form/data/test` to view it. The page also accepts commas to view multiple dashboards, e.g.: `/form/data/test_1,test_2,test_3`
+
+If a file under `assignments/intake-dashboard` isn't found in `schedules.json`, an entry will be created for it and it will be run hourly until the schedule is updated.
 
 ## Response templates
 
@@ -437,7 +450,6 @@ Response templates (for example, form letters) are used by intake specialists to
 ```
 
 Files must be named with a `.md` extension. This is intentional. We currently do not use or parse Markdown, but many of our response templates were initially created with light styling in mind (bold, links, even tables). This functionality may be added in the future.
-
 
 ### Template formatting and variables
 
@@ -492,17 +504,15 @@ Note the "es." prefix for variables that are specific to the Spanish language.
 
 The `{{ record_locator }}` variable is the same in every locale and does not need to be prefixed.
 
-
 #### Language codes
 
-* Spanish = 'es'
-* Chinese Traditional = 'zh-hant'
-* Chinese Simplified = 'zh-hans'
-* Vietnamese = 'vi'
-* Korean = 'ko'
-* Tagalog = 'tl'
-* English = 'en'
-
+- Spanish = 'es'
+- Chinese Traditional = 'zh-hant'
+- Chinese Simplified = 'zh-hans'
+- Vietnamese = 'vi'
+- Korean = 'ko'
+- Tagalog = 'tl'
+- English = 'en'
 
 ### Processing
 
@@ -604,7 +614,6 @@ class Migration(migrations.Migration):
     ]
 ```
 
-
 # Dependency management
 
 Dependencies are installed on each deploy of the application as part of the build process in CircleCI
@@ -637,7 +646,6 @@ docker-compose run web pipenv update --dev
 Either approach will result in an updated `Pipfile.lock` files located in your local copy of the codebase, ready for commit and submission of a pull request.
 
 [Pipenv]: https://docs.pipenv.org/
-
 
 # Periodic tasks
 
@@ -685,7 +693,6 @@ python manage.py generate_repeat_writer_info
 
 For more about the directory structure of deployed instances, see [cloudfoundry's docs](https://docs.cloudfoundry.org/buildpacks/understand-buildpacks.html#droplet-filesystem).
 
-
 ## Updating the U.S. Web Design System
 
 Our front-end stylesheets and UI components are based on the [U.S. Web Design System (USWDS)](https://designsystem.digital.gov/). We want to track updates to the USWDS closely whenever possible in order to adopt the most recent guidance in user experience, developer experience, and accessibility, and to keep our product up-to-date with other modern federal government websites. Update cadence should be roughly 1-2 months, but if we're behind, it's best to update only one minor version at a time (usually okay to include all patch updates) incorporating changes at each step. _Despite following semantic versioning, USWDS v2 can introduce breaking changes at minor versions_.
@@ -694,18 +701,18 @@ In general, follow these steps to update the USWDS:
 
 1. Update `package.json` to set the next version of the `uswds` package and run `npm install`.
 2. Read the [changelog](https://github.com/uswds/uswds/releases) and incorporate any necessary updates:
-    - Update any markup changes (e.g. component code changes, accessibility updates)
-    - Adopt new components, if any. The USWDS sometimes introduces new components that can replace custom or third-party UI components that we use, and offloading our work to the USWDS is a one-time effort that makes it easier to maintain these components in the future.
-    - Note any other bug fixes or feature improvements that affect or improve our site.
+   - Update any markup changes (e.g. component code changes, accessibility updates)
+   - Adopt new components, if any. The USWDS sometimes introduces new components that can replace custom or third-party UI components that we use, and offloading our work to the USWDS is a one-time effort that makes it easier to maintain these components in the future.
+   - Note any other bug fixes or feature improvements that affect or improve our site.
 3. Updates to stylesheet and visual assets.
-    - Update our settings in `crt_portal/static/sass` from the [source theme](https://github.com/uswds/uswds/tree/develop/src/stylesheets/theme). (You can do a diff between the new version and last version to see new additions.) Don't override settings we set on purpose, but we should add or set new settings.
-    - Check that stylesheets can build with `npx gulp build-css`.
-        - A common issue is that a new component uses a color value that we set to `false`, which throws an error when Sass tries to resolve a value. Usually, setting it to the default value will resolve the problem.
-    - Check for any changes or additions to static files, e.g. images that should be copied to the [static folder](https://github.com/usdoj-crt/crt-portal/tree/develop/crt_portal/static/img).
+   - Update our settings in `crt_portal/static/sass` from the [source theme](https://github.com/uswds/uswds/tree/develop/src/stylesheets/theme). (You can do a diff between the new version and last version to see new additions.) Don't override settings we set on purpose, but we should add or set new settings.
+   - Check that stylesheets can build with `npx gulp build-css`.
+     - A common issue is that a new component uses a color value that we set to `false`, which throws an error when Sass tries to resolve a value. Usually, setting it to the default value will resolve the problem.
+   - Check for any changes or additions to static files, e.g. images that should be copied to the [static folder](https://github.com/usdoj-crt/crt-portal/tree/develop/crt_portal/static/img).
 4. Updates to JavaScript.
-    - Copy the minified JavaScript bundles from `node_modules/uswds/dist/js` (installed in step 1) to the `crt_portal/static/vendor` folder.
+   - Copy the minified JavaScript bundles from `node_modules/uswds/dist/js` (installed in step 1) to the `crt_portal/static/vendor` folder.
 5. Updates to the Gulp build process. This may not always occur.
-    - Update `package.json` to pin to a version of [`uswds-gulp`](https://github.com/uswds/uswds-gulp) that is expected to work with the version of USWDS installed in step 1. `uswds-gulp` does not use versioning, so we pin to a specific commit SHA. This will include changes to build dependencies and `gulpfile.js`, try to incorporate as many updates as possible.
+   - Update `package.json` to pin to a version of [`uswds-gulp`](https://github.com/uswds/uswds-gulp) that is expected to work with the version of USWDS installed in step 1. `uswds-gulp` does not use versioning, so we pin to a specific commit SHA. This will include changes to build dependencies and `gulpfile.js`, try to incorporate as many updates as possible.
 6. Verify that the build process works and that all functionality works as expected.
 7. Ready to review and deploy!
 
@@ -716,7 +723,6 @@ We use an environment variable, `MAINTENANCE_MODE`, to run the application with 
 To **enable** maintenance mode, we need to set the `MAINTENANCE_MODE` environment variable to `True` and restart all running instances.
 
 > **NOTE**: Cloud Foundry [CLI Version 7](https://docs.cloudfoundry.org/cf-cli/v7.html) is required to use `--strategy rolling`
-
 
 ```shell
 cf target -s {target environment}
@@ -734,13 +740,12 @@ cf restart crt-portal-django --strategy rolling
 
 # Voting Mode
 
-Like Maintenance mode, we use an environment variable, `VOTING_MODE`, to run the application during voting season.  This places Voting choice as the primary reason at the top
+Like Maintenance mode, we use an environment variable, `VOTING_MODE`, to run the application during voting season. This places Voting choice as the primary reason at the top
 of the proForm and regular report section, and will add a banner to a page to give users a better sense of their voting rights.
 
 To **enable** voting mode, we need to set the `VOTING_MODE` environment variable to `True` and restart all running instances.
 
 > **NOTE**: Cloud Foundry [CLI Version 7](https://docs.cloudfoundry.org/cf-cli/v7.html) is required to use `--strategy rolling`
-
 
 ```shell
 cf target -s {target environment}
@@ -758,9 +763,9 @@ cf restart crt-portal-django --strategy rolling
 
 ## A list of modified functionality when operating in maintenance mode
 
-URL | Method | Normal | Maintenance mode
-----|--------|--------|--------
-/report/| GET | Render report form | Render 503 maintenance page
+| URL      | Method | Normal             | Maintenance mode            |
+| -------- | ------ | ------------------ | --------------------------- |
+| /report/ | GET    | Render report form | Render 503 maintenance page |
 
 ## Email configuration
 
@@ -787,23 +792,21 @@ For example, this command will enable Jim with a 50% chance to reject an incomin
 
 To enable outbound emails, a deployed instance **must** have the following environment variables defined in cloud.gov either via the command line or cloud.gov dashboard.
 
-
-Variable | Description
----------|-----------
-`TMS_AUTH_TOKEN` | TMS API authentication token
-`RESTRICT_EMAIL_RECIPIENTS_TO` | `;` delimited string of email addresses which, when non-empty, will prevent outbound email from being sent to any address other than those specified here. We use this to prevent sending unexpected emails from development instances.
-`TMS_WEBHOOK_ALLOWED_CIDR_NETS` | `;` delimited string of IP addresses from which we're expecting webhook requests. Requests from all other origins will be rejected. May be set to `*` in development to allow requests from all origins.
-
+| Variable                        | Description                                                                                                                                                                                                                             |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TMS_AUTH_TOKEN`                | TMS API authentication token                                                                                                                                                                                                            |
+| `RESTRICT_EMAIL_RECIPIENTS_TO`  | `;` delimited string of email addresses which, when non-empty, will prevent outbound email from being sent to any address other than those specified here. We use this to prevent sending unexpected emails from development instances. |
+| `TMS_WEBHOOK_ALLOWED_CIDR_NETS` | `;` delimited string of IP addresses from which we're expecting webhook requests. Requests from all other origins will be rejected. May be set to `*` in development to allow requests from all origins.                                |
 
 Command line example
 
-   ```
-   # Authenticate and target desired space
-   cf set-env crt-portal-django TMS_AUTH_TOKEN not_a_real_token
-   cf set-env crt-portal-django TMS_WEBHOOK_ALLOWED_CIDR_NETS 192.168.0.15/24
-   cf set-env crt-portal-django RESTRICT_EMAIL_RECIPIENTS_TO developer.email@example.com;dev@example.com
-   # re-stage application
-   ```
+```
+# Authenticate and target desired space
+cf set-env crt-portal-django TMS_AUTH_TOKEN not_a_real_token
+cf set-env crt-portal-django TMS_WEBHOOK_ALLOWED_CIDR_NETS 192.168.0.15/24
+cf set-env crt-portal-django RESTRICT_EMAIL_RECIPIENTS_TO developer.email@example.com;dev@example.com
+# re-stage application
+```
 
 > **WARNING**:
- If `TMS_AUTH_TOKEN` and `TMS_WEBHOOK_ALLOWED_CIDR_NETS` values are not configured the application will start but `EMAIL_ENABLED` will be set to `False` and the user interface will not provide an option to generate and send emails.
+> If `TMS_AUTH_TOKEN` and `TMS_WEBHOOK_ALLOWED_CIDR_NETS` values are not configured the application will start but `EMAIL_ENABLED` will be set to `False` and the user interface will not provide an option to generate and send emails.


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1731

## What does this change?

- 🌎 Currently, changes to Jupyter schedules require a code change / change to the file on disk
- ⛔ This means we can't prototype auto-refreshing dashboards for users on production, which slows down development
- ✅ This commit defaults schedules.json for new dashboards in the intake-dashboard folder

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
