### PR TITLE
Script to parse url logs

### DIFF
--- a/log_parser.sh
+++ b/log_parser.sh
@@ -1,16 +1,49 @@
 #!/bin/bash
 echo -n "{}" > filter_logs.json
-declare -a filters=("status" "retention_schedule" "litigation_hold" "contact_phone" "language" "referred" "hate_crime" "servicemember" "intake_format" "location_state" "primary_complaint" "contact_first_name" "contact_last_name" "contact_email" "violation_summary" "location_name" "location_name_1" "location_name_2" "location_city_town" "create_date_start" "create_date_end" "summary" "origination_utm_campaign" "assigned_to" "dj_number" "tags" "public_id" "primary_statute" "district" "reported_reason" "commercial_or_public_place")
-jq -r '.[].link' exportedLogRecords.json | while read link ; do
+declare -a filters=(\
+  "assigned_to"\
+  "commercial_or_public_place"\
+  "contact_email"\
+  "contact_first_name"\
+  "contact_last_name"\
+  "contact_phone"\
+  "create_date_end"\
+  "create_date_start"\
+  "district"\
+  "dj_number"\
+  "hate_crime"\
+  "intake_format"\
+  "language"\
+  "litigation_hold"\
+  "location_city_town"\
+  "location_name"\
+  "location_name_1"\
+  "location_name_2"\
+  "location_state"\
+  "origination_utm_campaign"\
+  "primary_complaint"\
+  "primary_statute"\
+  "public_id"\
+  "referred"\
+  "reported_reason"\
+  "retention_schedule"\
+  "servicemember"\
+  "status"\
+  "summary"\
+  "tags"\
+  "violation_summary"\
+)
+jq -r '.[] | .message' exportedLogRecords.json | while read link ; do
     linkparams=( $(echo ${link} | tr "?" "\n") )
-    for j in $(echo ${linkparams[2]} | tr "&" "\n"); do
-        for k in $(echo $j | tr "=" "\n"); do
-            inarray=$(echo ${filters[@]} | grep -w "${k}" | wc -w)
+    for param in $(echo ${linkparams[8]} | tr "&" "\n"); do
+        echo "$param"
+        for filter in $(echo $param | tr "=" "\n"); do
+            inarray=$(echo ${filters[@]} | grep -w "${filter}" | wc -w)
             if [ "${inarray}" -gt "0" ]; then
-                originalval=$(jq -r ."${k}" filter_logs.json)
-                newval=$((originalval + 1))
-                tmp=$(mktemp)
-                jq --arg v $newval '.'${k}' = $v' filter_logs.json > "$tmp" && mv "$tmp" filter_logs.json
+                originalval="$(jq -r ."${filter}" filter_logs.json)"
+                newval="$((originalval + 1))"
+                tmp="$(mktemp)"
+                jq --arg v $newval '.'${filter}' = $v' filter_logs.json > "$tmp" && mv "$tmp" filter_logs.json
             fi
         done
     done

--- a/log_parser.sh
+++ b/log_parser.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+echo -n "{}" > filter_logs.json
+declare -a filters=("status" "retention_schedule" "litigation_hold" "contact_phone" "language" "referred" "hate_crime" "servicemember" "intake_format" "location_state" "primary_complaint" "contact_first_name" "contact_last_name" "contact_email" "violation_summary" "location_name" "location_name_1" "location_name_2" "location_city_town" "create_date_start" "create_date_end" "summary" "origination_utm_campaign" "assigned_to" "dj_number" "tags" "public_id" "primary_statute" "district" "reported_reason" "commercial_or_public_place")
+jq -r '.[].link' exportedLogRecords.json | while read link ; do
+    linkparams=( $(echo ${link} | tr "?" "\n") )
+    for j in $(echo ${linkparams[2]} | tr "&" "\n"); do
+        for k in $(echo $j | tr "=" "\n"); do
+            inarray=$(echo ${filters[@]} | grep -w "${k}" | wc -w)
+            if [ "${inarray}" -gt "0" ]; then
+                originalval=$(jq -r ."${k}" filter_logs.json)
+                newval=$((originalval + 1))
+                tmp=$(mktemp)
+                jq --arg v $newval '.'${k}' = $v' filter_logs.json > "$tmp" && mv "$tmp" filter_logs.json
+            fi
+        done
+    done
+done


### PR DESCRIPTION
Spike: Filter analytics
[#1816](https://github.com/usdoj-crt/crt-portal-management/issues/1816)

## What does this change?
This PR adds a script to parse url logs to determine which filters are being used to inform a filter redesign. Findings are in the issue linked above.
## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
