### PR TITLE
Fix dashboard maps sizes with sidenav

### DIFF
--- a/crt_portal/static/js/side_nav_slider.js
+++ b/crt_portal/static/js/side_nav_slider.js
@@ -9,6 +9,11 @@
     mainWrapper.classList.add('display-flex');
     const menuSlider = mainWrapper.querySelector('.menu-slider');
     menuSlider.addEventListener('click', toggleMenu);
+
+    // Some items on the page calculate their size based on the side-nav
+    // This resize event gives them a chance to recalculate their size following
+    // the display-flex:
+    window.dispatchEvent(new Event('resize'));
   }
 
   window.addEventListener('DOMContentLoaded', setUpSideNav);


### PR DESCRIPTION

https://github.com/usdoj-crt/crt-portal-management/issues/1871

## What does this change?

- 🌎 The sidenav changes itself to display-flex after load
- ⛔ This throws off elements that load and calculate their widths prior to the sidenav loading
- ✅ This commit triggers a resize event, allowing dynamic elements to resize themselves properly

## Screenshots (for front-end PR):

<img width="1236" alt="image" src="https://github.com/usdoj-crt/crt-portal-management/assets/15126660/559e51fa-6fb0-4abd-89da-68c1fd0a168a">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
