### PR TITLE
Preview optionals in the admin panel

### DIFF
--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -4,7 +4,7 @@ from api.serializers import ReportSerializer, ResponseTemplateSerializer, Relate
 from utils.pdf import convert_html_to_pdf
 from cts_forms.filters import report_filter
 from cts_forms.mail import mail_to_complainant, mail_to_agency, build_letters, build_preview
-from utils.markdown_extensions import CustomHTMLExtension
+from utils.markdown_extensions import CustomHTMLExtension, OptionalExtension
 from cts_forms.models import Report, ResponseTemplate
 from cts_forms.views import mark_report_as_viewed, mark_reports_as_viewed
 from cts_forms.forms import add_activity
@@ -151,7 +151,7 @@ class ResponseTemplatePreviewBase:
         context = self._make_example_context()
         if is_html:
             subbed = str(Template(body).render(context))
-            md = markdown.markdown(subbed, extensions=['extra', 'sane_lists', 'admonition', 'nl2br', CustomHTMLExtension(), *extra_markdown_extensions])
+            md = markdown.markdown(subbed, extensions=[OptionalExtension(preview=True), 'extra', 'sane_lists', 'admonition', 'nl2br', CustomHTMLExtension(), *extra_markdown_extensions])
             return render(request, 'email.html', {'content': md})
 
         return HttpResponse(Template(body.replace('\n', '<br>')).render(context))

--- a/crt_portal/cts_forms/templates/template_help.md
+++ b/crt_portal/cts_forms/templates/template_help.md
@@ -316,6 +316,36 @@ The following types are standard, but we can invent our own:
 
 ---
 
+#### Optional sections
+
+Optional sections are a custom extension for working with response templates that have paragraphs that might or might not be included in the final response. They look like this:
+
+```
+This content is not optional
+
+[%optional group="The checkbox group" name="The individual checkbox name"]
+
+This content is optional
+
+[%endoptional]
+
+More not optional content
+```
+
+which becomes:
+
+This content is not optional
+
+[%optional group="The checkbox group" name="The individual checkbox name"]
+
+This content is optional
+
+[%endoptional]
+
+More not optional content
+
+Note that the dropdown is just for previewing that this works - in the Contact Complaianant page, these will be checkboxes. Unchecking the boxes will hide the section completely.
+
 #### Footnotes
 
 ```

--- a/crt_portal/utils/markdown_extensions.py
+++ b/crt_portal/utils/markdown_extensions.py
@@ -118,8 +118,8 @@ class OptionalProcessor(Preprocessor):
             # This must be a single line; whitespace throws off the markdown:
             raw_markdown = (
                 f"{raw_markdown[:start]}\n\n<details><summary>"
-                f"[Optional] {option["group"]}: {option["name"]}</summary>"
-                f"\n\n{option["content"]}\n\n</details>\n\n{raw_markdown[end:]}"
+                f"[Optional] {option['group']}: {option['name']}</summary>"
+                f"\n\n{option['content']}\n\n</details>\n\n{raw_markdown[end:]}"
             )
 
         return raw_markdown


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1795

## What does this change?

- 🌎 Response templates can have optional content that renders as checkboxes
- ⛔ The syntax is complicated, and we don't currently have a way to preview if it'll work correctly
- ✅ This commit adds an admin panel preview for optionals, rendering them as dropdowns (details tags)

## Screenshots (for front-end PR):

<img width="771" alt="image" src="https://github.com/usdoj-crt/crt-portal-management/assets/15126660/a10f874e-3295-4618-b9be-fa1df9c43f8b">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
