### PR TITLE
Fixes two issues with the e2e tests

### DIFF
--- a/crt_portal/cts_forms/tests/integration/report_submission.py
+++ b/crt_portal/cts_forms/tests/integration/report_submission.py
@@ -56,6 +56,7 @@ def test_report_complete_and_valid_submission(page):
     page.fill("input[name='0-contact_email']", "testing@test.com")
 
     page.fill(".iti .iti__tel-input", "555-555-5555")
+    page.wait_for_timeout(500)
 
     # Fill input[name="0-contact_address_line_1"]
     page.fill("input[name='0-contact_address_line_1']", "1 tester street")
@@ -67,7 +68,7 @@ def test_report_complete_and_valid_submission(page):
     page.fill("input[name='0-contact_zip']", "10001")
 
     # Fill input[name="0-servicemember"]
-    page.check("input[name='0-servicemember']")
+    page.check("input[name='0-servicemember'][value='yes']")
 
     # Go to step 2
     next_step()


### PR DESCRIPTION
No issue, fixing e2e tests

## What does this change?

- The servicemember box was not specific enough (it was matching two elements)
- The phone number widget requires a short wait for event handlers to complete due to validation

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

Tested using:
```
pipenv run pytest crt_portal/cts_forms/tests/integration/report_submission.py --base-url=https://crt-portal-django-dev.app.cloud.gov --headed
```

I was unable to reproduce this when running against my local development server.

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
