### PR TITLE
Update cimg to 2024-02

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,8 +182,8 @@ jobs:
 
 # owasp scans on live sties
   owasp-scan-dev:
-    machine:
-      image: ubuntu-2004:202201-02
+    docker:
+      image: cimg/base:2024.02
     working_directory: ~/code
     steps:
       - checkout
@@ -193,8 +193,8 @@ jobs:
               docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-stable:latest zap-baseline.py \
               -t https://crt-portal-django-dev.app.cloud.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
   owasp-scan-stage:
-    machine:
-      image: ubuntu-2004:202201-02
+    docker:
+      image: cimg/base:2024.02
     working_directory: ~/code
     steps:
       - checkout
@@ -204,8 +204,8 @@ jobs:
               docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-stable:latest zap-baseline.py \
               -t https://crt-portal-django-stage.app.cloud.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
   owasp-scan-prod:
-    machine:
-      image: ubuntu-2004:202201-02
+    docker:
+      image: cimg/base:2024.02
     working_directory: ~/code
     steps:
       - checkout
@@ -412,7 +412,7 @@ jobs:
     docker:
       # Use CircleCI convenience base image since we only need
       # CloudFoundry CLI
-      - image: cimg/base:2020.01
+      - image: cimg/base:2024.02
         environment:
           - CF_SPACE: prod
     steps:
@@ -448,7 +448,7 @@ jobs:
     docker:
       # Use CircleCI convenience base image since we only need
       # CloudFoundry CLI
-      - image: cimg/base:2020.01
+      - image: cimg/base:2024.02
         environment:
           - CF_SPACE: staging
     steps:
@@ -488,7 +488,7 @@ jobs:
     docker:
       # Use CircleCI convenience base image since we only need
       # CloudFoundry CLI
-      - image: cimg/base:2020.01
+      - image: cimg/base:2024.02
         environment:
           - CF_SPACE: dev
     steps:
@@ -525,7 +525,7 @@ jobs:
     docker:
       # Use CircleCI convenience base image since we only need
       # CloudFoundry CLI
-      - image: cimg/base:2020.01
+      - image: cimg/base:2024.02
         environment:
           - CF_SPACE: dev
     steps:
@@ -543,7 +543,7 @@ jobs:
     docker:
       # Use CircleCI convenience base image since we only need
       # CloudFoundry CLI
-      - image: cimg/base:2020.01
+      - image: cimg/base:2024.02
         environment:
           - CF_SPACE: staging
     steps:
@@ -561,7 +561,7 @@ jobs:
     docker:
       # Use CircleCI convenience base image since we only need
       # CloudFoundry CLI
-      - image: cimg/base:2020.01
+      - image: cimg/base:2024.02
         environment:
           - CF_SPACE: prod
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
 # owasp scans on live sties
   owasp-scan-dev:
     docker:
-      image: cimg/base:2024.02
+      - image: cimg/base:2024.02
     working_directory: ~/code
     steps:
       - checkout
@@ -194,7 +194,7 @@ jobs:
               -t https://crt-portal-django-dev.app.cloud.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
   owasp-scan-stage:
     docker:
-      image: cimg/base:2024.02
+      - image: cimg/base:2024.02
     working_directory: ~/code
     steps:
       - checkout
@@ -205,7 +205,7 @@ jobs:
               -t https://crt-portal-django-stage.app.cloud.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
   owasp-scan-prod:
     docker:
-      image: cimg/base:2024.02
+      - image: cimg/base:2024.02
     working_directory: ~/code
     steps:
       - checkout


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1757

## What does this change?

- 🌎 Circleci uses ubuntu images to run maintenance tasks and owasp
- ⛔ Old ubuntu images no longer exist, so we must update
- ✅ This commit moves all maintenance / etc to cimg/base, which includes docker, so should work for any simple task needs.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
