### PR TITLE
fix icons on nav updates

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/side_nav_section_filter.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/index/filters/side_nav_section_filter.html
@@ -10,9 +10,9 @@
       type="button"
       data-crt-dropdown-control
     >
-    <svg class="expand-icon" fill="#ffbe2e" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="{% static 'img/sprite.svg' %}#expand_more"></use>
-    </svg>
+      <svg xmlns="http://www.w3.org/2000/svg" id="expand_more" viewBox="0 0 24 24" class="expand-icon" fill="#ffbe2e" aria-hidden="true" focusable="false" role="img">
+        <path d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"/>
+      </svg>
       <span id="assigned-section-label" class="label">{{ form.get_section_filters|multiselect_summary:"View sections" }}</span>
     </button>
     <div class="content" id="assigned-section" hidden>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/side_nav.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/side_nav.html
@@ -1,8 +1,8 @@
 <div class="side-nav">
 <div class="side-nav-content">
     <a href="#" class="menu-slider">
-        <svg class="icon menu-icon" fill="#FFF" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="{% static 'img/sprite.svg' %}#menu"></use>
+        <svg class="icon menu-icon" fill="#FFF" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" id="menu" viewBox="0 0 24 24">
+            <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/>
         </svg>
     </a>
     <h1 class="title-copy intake-section-title">
@@ -15,9 +15,9 @@
     <span>RECORD MANAGEMENT</span>
     <a class="add-record display-flex flex-align-center" href="/form/new/" label="create record" name="Create record">
         <span class="usa-tooltip" data-position="right" data-classes="display-inline" title="Add new record">
-        <svg class="icon plus-icon" fill="#FFBE2E" aria-hidden="true" focusable="false" role="img">
-            <use xlink:href="{% static 'img/sprite.svg' %}#add"></use>
-        </svg>
+            <svg fill="#ffbe2e" class="icon plus-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="add">
+                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+            </svg>
         </span>
         <span>New record</span>
     </a>


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?
Currently the icons are not showing up on the new side nav. This PR fixes them.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
