### PR TITLE
Consider optionals when rendering mail

### DIFF
--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -61,12 +61,7 @@ def render_agency_mail(*, complainant_letter: Mail, report, template, extra_ccs=
 
 
 def render_complainant_mail(*, report, template, action) -> Mail:
-    message = template.render_body(report)
-
-    if template.is_html:
-        content = markdown.markdown(message, extensions=['extra', 'sane_lists', 'admonition', 'nl2br', CustomHTMLExtension()])
-    else:
-        content = message.replace('\n', '<br>')
+    content = template.render_body_as_markdown(report, extensions=[CustomHTMLExtension()])
 
     html_source = 'print.html' if action == 'print' else 'email.html'
     html_message = render_to_string(html_source,
@@ -82,7 +77,7 @@ def render_complainant_mail(*, report, template, action) -> Mail:
 
     return Mail(
         subject=template.render_subject(report),
-        message=template.render_body(report),
+        message=template.render_plaintext(report),
         html_message=html_message,
         recipients=allowed_recipients,
         disallowed_recipients=disallowed_recipients,

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -22,7 +22,7 @@ from django.utils.functional import cached_property
 from django.utils.html import escape
 
 from utils import sanitize
-from utils.markdown_extensions import get_optionals, OptionalExtension
+from utils.markdown_extensions import get_optionals, OptionalExtension, OptionalProcessor
 
 from .managers import ActiveProtectedClassChoiceManager
 from .model_variables import (BATCH_STATUS_CHOICES, CLOSED_STATUS,
@@ -874,6 +874,8 @@ class ResponseTemplate(models.Model):
     is_user_created = models.BooleanField('Is user created', default=True,)
     referral_contact = models.ForeignKey(ReferralContact, blank=True, null=True, related_name="response_templates", on_delete=models.SET_NULL)
 
+    optionals = None
+
     def utc_timezone_to_est(self, utc_dt):
         local_tz = pytz.timezone('US/Eastern')
         local_dt = utc_dt.replace(tzinfo=pytz.utc).astimezone(local_tz)
@@ -969,13 +971,17 @@ class ResponseTemplate(models.Model):
         context.update({**kwargs, 'report': report})
         return escape(template.render(context))
 
-    def render_body_as_markdown(self, report, optionals=None, **kwargs):
+    def render_body_as_markdown(self, report, optionals=None, extensions=None, **kwargs):
+        if extensions is None:
+            extensions = []
+        if optionals is None:
+            optionals = self.optionals
         template = Template(self.body)
         context = self.available_report_fields(report)
         context.update({**kwargs, 'report': report})
         rendered = template.render(context)
         if self.is_html:
-            return markdown.markdown(rendered, extensions=[OptionalExtension(include=optionals), 'extra', 'sane_lists', 'admonition', 'nl2br'])
+            return markdown.markdown(rendered, extensions=[OptionalExtension(include=optionals), 'extra', 'sane_lists', 'admonition', 'nl2br', *extensions])
         return rendered.replace('\n', '<br>')
 
     def render_body(self, report, **kwargs):
@@ -983,6 +989,16 @@ class ResponseTemplate(models.Model):
         context = self.available_report_fields(report)
         context.update({**kwargs, 'report': report})
         return escape(template.render(context))
+
+    def render_plaintext(self, report, optionals=None, **kwargs):
+        if optionals is None:
+            optionals = self.optionals
+        template = Template(self.body)
+        context = self.available_report_fields(report)
+        context.update({**kwargs, 'report': report})
+        rendered = template.render(context)
+        optional_processor = OptionalProcessor(include=self.optionals)
+        return escape('\n'.join(optional_processor.run(rendered.split('\n'))))
 
     def render_bulk_subject(self, report, reports, **kwargs):
         template = Template(self.subject)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -823,6 +823,13 @@ class ResponseView(LoginRequiredMixin, View):
         }[tab]
         template = form.cleaned_data[template_kind]
         button_type = request.POST['type']
+        optionals = {
+            key.replace('optionals_', ''): request.POST.getlist(key)
+            for key in request.POST.keys()
+            if key.startswith('optionals_')
+        }
+        if optionals:
+            template.optionals = optionals
 
         if button_type == 'send':  # We're going to send an email!
             try:

--- a/crt_portal/static/js/reply.js
+++ b/crt_portal/static/js/reply.js
@@ -48,7 +48,7 @@
       function rerenderWithOptionals() {
         const userSelections = container.querySelectorAll('input[type="checkbox"]:checked');
         const selectedOptions = Array.from(userSelections)
-          .map(input => [input.name, input.value])
+          .map(input => [input.name.replace('optionals_', ''), input.value])
           .reduce((acc, [name, value]) => {
             if (!acc[name]) acc[name] = [];
             acc[name].push(value);
@@ -65,7 +65,7 @@
         field.classList.add('usa-checkbox');
         input.classList.add('usa-checkbox__input');
         input.type = 'checkbox';
-        input.name = group;
+        input.name = `optionals_${group}`;
         input.value = option.name;
         input.addEventListener('change', () => {
           if (!currentRerender) {


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1779

## What does this change?

- 🌎 Templates support [%optional] sections which can be chosen from when sending a message
- ⛔ We don't actually factor those in when sending
- ✅ This commit considers optionals in rendered complainant mail

## Screenshots (for front-end PR):

<img width="862" alt="image" src="https://github.com/usdoj-crt/crt-portal-management/assets/15126660/cfe62e33-7fbf-4913-a9fd-7a5ce5bf6b37">

(See e2e tests, I've tested against the TMS content in our logs)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
