### PR TITLE
Fix Jupyter HTML Export

### DIFF
--- a/jupyterhub/helpers/table_contents_manager.py
+++ b/jupyterhub/helpers/table_contents_manager.py
@@ -7,6 +7,7 @@ import os
 
 from jupyter_server.services.contents.checkpoints import Checkpoints
 from jupyter_server.services.contents.manager import ContentsManager
+from nbformat import from_dict
 from psycopg2 import sql
 import psycopg2
 
@@ -147,6 +148,10 @@ class TableContentsManager(ContentsManager):
             return None
 
         file = _make_file([*fields, 'id'], result, content=content)
+
+        if type == 'notebook' or file['type'] == 'notebook':
+            file['content'] = from_dict(file['content'])
+
         if not content or file['type'] != 'directory':
             return file
 
@@ -168,6 +173,7 @@ class TableContentsManager(ContentsManager):
             _make_file([*fields, 'id'], row, content=False)
             for row in result
         ]
+
         return file
 
     def save(self, model, path):


### PR DESCRIPTION
## What does this change?

- 🌎 As we develop notebooks, we need an easier way to share exploratory ideas
- ⛔ Right now, we can only download as ipynb, which isn't really sharable with non-technical folks
- ✅ This commit fixes export as HTML, which makes a single file that folks can open to see notebook results

## Screenshots (for front-end PR):

![html](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/058b680f-fb87-4558-8241-e9c2f4422ea8)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
