### PR TITLE
Fix searching exact hashtag description

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta
 from operator import and_
 
 from django.apps import apps
-from django.core.validators import ValidationError
 
 from django.db.models import Q, ExpressionWrapper, Count, IntegerField, Min, F, Value, CharField, DateField, Func
 from django.db.models.functions import ExtractYear, Concat, Cast, Left
@@ -241,9 +240,10 @@ def report_filter(querydict):
                     continue  # This means "all other reports" when grouping
                 try:
                     report = Report.objects.get(pk=report_id)
+                    qs = qs.filter(violation_summary=report.violation_summary)
                 except (Report.DoesNotExist, ValueError):
-                    raise ValidationError(f'Attempted to filter by Personal Description for report {report_id}, but that report does not exist.')
-                qs = qs.filter(violation_summary=report.violation_summary)
+                    # This might not be a report id (for example, hashtags):
+                    qs = qs.filter(violation_summary=search_query[1:-1])
             elif search_query.startswith('^') and search_query.endswith('$'):
                 # Allow for "exact match" using the common regex syntax.
                 qs = qs.filter(violation_summary=search_query[1:-1])

--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -78,6 +78,9 @@ class ReportFilterTests(TestCase):
         test_data['violation_summary'] = 'motorcycle'
         Report.objects.create(**test_data)
 
+        test_data['violation_summary'] = '#hashtag'
+        Report.objects.create(**test_data)
+
     def test_no_filters(self):
         """Returns all reports when no filters provided"""
         reports, _ = report_filter(QueryDict(''))
@@ -118,6 +121,12 @@ class ReportFilterTests(TestCase):
         self.assertEqual(reports.count(), 5)
         for report in reports:
             self.assertEqual('boat' in report.violation_summary or 'hovercraft' in report.violation_summary, True)
+
+    def test_hashtag_exact(self):
+        reports, _ = report_filter(QueryDict('violation_summary=^#hashtag$'))
+        self.assertEqual(reports.count(), 1)
+        for report in reports:
+            self.assertIn('#hashtag', report.violation_summary)
 
     def test_and_search(self):
         # "boat AND hovercraft" is functionally the same as "boat hovercraft"


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1740

## What does this change?

- 🌎 It's possible to search for descriptions matching a report by using `^#id$`.
- ⛔ This feature blocks searching for reports that start with #
- ✅ This commit fixes this by trying to fetch a report ID, but defaulting to exact match if that report doesn't exist.

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
