### PR TITLE
Update owasp scan, with debug config to run on push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,8 +191,7 @@ jobs:
       - run:
           name: Pull owasp zap docker image and run scan
           command: |
-            docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-stable:latest zap-baseline.py \
-            -t https://crt-portal-django-dev.app.cloud.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
+            docker run -v $(pwd):/zap/wrk/:rw -t softwaresecurityproject/zap-stable zap-baseline.py -t https://crt-portal-django-dev.app.cloud.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
   owasp-scan-stage:
     machine:
       image: ubuntu-2204:2024.01.1
@@ -202,8 +201,7 @@ jobs:
       - run:
           name: Pull owasp zap docker image and run scan
           command: |
-            docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-stable:latest zap-baseline.py \
-            -t https://crt-portal-django-stage.app.cloud.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
+            docker run -v $(pwd):/zap/wrk/:rw -t softwaresecurityproject/zap-stable zap-baseline.py -t https://crt-portal-django-stage.app.cloud.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
   owasp-scan-prod:
     machine:
       image: ubuntu-2204:2024.01.1
@@ -213,8 +211,7 @@ jobs:
       - run:
           name: Pull owasp zap docker image and run scan
           command: |
-            docker run -v $(pwd):/zap/wrk/:rw -t owasp/zap2docker-stable:latest zap-baseline.py \
-            -t https://civilrights.justice.gov/report/ -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
+            docker run -v $(pwd):/zap/wrk/:rw -t softwaresecurityproject/zap-stable zap-baseline.py -t https://civilrights.justice.gov/report -c .circleci/zap.conf --autooff -z "-config rules.cookie.ignorelist=django_language"
   # deployments
   deploy-dev:
     working_directory: ~/code
@@ -610,10 +607,10 @@ workflows:
     jobs:
       - build_and_test
 
-      - owasp-scan-dev:
-          filters:
-            branches:
-              only: /^release.*/
+      - owasp-scan-dev
+          # filters:
+          #   branches:
+          #     only: /^release.*/
 
       - owasp-scan-stage:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,10 +607,10 @@ workflows:
     jobs:
       - build_and_test
 
-      - owasp-scan-dev
-          # filters:
-          #   branches:
-          #     only: /^release.*/
+      - owasp-scan-dev:
+          filters:
+            branches:
+              only: /^release.*/
 
       - owasp-scan-stage:
           filters:


### PR DESCRIPTION
Quick fix for CCI failures: https://app.circleci.com/pipelines/github/usdoj-crt/crt-portal/12949/workflows/01c71524-cf94-42d0-bc4c-50638e06f760/jobs/16745

## What does this change?

Updates OWASP image to use new organization. The old OWASP org is deprecated and failing to run.

I've tested the dev piece against this branch, and it appears to work. The staging and production runs look good, but won't be tested prior to deployments.

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
