### PR TITLE
Fix fuzzy search to preserve form field values on reload

### DIFF
--- a/crt_portal/cts_forms/widgets.py
+++ b/crt_portal/cts_forms/widgets.py
@@ -1,5 +1,6 @@
 """Form widgets"""
 import datetime
+import logging
 from django.forms import MultiValueField, CharField, IntegerField
 from django.forms.widgets import ChoiceWidget, TextInput, NumberInput, Select, SelectMultiple, DateInput, MultiWidget
 
@@ -74,6 +75,8 @@ class FuzzyWidget(MultiWidget):
         if len(raw) != 3:
             return ['', 0, 0]
         value, sound, look = raw
+        sound = 0 if sound == '' else sound
+        look = 0 if look == '' else look
         try:
             return [value, int(sound), int(look)]
         except ValueError:

--- a/crt_portal/cts_forms/widgets.py
+++ b/crt_portal/cts_forms/widgets.py
@@ -1,6 +1,5 @@
 """Form widgets"""
 import datetime
-import logging
 from django.forms import MultiValueField, CharField, IntegerField
 from django.forms.widgets import ChoiceWidget, TextInput, NumberInput, Select, SelectMultiple, DateInput, MultiWidget
 
@@ -75,8 +74,8 @@ class FuzzyWidget(MultiWidget):
         if len(raw) != 3:
             return ['', 0, 0]
         value, sound, look = raw
-        sound = 0 if sound == '' else sound
-        look = 0 if look == '' else look
+        sound = sound or 0
+        look = look or 0
         try:
             return [value, int(sound), int(look)]
         except ValueError:


### PR DESCRIPTION
Fuzzy search exact match bug
[#1835](https://github.com/usdoj-crt/crt-portal-management/issues/1835)

## What does this change?
This PR fixes a bug where the Organization name fuzzy search fields show as blank on page reload even when the filters are applied.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
