### PR TITLE
Add batch status filter

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/chipbar.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/chipbar.html
@@ -1,4 +1,15 @@
 <div class="chipbar">
+  {% if disposition_status == 'batches' %}
+  <fieldset>
+    <h3>Status</h3>
+    {% for status in statuses %}
+      <label class="status">
+        {{ status }}
+        <input type="radio" name="status" value="{{status}}">
+      </label>
+    {% endfor %}
+  </fieldset>
+  {% else %}
   <fieldset>
     <h3>Schedule</h3>
     {% for schedule in schedules %}
@@ -33,4 +44,5 @@
       {% endfor %}
     {% endif %}
   </fieldset>
+  {% endif %}
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/index.html
@@ -31,15 +31,12 @@
         {% include 'forms/complaint_view/index/filters/per_page.html' with per_page=page_format.per_page %}
       </span>
     </div>
-    {% if disposition_status == 'batches' %}
-    {% else %}
     <div class="intake-table-chipbar">
       {% include "forms/complaint_view/disposition/chipbar.html" with disposition_status=disposition_status %}
       <div class="controls">
       {% include "forms/complaint_view/disposition/filter-controls.html" with filters=filters form=form %}
       </div>
     </div>
-    {% endif %}
   </form>
 </div>
   <div class="scrollable-table">

--- a/crt_portal/static/js/disposition_filters.js
+++ b/crt_portal/static/js/disposition_filters.js
@@ -5,7 +5,8 @@
     per_page: '',
     disposition_status: '',
     retention_schedule: '',
-    expiration_date: ''
+    expiration_date: '',
+    status: ''
   };
 
   function filterController() {
@@ -17,6 +18,7 @@
     const radioExpirationDateEls = dom.querySelectorAll('input[name="expiration_date"]');
     const retentionScheduleEls = dom.getElementsByName('retention_schedule');
     const dispositionStatusEls = dom.getElementsByName('disposition_status');
+    const batchStatusEls = dom.getElementsByName('status');
 
     root.CRT.formView({
       el: root.CRT.formEl
@@ -62,12 +64,19 @@
     });
     root.CRT.selectRadio(retentionScheduleEls, 'retention_schedule');
 
+    root.CRT.radioButtonView({
+      el: batchStatusEls,
+      name: 'status'
+    });
+    root.CRT.selectRadio(batchStatusEls, 'status');
+
     root.CRT.clearFiltersView({
       el: clearAllEl,
       onClick: () => {
         const updates = {
           retention_schedule: '',
-          expiration_date: ''
+          expiration_date: '',
+          status: ''
         };
         root.CRT.mutateFilterDataWithUpdates(root.CRT.filterDataModel, updates);
         root.CRT.formView.doSearch(root.CRT.formEl);

--- a/crt_portal/static/sass/custom/intake.scss
+++ b/crt_portal/static/sass/custom/intake.scss
@@ -1008,6 +1008,10 @@ label.flex-column span.usa-tooltip {
         background-color: #e1e7f1;
         border-radius: 5px;
 
+        &.status {
+          text-transform: uppercase;
+        }
+
         &:has(input:checked) {
           background-color: #162e51;
           color: white;


### PR DESCRIPTION
Disposition rejection process implementation
[#1808](https://github.com/usdoj-crt/crt-portal-management/issues/1808)

## What does this change?
This PR adds a status filter to the disposition batches page.

## Screenshots (for front-end PR):
![Image](https://github.com/usdoj-crt/crt-portal-management/assets/18104884/160fd041-f449-4397-9ba4-2dbcc35e061d)
## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
