### PR TITLE
Shows shortlinks for saved searches

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -2928,6 +2928,7 @@ class SavedSearchActions(ModelForm):
                     'name': 'name',
                     'placeholder': 'Name',
                     'aria-label': 'Name',
+                    'data-urlify-source': 'name_to_link',
                 },
             ),
             required=True,

--- a/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/intake_base.html
@@ -31,6 +31,7 @@
 {{ block.super }}
 <script src="{% static 'js/dropdown.min.js' %}"></script>
 <script src="{% static 'js/usa_tag_select.min.js' %}"></script>
+<script src="{% static 'js/short_link.min.js' %}"></script>
 {%endblock%}
 {# no google analytics on backend #}
 {% block analytics %}{% endblock %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/saved_searches/actions/new-action.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/saved_searches/actions/new-action.html
@@ -1,4 +1,5 @@
 {% extends "forms/complaint_view/show/card.html" %}
+{% load get_env %}
 {% block title %}{{title}}{% endblock %}
 {% block extra_classes %}crt-action-card{% endblock %}
 {% block icon %}
@@ -19,6 +20,14 @@
         {{ form.fields.name.label }}
       </label>
       {{ form.name }}
+    </div>
+    <div class="margin-bottom-2 crt-dropdown crt-dropdown__shrink-to-contents">
+      <label class="intake-label">Short Link
+      {% include 'partials/help_tooltip.html' with tip="This is generated based on the search name, and must be saved before it will work." %}
+      </label>
+      <a href="#" data-urlify-base="{% intake_site_prefix %}/link/" data-urlify-prefix="search/" data-urlify-destination="name_to_link" class="usa-link">
+        {% intake_site_prefix %}/link/...
+      </a>
     </div>
     <div class="margin-bottom-2 crt-dropdown crt-dropdown__shrink-to-contents">
       <label for="id_name" class="intake-label">

--- a/crt_portal/cts_forms/templates/forms/complaint_view/saved_searches/actions/update-action.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/saved_searches/actions/update-action.html
@@ -1,4 +1,5 @@
 {% extends "forms/complaint_view/show/card.html" %}
+{% load get_env %}
 {% block title %}{{title}}{% endblock %}
 {% block extra_classes %}crt-action-card{% endblock %}
 {% block icon %}
@@ -21,7 +22,13 @@
       {{ form.name }}
     </div>
     <div class="margin-bottom-2 crt-dropdown crt-dropdown__shrink-to-contents">
-      <label for="id_name" class="intake-label">
+      <label class="intake-label">Short Link</label>
+      <a href="{% intake_site_prefix %}/link/{{ form.instance.shortened_url }}" data-urlify-base="{% intake_site_prefix %}/link/" data-urlify-prefix="search/" data-urlify-destination="name_to_link" class="usa-link">
+        {% intake_site_prefix %}/link/{{ form.instance.shortened_url }}
+      </a>
+    </div>
+    <div class="margin-bottom-2 crt-dropdown crt-dropdown__shrink-to-contents">
+      <label for="id_description" class="intake-label">
         {{ form.fields.description.label }}
       </label>
       {{ form.description }}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/saved_searches/saved-search-table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/saved_searches/saved-search-table.html
@@ -27,7 +27,7 @@
           <td>
             <a
               data-ga-event-name="saved search link: {{ saved_search.name }}"
-              href="/form/view/?{{ saved_search.query }}"
+              href="/link/{{ saved_search.shortened_url }}"
               >{{ saved_search.name }}</a
             >
           </td>

--- a/crt_portal/cts_forms/templatetags/get_env.py
+++ b/crt_portal/cts_forms/templatetags/get_env.py
@@ -1,6 +1,7 @@
 import os
 
 from django import template
+from utils.site_prefix import get_site_prefix
 
 register = template.Library()
 
@@ -8,3 +9,8 @@ register = template.Library()
 @register.simple_tag
 def environment():
     return os.environ.get('ENV', 'UNDEFINED')
+
+
+@register.simple_tag
+def intake_site_prefix():
+    return get_site_prefix(for_intake=True)

--- a/crt_portal/cts_forms/tests/integration_authed/saved_search.py
+++ b/crt_portal/cts_forms/tests/integration_authed/saved_search.py
@@ -2,15 +2,14 @@ import uuid
 import pytest
 
 from cts_forms.tests.integration_authed.auth import login_as_superuser
-from cts_forms.tests.integration_util import console, admin_models, element, reporting
+from cts_forms.tests.integration_util import console, admin_models, element, reporting, features
 
 
 @pytest.mark.only_browser("chromium")
 @console.raise_errors(ignore='404')
 @reporting.capture_report('saved_search.pdf')
+@features.login_as_superuser_with_feature('saved-searches')
 def test_intake_add_search(page, *, report):
-    login_as_superuser(page)
-
     admin_models.delete(
         page,
         '/admin/cts_forms/savedsearch',

--- a/crt_portal/cts_forms/tests/integration_authed/saved_search.py
+++ b/crt_portal/cts_forms/tests/integration_authed/saved_search.py
@@ -8,7 +8,7 @@ from cts_forms.tests.integration_util import console, admin_models, element, rep
 @pytest.mark.only_browser("chromium")
 @console.raise_errors(ignore='404')
 @reporting.capture_report('saved_search.pdf')
-@features.login_as_superuser_with_feature('saved_searches')
+@features.login_as_superuser_with_feature('saved-searches')
 def test_intake_add_search(page, *, report):
     admin_models.delete(
         page,

--- a/crt_portal/cts_forms/tests/integration_authed/saved_search.py
+++ b/crt_portal/cts_forms/tests/integration_authed/saved_search.py
@@ -99,98 +99,98 @@ def test_intake_add_search(page, *, report):
     assert not page.locator('#id_shared').is_checked()
 
 
-# @pytest.mark.only_browser("chromium")
-# @console.raise_errors(ignore='404')
-# def test_auto_close(page):
-#     login_as_superuser(page)
+@pytest.mark.only_browser("chromium")
+@console.raise_errors(ignore='404')
+def test_auto_close(page):
+    login_as_superuser(page)
 
-#     admin_models.delete(
-#         page,
-#         '/admin/cts_forms/savedsearch',
-#         name__contains='Saved Search Integration Test',
-#     )
+    admin_models.delete(
+        page,
+        '/admin/cts_forms/savedsearch',
+        name__contains='Saved Search Integration Test',
+    )
 
-#     unclosed = admin_models.create_report(
-#         page,
-#         crt_reciept_month='12',
-#         crt_reciept_day='25',
-#         crt_reciept_year='2000',
-#         intake_format='phone',
-#         primary_complaint='something_else',
-#         contact_first_name='SavedSearchTest',
-#     )
+    unclosed = admin_models.create_report(
+        page,
+        crt_reciept_month='12',
+        crt_reciept_day='25',
+        crt_reciept_year='2000',
+        intake_format='phone',
+        primary_complaint='something_else',
+        contact_first_name='SavedSearchTest',
+    )
 
-#     page.goto(f'/form/view/{unclosed}')
-#     assert element.normalize_text(page.locator('#id_status [selected]')) == 'New'
+    page.goto(f'/form/view/{unclosed}')
+    assert element.normalize_text(page.locator('#id_status [selected]')) == 'New'
 
-#     admin_models.create(
-#         page,
-#         '/admin/cts_forms/savedsearch',
-#         name='Saved Search Integration Test - Auto-close',
-#         auto_close=True,
-#         auto_close_reason='it was auto-routed to other agency for processing',
-#         query='status=new&status=open&violation_summary=%22refer%20to%20agency!%22&no_status=false&grouping=default',
-#     )
+    admin_models.create(
+        page,
+        '/admin/cts_forms/savedsearch',
+        name='Saved Search Integration Test - Auto-close',
+        auto_close=True,
+        auto_close_reason='it was auto-routed to other agency for processing',
+        query='status=new&status=open&violation_summary=%22refer%20to%20agency!%22&no_status=false&grouping=default',
+    )
 
-#     closed = admin_models.create_report(
-#         page,
-#         crt_reciept_month='12',
-#         crt_reciept_day='25',
-#         crt_reciept_year='2000',
-#         intake_format='phone',
-#         primary_complaint='something_else',
-#         contact_first_name='SavedSearchTest',
-#         violation_summary='refer to agency!',
-#     )
+    closed = admin_models.create_report(
+        page,
+        crt_reciept_month='12',
+        crt_reciept_day='25',
+        crt_reciept_year='2000',
+        intake_format='phone',
+        primary_complaint='something_else',
+        contact_first_name='SavedSearchTest',
+        violation_summary='refer to agency!',
+    )
 
-#     page.goto(f'/form/view/{closed}')
-#     assert element.normalize_text(page.locator('#id_status [selected]')) == 'Closed'
-#     assert page.locator('#id_summary').input_value() == 'Report automatically closed on submission because it was auto-routed to other agency for processing'
+    page.goto(f'/form/view/{closed}')
+    assert element.normalize_text(page.locator('#id_status [selected]')) == 'Closed'
+    assert page.locator('#id_summary').input_value() == 'Report automatically closed on submission because it was auto-routed to other agency for processing'
 
 
-# @pytest.mark.only_browser("chromium")
-# @console.raise_errors(ignore='404')
-# def test_auto_reroute(page):
-#     login_as_superuser(page)
+@pytest.mark.only_browser("chromium")
+@console.raise_errors(ignore='404')
+def test_auto_reroute(page):
+    login_as_superuser(page)
 
-#     admin_models.delete(
-#         page,
-#         '/admin/cts_forms/savedsearch',
-#         name__contains='Saved Search Integration Test',
-#     )
+    admin_models.delete(
+        page,
+        '/admin/cts_forms/savedsearch',
+        name__contains='Saved Search Integration Test',
+    )
 
-#     unrouted = admin_models.create_report(
-#         page,
-#         crt_reciept_month='12',
-#         crt_reciept_day='25',
-#         crt_reciept_year='2000',
-#         intake_format='phone',
-#         primary_complaint='something_else',
-#         contact_first_name='SavedSearchTest',
-#     )
+    unrouted = admin_models.create_report(
+        page,
+        crt_reciept_month='12',
+        crt_reciept_day='25',
+        crt_reciept_year='2000',
+        intake_format='phone',
+        primary_complaint='something_else',
+        contact_first_name='SavedSearchTest',
+    )
 
-#     page.goto(f'/form/view/{unrouted}')
-#     assert element.normalize_text(page.locator('#id_assigned_section [selected]')) == 'ADM'
+    page.goto(f'/form/view/{unrouted}')
+    assert element.normalize_text(page.locator('#id_assigned_section [selected]')) == 'ADM'
 
-#     admin_models.create(
-#         page,
-#         '/admin/cts_forms/savedsearch',
-#         name='Saved Search Integration Test - auto-reroute',
-#         override_section_assignment=True,
-#         override_section_assignment_with='DRS',
-#         query='status=new&status=open&violation_summary=%22reroute!%22&no_status=false&grouping=default',
-#     )
+    admin_models.create(
+        page,
+        '/admin/cts_forms/savedsearch',
+        name='Saved Search Integration Test - auto-reroute',
+        override_section_assignment=True,
+        override_section_assignment_with='DRS',
+        query='status=new&status=open&violation_summary=%22reroute!%22&no_status=false&grouping=default',
+    )
 
-#     routed = admin_models.create_report(
-#         page,
-#         crt_reciept_month='12',
-#         crt_reciept_day='25',
-#         crt_reciept_year='2000',
-#         intake_format='phone',
-#         primary_complaint='something_else',
-#         contact_first_name='SavedSearchTest',
-#         violation_summary='reroute!',
-#     )
+    routed = admin_models.create_report(
+        page,
+        crt_reciept_month='12',
+        crt_reciept_day='25',
+        crt_reciept_year='2000',
+        intake_format='phone',
+        primary_complaint='something_else',
+        contact_first_name='SavedSearchTest',
+        violation_summary='reroute!',
+    )
 
-#     page.goto(f'/form/view/{routed}')
-#     assert element.normalize_text(page.locator('#id_assigned_section [selected]')) == 'DRS'
+    page.goto(f'/form/view/{routed}')
+    assert element.normalize_text(page.locator('#id_assigned_section [selected]')) == 'DRS'

--- a/crt_portal/cts_forms/tests/integration_authed/saved_search.py
+++ b/crt_portal/cts_forms/tests/integration_authed/saved_search.py
@@ -22,8 +22,7 @@ def test_intake_add_search(page, *, report):
 
     report.screenshot(page, full_page=True, caption='The easiest way to create a saved search is from the list page. Start by choosing the filters you want to save and choose "Apply Filters".')
 
-    with page.expect_navigation():
-        page.locator('button').filter(has_text='Apply filters').click()
+    page.goto('/form/view?status=new&status=open&summary=test')
 
     report.screenshot(page, full_page=True, caption='Once the filters update, you can choose "Save search" to save the search.')
 

--- a/crt_portal/cts_forms/tests/integration_authed/saved_search.py
+++ b/crt_portal/cts_forms/tests/integration_authed/saved_search.py
@@ -8,7 +8,7 @@ from cts_forms.tests.integration_util import console, admin_models, element, rep
 @pytest.mark.only_browser("chromium")
 @console.raise_errors(ignore='404')
 @reporting.capture_report('saved_search.pdf')
-@features.login_as_superuser_with_feature('saved-searches')
+@features.login_as_superuser_with_feature('saved_searches')
 def test_intake_add_search(page, *, report):
     admin_models.delete(
         page,

--- a/crt_portal/cts_forms/tests/integration_authed/saved_search.py
+++ b/crt_portal/cts_forms/tests/integration_authed/saved_search.py
@@ -1,12 +1,14 @@
+import uuid
 import pytest
 
 from cts_forms.tests.integration_authed.auth import login_as_superuser
-from cts_forms.tests.integration_util import console, admin_models, element
+from cts_forms.tests.integration_util import console, admin_models, element, reporting
 
 
 @pytest.mark.only_browser("chromium")
 @console.raise_errors(ignore='404')
-def test_auto_close(page):
+@reporting.capture_report('saved_search.pdf')
+def test_intake_add_search(page, *, report):
     login_as_superuser(page)
 
     admin_models.delete(
@@ -15,87 +17,180 @@ def test_auto_close(page):
         name__contains='Saved Search Integration Test',
     )
 
-    unclosed = admin_models.create_report(
-        page,
-        crt_reciept_month='12',
-        crt_reciept_day='25',
-        crt_reciept_year='2000',
-        intake_format='phone',
-        primary_complaint='something_else',
-        contact_first_name='SavedSearchTest',
-    )
+    page.goto('/form/view')
+    page.fill('#id_summary', 'test')
 
-    page.goto(f'/form/view/{unclosed}')
-    assert element.normalize_text(page.locator('#id_status [selected]')) == 'New'
+    report.screenshot(page, full_page=True, caption='The easiest way to create a saved search is from the list page. Start by choosing the filters you want to save and choose "Apply Filters".')
 
-    admin_models.create(
-        page,
-        '/admin/cts_forms/savedsearch',
-        name='Saved Search Integration Test - Auto-close',
-        auto_close=True,
-        auto_close_reason='it was auto-routed to other agency for processing',
-        query='status=new&status=open&violation_summary=%22refer%20to%20agency!%22&no_status=false&grouping=default',
-    )
+    with page.expect_navigation():
+        page.locator('button').filter(has_text='Apply filters').click()
 
-    closed = admin_models.create_report(
-        page,
-        crt_reciept_month='12',
-        crt_reciept_day='25',
-        crt_reciept_year='2000',
-        intake_format='phone',
-        primary_complaint='something_else',
-        contact_first_name='SavedSearchTest',
-        violation_summary='refer to agency!',
-    )
+    report.screenshot(page, full_page=True, caption='Once the filters update, you can choose "Save search" to save the search.')
 
-    page.goto(f'/form/view/{closed}')
-    assert element.normalize_text(page.locator('#id_status [selected]')) == 'Closed'
-    assert page.locator('#id_summary').input_value() == 'Report automatically closed on submission because it was auto-routed to other agency for processing'
+    with page.expect_navigation():
+        page.locator('button').filter(has_text='Save search').click()
+
+    search_id = str(uuid.uuid4())
+    page.fill('#id_name', f'Saved Search Integration Test {search_id}')
+    page.locator('a').filter(has_text='/link/search/saved-search-integration-test').wait_for()
+    page.locator('#id_description').fill('This is a test search')
+    assert page.locator('#id_query').input_value() == '&status=new&status=open&summary=test'
+    page.select_option('#id_section', 'ELS')
+    page.check('#id_shared')
+
+    report.screenshot(page, full_page=True, caption="""This will bring you to a page where you can name the search, add a description, and choose whether to share the search with others. The "Query" field is a representation of the filters you've selected; don't change it unless you know what you're doing. Once you're done, choose "Add" to save the search.""")
+
+    with page.expect_navigation():
+        page.locator('button').filter(has_text='Add').click()
+
+    page.locator('.usa-alert--success').filter(has_text=f'Successfully added new saved search: Saved Search Integration Test {search_id}.').wait_for()
+
+    report.screenshot(page, full_page=True, caption="""You can now see your saved search in the list of saved searches. Note that you may need to move to the "My Saved Searches" tab if you didn't choose to share it.""")
+
+    row = page.locator('tr').filter(has_text=search_id)
+
+    assert row.locator('a').filter(has_text='Saved Search Integration Test').get_attribute('href') == f'/link/search/saved-search-integration-test-{search_id}'
+
+    with page.expect_navigation():
+        row.locator('button').filter(has_text='Edit').click()
+
+    assert page.locator('#id_name').input_value() == f'Saved Search Integration Test {search_id}'
+    assert f'/link/search/saved-search-integration-test-{search_id}' in page.locator('div').filter(has_text='Short Link').locator('a').get_attribute('href')
+    assert page.locator('#id_description').input_value() == 'This is a test search'
+    assert page.locator('#id_query').input_value() == '&status=new&status=open&summary=test'
+    assert element.normalize_text(page.locator('#id_section [selected]')) == 'ELS'
+    assert page.locator('#id_shared').is_checked()
+
+    page.fill('#id_name', f'Saved Search Integration Test {search_id} - Updated')
+    page.fill('#id_description', 'This is an updated test search')
+    page.fill('#id_query', 'status=new&status=open&summary=test2')
+    page.select_option('#id_section', 'ADM')
+    page.uncheck('#id_shared')
+    page.locator('div').filter(has_text='Short Link').locator('a').filter(has_text=f'/link/search/saved-search-integration-test-{search_id}-updated').wait_for()
+
+    report.screenshot(page, full_page=True, caption="""You can edit your saved search by choosing the "Edit" button. You can change the name, description, and sharing settings. Changing the name will update the short link. Again, the "Query" field is a representation of the filters you've selected; don't change it unless you know what you're doing. Choose "Apply changes" to save your changes.""")
+
+    with page.expect_navigation():
+        page.locator('button').filter(has_text='Apply changes').click()
+
+    page.locator('.usa-alert--success').filter(has_text=f'Successfully updated Name, Query, Section, Description, and Share in Saved Search Integration Test {search_id} - Updated').wait_for()
+
+    report.screenshot(page, full_page=True, caption="""Because your search is no longer shared, you won't see it in the "Shared saved searches" tab anymore.""")
+
+    assert search_id not in page.locator('.saved-search-table').text_content()
+    with page.expect_navigation():
+        page.locator('a').filter(has_text='My saved searches').click()
+    assert search_id in page.locator('.saved-search-table').text_content()
+
+    row = page.locator('tr').filter(has_text=search_id)
+
+    report.screenshot(page, full_page=True, caption="""Clicking "My saved searches" will show it.""")
+
+    assert f'/link/search/saved-search-integration-test-{search_id}-updated' in row.locator('a').filter(has_text='Saved Search Integration Test').get_attribute('href')
+
+    with page.expect_navigation():
+        row.locator('button').filter(has_text='Edit').click()
+
+    assert page.locator('#id_name').input_value() == f'Saved Search Integration Test {search_id} - Updated'
+    assert f'/link/search/saved-search-integration-test-{search_id}-updated' in page.locator('div').filter(has_text='Short Link').locator('a').get_attribute('href')
+    assert page.locator('#id_description').input_value() == 'This is an updated test search'
+    assert page.locator('#id_query').input_value() == 'status=new&status=open&summary=test2'
+    assert element.normalize_text(page.locator('#id_section [selected]')) == 'ADM'
+    assert not page.locator('#id_shared').is_checked()
 
 
-@pytest.mark.only_browser("chromium")
-@console.raise_errors(ignore='404')
-def test_auto_reroute(page):
-    login_as_superuser(page)
+# @pytest.mark.only_browser("chromium")
+# @console.raise_errors(ignore='404')
+# def test_auto_close(page):
+#     login_as_superuser(page)
 
-    admin_models.delete(
-        page,
-        '/admin/cts_forms/savedsearch',
-        name__contains='Saved Search Integration Test',
-    )
+#     admin_models.delete(
+#         page,
+#         '/admin/cts_forms/savedsearch',
+#         name__contains='Saved Search Integration Test',
+#     )
 
-    unrouted = admin_models.create_report(
-        page,
-        crt_reciept_month='12',
-        crt_reciept_day='25',
-        crt_reciept_year='2000',
-        intake_format='phone',
-        primary_complaint='something_else',
-        contact_first_name='SavedSearchTest',
-    )
+#     unclosed = admin_models.create_report(
+#         page,
+#         crt_reciept_month='12',
+#         crt_reciept_day='25',
+#         crt_reciept_year='2000',
+#         intake_format='phone',
+#         primary_complaint='something_else',
+#         contact_first_name='SavedSearchTest',
+#     )
 
-    page.goto(f'/form/view/{unrouted}')
-    assert element.normalize_text(page.locator('#id_assigned_section [selected]')) == 'ADM'
+#     page.goto(f'/form/view/{unclosed}')
+#     assert element.normalize_text(page.locator('#id_status [selected]')) == 'New'
 
-    admin_models.create(
-        page,
-        '/admin/cts_forms/savedsearch',
-        name='Saved Search Integration Test - auto-reroute',
-        override_section_assignment=True,
-        override_section_assignment_with='DRS',
-        query='status=new&status=open&violation_summary=%22reroute!%22&no_status=false&grouping=default',
-    )
+#     admin_models.create(
+#         page,
+#         '/admin/cts_forms/savedsearch',
+#         name='Saved Search Integration Test - Auto-close',
+#         auto_close=True,
+#         auto_close_reason='it was auto-routed to other agency for processing',
+#         query='status=new&status=open&violation_summary=%22refer%20to%20agency!%22&no_status=false&grouping=default',
+#     )
 
-    routed = admin_models.create_report(
-        page,
-        crt_reciept_month='12',
-        crt_reciept_day='25',
-        crt_reciept_year='2000',
-        intake_format='phone',
-        primary_complaint='something_else',
-        contact_first_name='SavedSearchTest',
-        violation_summary='reroute!',
-    )
+#     closed = admin_models.create_report(
+#         page,
+#         crt_reciept_month='12',
+#         crt_reciept_day='25',
+#         crt_reciept_year='2000',
+#         intake_format='phone',
+#         primary_complaint='something_else',
+#         contact_first_name='SavedSearchTest',
+#         violation_summary='refer to agency!',
+#     )
 
-    page.goto(f'/form/view/{routed}')
-    assert element.normalize_text(page.locator('#id_assigned_section [selected]')) == 'DRS'
+#     page.goto(f'/form/view/{closed}')
+#     assert element.normalize_text(page.locator('#id_status [selected]')) == 'Closed'
+#     assert page.locator('#id_summary').input_value() == 'Report automatically closed on submission because it was auto-routed to other agency for processing'
+
+
+# @pytest.mark.only_browser("chromium")
+# @console.raise_errors(ignore='404')
+# def test_auto_reroute(page):
+#     login_as_superuser(page)
+
+#     admin_models.delete(
+#         page,
+#         '/admin/cts_forms/savedsearch',
+#         name__contains='Saved Search Integration Test',
+#     )
+
+#     unrouted = admin_models.create_report(
+#         page,
+#         crt_reciept_month='12',
+#         crt_reciept_day='25',
+#         crt_reciept_year='2000',
+#         intake_format='phone',
+#         primary_complaint='something_else',
+#         contact_first_name='SavedSearchTest',
+#     )
+
+#     page.goto(f'/form/view/{unrouted}')
+#     assert element.normalize_text(page.locator('#id_assigned_section [selected]')) == 'ADM'
+
+#     admin_models.create(
+#         page,
+#         '/admin/cts_forms/savedsearch',
+#         name='Saved Search Integration Test - auto-reroute',
+#         override_section_assignment=True,
+#         override_section_assignment_with='DRS',
+#         query='status=new&status=open&violation_summary=%22reroute!%22&no_status=false&grouping=default',
+#     )
+
+#     routed = admin_models.create_report(
+#         page,
+#         crt_reciept_month='12',
+#         crt_reciept_day='25',
+#         crt_reciept_year='2000',
+#         intake_format='phone',
+#         primary_complaint='something_else',
+#         contact_first_name='SavedSearchTest',
+#         violation_summary='reroute!',
+#     )
+
+#     page.goto(f'/form/view/{routed}')
+#     assert element.normalize_text(page.locator('#id_assigned_section [selected]')) == 'DRS'

--- a/crt_portal/cts_forms/tests/integration_util/reporting.py
+++ b/crt_portal/cts_forms/tests/integration_util/reporting.py
@@ -14,9 +14,13 @@ def capture_report(path_to_pdf):
     def wrapper(func):
         def decorator(page, *args, **kwargs):
             report = PdfReport(path_to_pdf)
-            result = func(page, *args, report=report, **kwargs)
-            report.save()
-            return result
+            try:
+                return func(page, *args, report=report, **kwargs)
+            except Exception as e:
+                report.screenshot(page, full_page=True, caption=f'An error occurred: {e}')
+                raise
+            finally:
+                report.save()
         return decorator
     return wrapper
 

--- a/crt_portal/features/migrations/0010_email_responses_card.py
+++ b/crt_portal/features/migrations/0010_email_responses_card.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     operations = [
         AddFeatureMigration(
-            'email_responses_card',
+            'email-responses-card',
             True,
             description='Show the email responses card on the report detail page.'
         ),

--- a/crt_portal/features/migrations/0013_saved_searches.py
+++ b/crt_portal/features/migrations/0013_saved_searches.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     operations = [
         AddFeatureMigration(
-            'saved_searches',
+            'saved-searches',
             False,
             description='Show saved search features'
         ),

--- a/crt_portal/features/models.py
+++ b/crt_portal/features/models.py
@@ -10,6 +10,9 @@ FeatureNameValidator = RegexValidator(r'^[a-z\-]*$', 'Feature may only contain t
 
 class AddFeatureMigration(migrations.RunPython):
     def __init__(self, feature_name, enabled, *, description='', **kwargs):
+        if '_' in feature_name:
+            raise ValueError('Underscores are not allowed in feature names. Use dashes instead.')
+
         def add_feature(apps, schema_editor):
             drop_feature(apps, schema_editor)
             Feature.objects.create(name=feature_name,

--- a/crt_portal/shortener/tests.py
+++ b/crt_portal/shortener/tests.py
@@ -73,6 +73,6 @@ class UrlifyTest(TestCase):
         self.superuser = User.objects.create_superuser('SHORTENER_TEST_USER', 'a@a.com', '')
         self.client.force_login(self.superuser)
 
-        response = self.client.get('/link/urlify?name=Hooray%20for%20me')
+        response = self.client.get('/link/urlify/?name=Hooray%20for%20me')
 
         self.assertEqual(response.json()['url'], 'hooray-for-me')

--- a/crt_portal/shortener/views.py
+++ b/crt_portal/shortener/views.py
@@ -17,5 +17,5 @@ def redirect_to_shortened(request, *, path):
 def preview_urlify(request, *, prefix=''):
     name = request.GET.get('name')
     return JsonResponse({
-        'url': ShortenedURL.urlify(name, prefix=prefix)
+        'url': ShortenedURL.urlify(name, prefix=prefix),
     })

--- a/crt_portal/static/js/short_link.js
+++ b/crt_portal/static/js/short_link.js
@@ -1,0 +1,44 @@
+(function(root, dom) {
+  function urlify(source, destination) {
+    const base = destination.dataset.urlifyBase;
+    const prefix = destination.dataset.urlifyPrefix;
+    const encodedName = encodeURIComponent(source.value);
+    const target = `/link/urlify/${prefix}?name=${encodedName}`;
+    return window.fetch(target).then(response => {
+      if (!response.ok) return;
+      response.json().then(json => {
+        if (!json.url) {
+          destination.setAttribute('href', '#');
+          destination.textContent = '(Unable to preview link)';
+          return;
+        }
+
+        destination.setAttribute('href', `${base}${json.url}`);
+        destination.textContent = `${base}${json.url}`;
+      });
+    });
+  }
+
+  function init() {
+    const sources = Array.from(dom.querySelectorAll('[data-urlify-source]'));
+    const destinations = Array.from(dom.querySelectorAll('[data-urlify-destination]'));
+
+    const pairs = sources.map(source => {
+      const name = source.dataset.urlifySource;
+      const destination = destinations.find(
+        destination => destination.dataset.urlifyDestination === name
+      );
+      if (!destination) return [source, null];
+      return [source, destination];
+    }, {});
+
+    pairs.forEach(([source, destination]) => {
+      if (!destination) return;
+      let currentPromise = Promise.resolve();
+      source.addEventListener('input', () => {
+        currentPromise = currentPromise.then(() => urlify(source, destination));
+      });
+    });
+  }
+  window.addEventListener('DOMContentLoaded', init);
+})(window, document);

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -1278,6 +1278,16 @@ ul.messages {
   margin-bottom: 2rem;
 }
 
+fieldset[name="saved-search-actions"] {
+  .usa-link,.usa-checkbox__label {
+    width: 100%;
+  }
+
+  .usa-tooltip {
+    display: inline-block;
+  }
+}
+
 /* Match combo box input styling with other filters */
 .crt-combo-box-filter {
   width: 15rem; /* Hard code width to fix situation where input would expand when an item is selected */


### PR DESCRIPTION


[Link to ZenHub issue.](link-goes-here)

## What does this change?

- 🌎 Saved searches have shortlinks that are created on save
- ⛔ Those aren't yet surfaced to the user
- ✅ This commit surfaces them in the list, new, and update list.

This also adds end-to-end tests for saved searches to try out the new Javascript

## Screenshots (for front-end PR):

Generated docs from e2e test: 
[saved_search.pdf](https://github.com/usdoj-crt/crt-portal-management/files/14934309/saved_search.pdf)

URL making example:


![search](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/ecdc077a-4e17-486e-a66f-b8a5a51922b2)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
