### PR TITLE
Add a language parameter

### DIFF
--- a/crt_portal/crt_portal/locale_middleware.py
+++ b/crt_portal/crt_portal/locale_middleware.py
@@ -1,0 +1,17 @@
+from django.utils import translation
+
+
+class LanguageParamMiddleware():
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        language = request.GET.get("lang")
+        if not language:
+            return self.get_response(request)
+
+        translation.activate(language)
+        response = self.get_response(request)
+        response.set_cookie('django_language', language)
+
+        return response

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -120,6 +120,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.locale.LocaleMiddleware',
+    'crt_portal.locale_middleware.LanguageParamMiddleware',
     'crequest.middleware.CrequestMiddleware',
 ]
 

--- a/crt_portal/cts_forms/tests/integration/internationalization.py
+++ b/crt_portal/cts_forms/tests/integration/internationalization.py
@@ -19,6 +19,10 @@ def test_select_spanish_from_query(page, *, language_code, title):
     assert page.title() == title
     assert page.is_visible(f"button[data-value='{language_code}']")
 
+    with page.expect_navigation():
+        page.click("button[data-value='en']")
+    assert page.title() == 'Contact the Civil Rights Division | Department of Justice'
+
 
 @pytest.mark.only_browser("chromium")
 @console.raise_errors()

--- a/crt_portal/cts_forms/tests/integration/internationalization.py
+++ b/crt_portal/cts_forms/tests/integration/internationalization.py
@@ -4,6 +4,23 @@ from cts_forms.tests.integration_util import console, compat
 
 
 @pytest.mark.only_browser("chromium")
+@pytest.mark.parametrize("language_code,title", [
+    ('en', 'Contact the Civil Rights Division | Department of Justice'),
+    ('es', 'Comuníquese con la División de Derechos Civiles | Departamento de Justicia'),
+    ('zh-hant', '與民權科 | 司法部聯絡'),
+    ('zh-hans', '联系司法部民权司'),
+    ('vi', 'Liên hệ với Ban Dân Quyền | Bộ Tư pháp'),
+    ('ko', '법무부 | 민권국 연락처'),
+    ('tl', 'Makipag-ugnay sa Dibisyon sa mga Karapatang Sibil | Kagawaran ng Katarungan'),
+])
+@console.raise_errors()
+def test_select_spanish_from_query(page, *, language_code, title):
+    page.goto(f'/?lang={language_code}')
+    assert page.title() == title
+    assert page.is_visible(f"button[data-value='{language_code}']")
+
+
+@pytest.mark.only_browser("chromium")
 @console.raise_errors()
 def test_select_english_from_banner(page):
     page.goto('/')

--- a/crt_portal/static/js/banner_language_selection.js
+++ b/crt_portal/static/js/banner_language_selection.js
@@ -1,18 +1,21 @@
 (function(root, dom) {
-  var buttons = document.querySelectorAll('.language-selection__button');
-  for (var index in buttons) {
-    var button = buttons[index];
+  const buttons = document.querySelectorAll('.language-selection__button');
+  buttons.forEach(button => {
     button.onclick = function(event) {
       event.preventDefault();
 
-      var language_code = this.getAttribute('data-value');
+      const language_code = this.getAttribute('data-value');
 
-      var language_input_el = document.getElementById('language_input');
+      const language_input_el = document.getElementById('language_input');
 
       language_input_el.setAttribute('value', language_code);
 
-      var form = document.getElementById('language_selection_form');
+      const url = new URL(window.location.href);
+      url.searchParams.set('lang', language_code);
+      window.history.replaceState({}, '', url);
+
+      const form = document.getElementById('language_selection_form');
       form.submit();
     };
-  }
+  });
 })(window, document);


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1785

## What does this change?

- 🌎 The homepage + report's language selector lets users pick a language
- ⛔ We can't pre-select that when a user goes to a page
- ✅ This commit adds middleware to watch for the `lang` query param and change the language if it's present

## Screenshots (for front-end PR):

![param](https://github.com/usdoj-crt/crt-portal/assets/15126660/5a633b5a-06a0-4430-8771-8bd24a512f52)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
