### PR TITLE
Allows a default order on datatables

### DIFF
--- a/crt_portal/static/js/data-tables.js
+++ b/crt_portal/static/js/data-tables.js
@@ -61,10 +61,27 @@
     });
   }
 
+  function getDefaultOrder(table) {
+    const datasetOrder = getData(table, 'default_order');
+    if (datasetOrder) return datasetOrder;
+
+    const firstSumColumn = [...table.querySelectorAll('thead th')]
+      .map(th => th.innerText)
+      // We rely on index here, because name changes case.
+      .findIndex(text => text.toLowerCase().includes('(sum)'));
+
+    if (firstSumColumn) {
+      return [[firstSumColumn, 'desc']];
+    }
+
+    return [];
+  }
+
   function getOptions(table) {
     const options = {
       colReorder: true,
       select: true,
+      order: getDefaultOrder(table),
       language: {
         searchPanes: {
           clearMessage: 'Clear all filters'

--- a/jupyterhub/helpers/transformers.py
+++ b/jupyterhub/helpers/transformers.py
@@ -98,25 +98,28 @@ def column_to_html(table_name, key) -> str:
     return f'<th{filter_arg}>{display}</th>'
 
 
+def _encode_data(data):
+    return base64.b64encode(
+        json.dumps(data, separators=[',', ':']).encode('utf-8')
+    ).decode('utf-8')
+
+
 def result_to_html_table(result: ResultSet, table_name, **kwargs) -> str:
     columns = ''.join([
         column_to_html(table_name, key)
         for key in result.keys
     ])
 
-    rows = json.dumps([
-        *result.DataFrame().astype(str).to_numpy().tolist(),
-    ], separators=(',', ':'))
-    rows_encoded = base64.b64encode(rows.encode('utf-8')).decode('utf-8')
+    rows = _encode_data([*result.DataFrame().astype(str).to_numpy().tolist()])
 
     extra_data = '\n'.join([
-        f'data-{key}={value}'
+        f'data-{key}={_encode_data(value)}'
         for key, value in kwargs.items()
     ])
 
     return f'''
         <table
-            data-rows="{rows_encoded}"
+            data-rows="{rows}"
             {extra_data}
             class="crt-table datatable-table">
             <thead>{columns}</thead>


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1818

## What does this change?

- 🌎 Our tables come through as unordered, regardless of query ordering
- ⛔ This isn't great because we often want to see more reports first
- ✅ This commit applies default orders and enables manual ordering

## Screenshots (for front-end PR):

1. We can manually specify an order via Jupyter: ![Image](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/6fe2689c-e01b-4489-9b97-d1e2b0d4e1c1)
2. If we don't do that, we'll look for a (sum) column: ![Image](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/da8aa42f-75e4-46a2-a061-abb097537f06)
3. If neither is found, we won't apply an order

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
