### PR TITLE
Allowlist static users for ADFS

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -325,6 +325,7 @@ if environment in ['PRODUCTION', 'STAGE']:
             '^voting-resources',
             '^oauth2_provider/token/',
             '^oauth2_provider/userinfo/',
+            '^static/'
         ],
     }
 


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1756

## What does this change?

- 🌎 /static redirects to our AWS bucket.
- ⛔ It should be reachable by all users, but it's not
- ✅ This commit allowlists it under ADFS
- 🔮 Future commits may need to tweak this, as we can only test it on staging; I've manually deployed there, for now.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
