### PR TITLE
Fix fuzzy search tooltip

### DIFF
--- a/crt_portal/cts_forms/templates/forms/widgets/fuzzy.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/fuzzy.html
@@ -12,7 +12,7 @@
         <div class="margin-top-2">
           <label class="display-inline" id="{{widget.name}}_label" for="id_{{widget.name}}">
             {{widget.attrs.label}}
-            {% include 'partials/help_tooltip.html' with tip="{{widget.attrs.tooltip}}" %}
+            {% include 'partials/help_tooltip.html' with tip=widget.attrs.tooltip %}
           </label>
         </div>
       {% endif %}

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -401,6 +401,10 @@ hr {
       button {
         width: 100%;
       }
+
+      .help-text.icon-only {
+        display: inline-block;
+      }
     }
 
     .crt-dropdown:last-of-type {


### PR DESCRIPTION

## What does this change?

This PR fixes a bug where the tooltip was not showing up for the organization name fuzzy search.

## Screenshots (for front-end PR):
![Image](https://github.com/usdoj-crt/crt-portal-management/assets/18104884/73d9d388-cfdf-4e04-88c1-6412f6d8fac3)

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
