### PR TITLE
Adds optional section checkboxes to the frontend.

### DIFF
--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -216,11 +216,15 @@ class ResponseDetail(generics.RetrieveAPIView):
         # If a `?report_id=<pk>` is provided, then render the letter content
         # with the given report details
         report_pk = request.query_params.get('report_id')
-        if report_pk:
-            report = Report.objects.filter(pk=report_pk).first()
-            serialized_data['url'] = serialized_data['url'] + '?report_id=' + report_pk
-            serialized_data['subject'] = template.render_subject(report)
-            serialized_data['body'] = html.unescape(template.render_body(report))
+        if not report_pk:
+            return Response(serialized_data)
+
+        report = Report.objects.filter(pk=report_pk).first()
+        serialized_data['url'] = serialized_data['url'] + '?report_id=' + report_pk
+        serialized_data['subject'] = template.render_subject(report)
+        serialized_data['body'] = html.unescape(template.render_body(report))
+        serialized_data['optionals'] = template.get_optionals()
+
         return Response(serialized_data)
 
 

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -22,6 +22,7 @@ from django.utils.functional import cached_property
 from django.utils.html import escape
 
 from utils import sanitize
+from utils.markdown_extensions import get_optionals
 
 from .managers import ActiveProtectedClassChoiceManager
 from .model_variables import (BATCH_STATUS_CHOICES, CLOSED_STATUS,
@@ -877,6 +878,9 @@ class ResponseTemplate(models.Model):
         local_tz = pytz.timezone('US/Eastern')
         local_dt = utc_dt.replace(tzinfo=pytz.utc).astimezone(local_tz)
         return local_tz.normalize(local_dt)
+
+    def get_optionals(self):
+        return get_optionals(self.body)
 
     def available_report_fields(self, report: Optional[Report]):
         """

--- a/crt_portal/cts_forms/templates/forms/complaint_view/show/contact_complainant.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/show/contact_complainant.html
@@ -10,7 +10,7 @@
       <p class="intake-template--description">
         Subject: <strong id="intake_description">[Select response letter]</strong>
       </p>
-
+      <div class="optionals" hidden></div>
       <div id="intake_letter_html" class="form-letter" hidden></div>
       <textarea disabled aria-label="intake letter" id="intake_letter" rows="10" cols="80"></textarea>
 

--- a/crt_portal/static/js/form_letter.js
+++ b/crt_portal/static/js/form_letter.js
@@ -54,6 +54,7 @@
   var print = modal.querySelector('#intake_print');
   var letter = modal.querySelector('#intake_letter');
   var letter_html = modal.querySelector('#intake_letter_html');
+  const optionals = modal.querySelector('.optionals');
   var send_email = modal.querySelector('#intake_send');
 
   var email_enabled = modal.querySelector('#intake_send').dataset.emailEnabled === 'True';
@@ -87,6 +88,7 @@
         responseTemplate: event.target.value,
         htmlBox: letter_html,
         plaintextBox: letter,
+        optionals: optionals,
         afterRendered: data => {
           description.innerHTML = data.subject || '[Select response letter]';
         }

--- a/crt_portal/static/js/reply.js
+++ b/crt_portal/static/js/reply.js
@@ -33,9 +33,44 @@
     addressee.parentNode.insertBefore(newDeptAddressee, addressee);
   }
 
+  function renderOptionals(container, optionals) {
+    container.innerHTML = '';
+    let checkboxId = 0;
+    Object.entries(optionals).map(([group, options]) => {
+      const fieldset = document.createElement('fieldset');
+      fieldset.classList.add('usa-fieldset');
+      const legend = document.createElement('legend');
+      legend.classList.add('usa-legend');
+      legend.innerText = group;
+      fieldset.appendChild(legend);
+
+      const checkboxes = options.map(option => {
+        const field = document.createElement('div');
+        const label = document.createElement('label');
+        const input = document.createElement('input');
+        field.classList.add('usa-checkbox');
+        input.classList.add('usa-checkbox__input');
+        input.type = 'checkbox';
+        input.name = group;
+        input.value = option.name;
+        input.checked = option.checked === 'yes';
+        input.id = `contact-optionals-${checkboxId++}`;
+        label.htmlFor = input.id;
+        label.classList.add('usa-checkbox__label');
+        field.appendChild(input);
+        field.appendChild(label);
+        label.appendChild(document.createTextNode(option.name));
+        return field;
+      });
+      checkboxes.forEach(checkbox => fieldset.appendChild(checkbox));
+      container.appendChild(fieldset);
+    });
+    container.hidden = Object.keys(optionals).length === 0;
+  }
+
   root.CRT.renderTemplatePreview = function(
     modal,
-    { reportId, responseTemplate, htmlBox, plaintextBox, afterRendered }
+    { reportId, responseTemplate, htmlBox, plaintextBox, optionals, afterRendered }
   ) {
     window
       .fetch(`/api/responses/${responseTemplate}/?report_id=${reportId}`)
@@ -50,6 +85,7 @@
           plaintextBox.hidden = false;
           plaintextBox.innerHTML = data.body || '';
         }
+        renderOptionals(optionals, data.optionals ?? {});
         addReferralAddress(data.referral_contact);
         if (afterRendered) afterRendered(data);
       });

--- a/crt_portal/static/sass/custom/modal.scss
+++ b/crt_portal/static/sass/custom/modal.scss
@@ -196,6 +196,14 @@ body.is-modal {
     &::-webkit-scrollbar { /* Chrome, Opera, Safari */
       display: none;
     }
+
+    .usa-fieldset {
+      margin-top: 1rem;
+
+      &:first-of-type {
+        margin-top: 0;
+      }
+    }
   }
 
   .modal-step {


### PR DESCRIPTION
## What does this change?

- 🌎 We want to allow users to choose sections of letters to send
- ⛔ Right now there's nothing for them to select to do that
- ✅ This commit generates a list of checkboxes to check based on optional sections
- 🔮 Future commits will attach this to the backend to actually hide/show sections

Note that without a template that supports these sections, this will currently do nothing.

## Screenshots (for front-end PR):

<img width="711" alt="image" src="https://github.com/usdoj-crt/crt-portal-management/assets/15126660/9dae6c9e-0727-47b6-82d7-49b55a1949ac">

![image](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/5aa8708f-4c3d-4fd4-adf2-02f62b6598d0)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
