### PR TITLE
Fix exact match displaying with no input

### DIFF
--- a/crt_portal/cts_forms/templatetags/field_formatting.py
+++ b/crt_portal/cts_forms/templatetags/field_formatting.py
@@ -77,6 +77,9 @@ def _get_tags_markup(field_content):
 def _prepare_fuzzy_for_chip(key, filters):
     prefix = filters.get(key, [''])[0]
 
+    if not prefix:
+        return
+
     sounds_like_value = filters.pop(f'{key}_1', [''])[0]
     suffix = []
     if sounds_like_value and sounds_like_value != '0':


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal/pull/1698

## What does this change?

- 🌎 "Exact match" indicates the kind of fuzzy org name search we're doing
- ⛔ Right now, it displays even when we don't search for an org name
- ✅ This commit fixes that by skipping the fuzzy chip prep if no org name is specified

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
