### PR TITLE
Provide a redirect to AWS for /static

### DIFF
--- a/crt_portal/crt_portal/urls.py
+++ b/crt_portal/crt_portal/urls.py
@@ -34,6 +34,7 @@ from cts_forms.views_public import (
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.shortcuts import redirect
 from django.urls import include, path, re_path
 from django.views.generic import RedirectView, TemplateView
 
@@ -46,6 +47,21 @@ if environment in ['PRODUCTION', 'STAGE']:
     ]
 else:
     auth = []
+
+
+def redirect_static(request):
+    target = request.path.replace('/foostatic/', settings.STATIC_URL)
+    return redirect(target)
+
+
+static_for_aws = [
+    re_path(r'^static/.*$', redirect_static, name='aws-static-redirect')
+]
+
+if settings.STATIC_URL == '/static/':
+    static_urls = static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+else:
+    static_urls = static_for_aws
 
 # add app related urls here or in cts_forms.urls
 urlpatterns = auth + [
@@ -87,7 +103,7 @@ urlpatterns = auth + [
     path('voting-resources', TemplateView.as_view(template_name="vot_resources.html"), name='vot_resources'),
     path('', LandingPageView.as_view(), name='crt_landing_page'),
     path('api/', include('api.urls')),
-] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+] + static_urls
 
 handler400 = 'cts_forms.views_public.error_400'
 handler403 = 'cts_forms.views_public.error_403'

--- a/crt_portal/crt_portal/urls.py
+++ b/crt_portal/crt_portal/urls.py
@@ -50,7 +50,7 @@ else:
 
 
 def redirect_static(request):
-    target = request.path.replace('/foostatic/', settings.STATIC_URL)
+    target = request.path.replace('/static/', settings.STATIC_URL)
     return redirect(target)
 
 


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1739

## What does this change?

- 🌎 Templates can use {% static_url %} for directing to static resources.
- ⛔ Not all of our assets are that lucky - js, notebooks, etc have a hard time getting that URL
- ✅ This commit provides a redirect from /static/ to the configured AWS bucket so that non-templates can use /static as a valid url
- 🔮 Future commits may need to tweak this - I've tested it as far as I can locally, but this code has to run on dev before it can be fully verified.

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
