### PR TITLE
If someone edits a shared saved search, prompt them to create a new one

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/saved_searches/actions/update-action.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/saved_searches/actions/update-action.html
@@ -7,6 +7,28 @@
 {% endblock %}
 
 {% block card_content %}
+{% if form.shared.initial %}
+  <div id="warning_section" class="usa-alert usa-alert--warning">
+    <div class="display-flex flex-align-center flex-justify padding-2">
+      <img width="30" height="30" src="{% static 'img/alerts/warning.svg' %}" alt="warning" class="icon" />
+      <div class="margin-left-2 line-height-sans-5">
+        <span class="text-bold">This is a shared saved search so editing it might impact other users. Create a duplicate
+          version of this search by clicking</span>
+        <form id="save-search" method="GET" class="display-inline" action="{% url 'crt_forms:saved-search-actions' %}"
+          novalidate>
+          <input type="hidden" value="{{ form.query.initial }}" name="query" id="query" />
+          <input type="hidden" value="{{ form.description.initial }}" name="description" id="description" />
+          <input type="hidden" value="{{ form.name.initial }}" name="name" id="name" />
+          <input type="hidden" value="{{ form.section.initial }}" name="section" id="section" />
+          <button class="usa-button usa-button--unstyled text-bold" type="submit" id="apply-filters-button">
+            here
+          </button>
+        </form>
+        <span>.</span>
+      </div>
+    </div>
+  </div>
+{% endif %}
 <form id="saved-search-actions" class="usa-form" method="post" action="/form/saved-searches/actions/{{form.instance.pk}}/" novalidate>
   {% csrf_token %}
   <fieldset name="saved-search-actions" class="usa-fieldset usa-prose">

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1516,10 +1516,10 @@ class SavedSearchActionView(LoginRequiredMixin, View):
         section_filter = request.GET.get('section_filter', '')
         saved_search_view = request.GET.get('saved_search_view', 'all')
         name = request.GET.get('name', None)
-        if name:
-            saved_search_form = SavedSearchActions(request.GET, instance=saved_search)
-        else:
-            saved_search_form = SavedSearchActions(query=query, instance=saved_search)
+        saved_search_form = SavedSearchActions(
+            request.GET if name else query,
+            instance=saved_search
+        )
         output = {
             'form': saved_search_form,
             'section_filter': section_filter,

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1515,7 +1515,11 @@ class SavedSearchActionView(LoginRequiredMixin, View):
             query = get_filter_args(query_filters)
         section_filter = request.GET.get('section_filter', '')
         saved_search_view = request.GET.get('saved_search_view', 'all')
-        saved_search_form = SavedSearchActions(query=query, instance=saved_search)
+        name = request.GET.get('name', None)
+        if name:
+            saved_search_form = SavedSearchActions(request.GET, instance=saved_search)
+        else:
+            saved_search_form = SavedSearchActions(query=query, instance=saved_search)
         output = {
             'form': saved_search_form,
             'section_filter': section_filter,

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1516,10 +1516,10 @@ class SavedSearchActionView(LoginRequiredMixin, View):
         section_filter = request.GET.get('section_filter', '')
         saved_search_view = request.GET.get('saved_search_view', 'all')
         name = request.GET.get('name', None)
-        saved_search_form = SavedSearchActions(
-            request.GET if name else query,
-            instance=saved_search
-        )
+        if name:
+            saved_search_form = SavedSearchActions(request.GET, instance=saved_search)
+        else:
+            saved_search_form = SavedSearchActions(query=query, instance=saved_search)
         output = {
             'form': saved_search_form,
             'section_filter': section_filter,


### PR DESCRIPTION
If someone edits a shared saved search, prompt them to create a new one
[#1774](https://github.com/usdoj-crt/crt-portal-management/issues/1774)

## What does this change?
This PR mitigates the risk of users changing searches that other users are reliant on by adding a prompt for users to create a new saved search when they attempt to edit an existing shared saved search.

## Screenshots (for front-end PR):
![Image](https://github.com/usdoj-crt/crt-portal-management/assets/18104884/51b37bab-903d-469b-b4cb-4532a239130c)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
