### PR TITLE
Fix batch expiration column

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/actions/report_list.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/actions/report_list.html
@@ -43,7 +43,7 @@
           {% for datum in data %}
             <tr class="stripe">
               <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.public_id }}</a></td>
-              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.assigned_section }}</a></td>
+              <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.expiration_date|date:"SHORT_DATE_FORMAT" }}</a></td>
               <td><a class="td-link display-block" href="{{datum.url}}">{{ datum.report.location_name|default:"-" }}</a></td>
               <td>
                 <a class="td-link display-block" href="{{datum.url}}">


### PR DESCRIPTION
Expiration column displaying incorrect data
[#1799](https://github.com/usdoj-crt/crt-portal-management/issues/1799)

## What does this change?
This fixes an issue where the section is showing in the expiration date column for the batch review page.

## Screenshots (for front-end PR):
![Image](https://github.com/usdoj-crt/crt-portal-management/assets/18104884/5caec9be-c4c5-41a7-989d-4fff028b6490)
## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
