### PR TITLE
Bump disk space for Jupyter

### DIFF
--- a/manifest_dev.yaml
+++ b/manifest_dev.yaml
@@ -40,7 +40,7 @@ applications:
   routes:
   - route: crt-portal-jupyter-dev.app.cloud.gov
   memory: 2G
-  disk_quota: 5G
+  disk_quota: 6G
   instances: 1
   env:
     ENV: DEVELOP

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -41,7 +41,7 @@ applications:
   routes:
   - route: crt-portal-jupyter-stage.app.cloud.gov
   memory: 2G
-  disk_quota: 5G
+  disk_quota: 6G
   instances: 1
   env:
     ENV: STAGE


### PR DESCRIPTION
## What does this change?

Jupyter is failing to deploy due to no disk space left on device. This is happening during installation only - after installation the space is down to 2.8G

Future PRs should investigate how to reduce the installation size of python dependencies

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
