### PR TITLE
Fix disposition bugs

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -2047,7 +2047,6 @@ class BatchReviewForm(ModelForm, ActivityStreamUpdater):
             if self.field_changed(field_name)
         ]
 
-
     status = TypedChoiceField(
         choices=(('approved', 'Approved'), ('rejected', 'Rejected')),
         empty_value=None,

--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/actions/bulk_actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/actions/bulk_actions.html
@@ -88,8 +88,8 @@
           <tr>
             <th>Proposed Disposal Date</th>
             <td>
-              <input type="hidden" value="{{ shared_report_fields.proposed_disposal_date }}" name="proposed_disposal_date" id="proposed_disposal_date" />
-              {{ shared_report_fields.proposed_disposal_date }}
+              <input type="hidden" value="{{ shared_report_fields.expiration_date }}" name="proposed_disposal_date" id="proposed_disposal_date" />
+              {{ shared_report_fields.expiration_date }}
             </td>
           </tr>
         </table>
@@ -108,8 +108,8 @@
             {{ bulk_disposition_form.create_date }}
           </div>
         </div>
-        {% if shared_report_fields.retention_schedule == 'Multiple' or shared_report_fields.proposed_disposal_date == 'Multiple' %}
-          <p>The selected reports have multiple retention schedules.</p>
+        {% if shared_report_fields.retention_schedule == 'Multiple' or shared_report_fields.expiration_date == 'Multiple' %}
+          <p>The selected reports have multiple retention schedules and/or expiration dates.</p>
           <p>All reports must have the same retention schedule and expiration date to be batched.</p>
         {% endif %}
         <input type="hidden" value="{{ all_ids_count }}" name="disposed_count" id="disposed_count" />
@@ -122,7 +122,7 @@
         {% else %}
           <button class="usa-button{% if show_warning %} button--warning display-flex align-center{% endif %}"
                 {% if show_warning %}id="show_warning_section_partial"{% endif %}
-                {% if shared_report_fields.retention_schedule == 'Multiple' or shared_report_fields.proposed_disposal_date == 'Multiple' %}disabled{% endif %}
+                {% if shared_report_fields.retention_schedule == 'Multiple' or shared_report_fields.expiration_date == 'Multiple' %}disabled{% endif %}
                 type="submit"
                 id="submit_report_count"
                 name="selected_ids"

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1135,7 +1135,7 @@ class DispositionActionsView(LoginRequiredMixin, FormView):
             plural = 's have' if batch.disposed_count > 1 else ' has'
             message = f'{batch.disposed_count} record{plural} been approved for disposal. The records unit will review your request and approve or deny your deletion request. Follow status updates in ‘Report batches for disposal’'
             messages.add_message(request, messages.SUCCESS, message)
-             # log this action for an audit trail.
+            # log this action for an audit trail.
             logger.info(f'Batch #{batch.uuid} with {batch.disposed_count} record{plural} has been created by {request.user}')
             url = reverse('crt_forms:disposition')
             return redirect(f"{url}{return_url_args}")
@@ -1272,7 +1272,7 @@ class DispositionBatchActionsView(LoginRequiredMixin, FormView):
             elif batch.status == 'rejected':
                 message = f'{batch.uuid} has been rejected for disposal.'
                 messages.add_message(request, messages.INFO, message)
-             # log this action for an audit trail.
+            # log this action for an audit trail.
             logger.info(f'Batch #{batch.uuid} has been {batch.status} by {request.user}')
             url = reverse('crt_forms:disposition')
             return redirect(f"{url}{return_url_args}")

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -28,6 +28,8 @@ from formtools.wizard.views import SessionWizardView
 from analytics.models import AnalyticsFile, get_dashboard_structure_from_db
 from tms.models import TMSEmail
 from datetime import datetime
+from django.db.models.functions import ExtractYear, Cast, Concat
+from django.db.models import F, Value, CharField, DateField
 
 
 from .attachments import ALLOWED_FILE_EXTENSIONS
@@ -689,7 +691,7 @@ def get_batch_data(disposition_batches, all_args_encoded):
         data.append({
             'batch': batch,
             'truncated_uuid': f'...{str(batch.uuid)[-6:]}',
-            'retention_schedule': RetentionSchedule.objects.get(retention_years=batch.retention_schedule).name if batch.retention_schedule else '',
+            'retention_schedule': RetentionSchedule.objects.get(pk=batch.retention_schedule).name if batch.retention_schedule else '',
             'url': f'{url}?return_url_args={all_args_encoded}',
         })
     return data
@@ -1010,13 +1012,21 @@ class DispositionActionsView(LoginRequiredMixin, FormView):
         # make sure the queryset does not order by anything, otherwise
         # we will have difficulty getting distinct results.
         query = record_query.order_by()
+        query = query.annotate(
+            retention_year=F('retention_schedule__retention_years'),
+            expiration_year=F('retention_year') + ExtractYear('closed_date') + 1,
+            expiration_date=Cast(Concat(F('expiration_year'), Value('-'), Value('01'), Value('-'), Value('01'), output_field=CharField()), output_field=DateField())
+        )
         for key in keys:
             values = query.values_list(key, flat=True).distinct()
             if values.count() != 1:
                 yield key, self.EMPTY_CHOICE
                 continue
             if key == 'retention_schedule':
-                yield key, RetentionSchedule.objects.get(retention_years=values[0]).name
+                yield key, RetentionSchedule.objects.get(pk=values[0]).name
+                continue
+            if key == 'expiration_date':
+                yield key, values[0].strftime('%m/%d/%Y')
                 continue
             yield key, values[0]
 
@@ -1025,12 +1035,6 @@ class DispositionActionsView(LoginRequiredMixin, FormView):
         intake_date = query.values_list('create_date', flat=True).order_by('create_date').first().strftime('%m/%d/%Y')
         close_date = query.values_list('closed_date', flat=True).order_by('closed_date').last().strftime('%m/%d/%Y')
         return f'{intake_date} - {close_date}'
-
-    def get_proposed_disposal_date(self, record_query):
-        query = record_query.order_by()
-        close_date = query.values_list('closed_date', flat=True).order_by('closed_date').last()
-        retention_schedule = query.values_list('retention_schedule', flat=True).distinct()
-        return datetime(close_date.year + retention_schedule[0] + 1, 1, 1).date().strftime('%m/%d/%Y')
 
     def reconstruct_id_args(self, ids):
         return ''.join([f'&id={id}' for id in ids])
@@ -1056,11 +1060,10 @@ class DispositionActionsView(LoginRequiredMixin, FormView):
         _, query_filters = report_filter(QueryDict(query_string))
         filter_args = f'{get_filter_args(query_filters)}'
         shared_report_fields = {}
-        keys = ['assigned_section', 'retention_schedule', 'status']
+        keys = ['assigned_section', 'retention_schedule', 'status', 'expiration_date']
         for key, value in self.get_shared_report_values(requested_query, keys):
             shared_report_fields[key] = value
         shared_report_fields['date_range'] = self.get_report_date_range(requested_query)
-        shared_report_fields['proposed_disposal_date'] = self.get_proposed_disposal_date(requested_query)
         all_ids_count = requested_query.count()
         ids_count = len(ids)
 
@@ -1155,8 +1158,7 @@ class DispositionActionsView(LoginRequiredMixin, FormView):
             filter_args = f'{get_filter_args(query_filters)}'
             shared_report_fields = {}
             shared_report_fields['date_range'] = self.get_report_date_range(requested_query)
-            shared_report_fields['proposed_disposal_date'] = self.get_proposed_disposal_date(requested_query)
-            keys = ['assigned_section', 'retention_schedule']
+            keys = ['assigned_section', 'retention_schedule', 'expiration_date']
             for key, value in self.get_shared_report_values(requested_query, keys):
                 shared_report_fields[key] = value
             shared_report_fields['date_range'] = self.get_report_date_range(requested_query)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1015,7 +1015,7 @@ class DispositionActionsView(LoginRequiredMixin, FormView):
         query = query.annotate(
             retention_year=F('retention_schedule__retention_years'),
             expiration_year=F('retention_year') + ExtractYear('closed_date') + 1,
-            expiration_date=Cast(Concat(F('expiration_year'), Value('-'), Value('01'), Value('-'), Value('01'), output_field=CharField()), output_field=DateField())
+            expiration_date=Cast(Concat(F('expiration_year'), Value('-01-01'), output_field=CharField()), output_field=DateField())
         )
         for key in keys:
             values = query.values_list(key, flat=True).distinct()


### PR DESCRIPTION
Disposition - batching 3 year reports is triggering a 500 error
[#1791](https://github.com/usdoj-crt/crt-portal-management/issues/1791)
Batch memo not displaying correct retention time
[#1790](https://github.com/usdoj-crt/crt-portal-management/issues/1790)

## What does this change?
This PR fixes a couple bugs on the disposition page:
- the retention schedule should now be consistent and correct on all forms
- batching 3 year retention schedule records will not result in an error
- users will not be able to batch reports with multiple expiration dates
- the batch table will display the retention schedule and disposal date associated with the batch

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
