### PR TITLE
Patch phone number input accessibility

### DIFF
--- a/crt_portal/static/js/report_phone.js
+++ b/crt_portal/static/js/report_phone.js
@@ -15,14 +15,22 @@
       nationalMode: true
     });
 
-    function handleChange() {
-      showValidity(input, telInputApi);
+    function setHiddenValue() {
       inputWithCountry.value = telInputApi.getNumber();
     }
-    input.addEventListener('change', handleChange);
-    input.addEventListener('keyup', handleChange);
+
+    input.addEventListener('change', setHiddenValue);
+    input.addEventListener('keyup', setHiddenValue);
+    input.addEventListener('focusout', () => showValidity(input, telInputApi));
 
     document.querySelector('.iti__search-input').setAttribute('title', 'Search for a country');
+
+    // The country dropdown is not accessible currently, so we're hiding it from
+    // screen readers. We should revisit this when the dropdown is accessible:
+    //
+    // https://github.com/jackocnr/intl-tel-input/issues/1536
+    document.querySelector('.iti__selected-flag').setAttribute('tabindex', '-1');
+    document.querySelector('.iti__flag-container').setAttribute('tabindex', '-1');
   }
 
   document.addEventListener('DOMContentLoaded', function() {
@@ -30,7 +38,7 @@
   });
 
   function isValid(input, telInputApi) {
-    if (!input.value) return null;
+    if (!input.value) return true;
     const country = telInputApi.getSelectedCountryData() || {};
     if (country.iso2 === 'us' && telInputApi.getNumber().length !== 12) return false;
     if (!telInputApi.isValidNumber()) return false;


### PR DESCRIPTION
Ignores the country dropdown for screen readers. Users can still enter country codes and benefit from advanced validation.

## What does this change?

- 🌎 We've recently added an international phone number widget with better validation
- ⛔ The country dropdown in the phone input is not accessible
- ✅ This commit hides the country dropdown from screen readers. The input can be controlled entirely from the text box (e.g., +481234302 works)
- 🔮 This is obviously not ideal - future commits will follow up on this when the underlying component is fixed (https://github.com/jackocnr/intl-tel-input/issues/1536)

## Screenshots (for front-end PR):

![accessibility](https://github.com/usdoj-crt/crt-portal/assets/15126660/88e47987-da14-47fb-bff4-68294935cff5)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
