### PR TITLE
Don't reassign auto-closed items to ADM

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -286,7 +286,6 @@ def maybe_auto_close(report):
         system_user = get_system_user()
         report.status = CLOSED_STATUS
         report.closeout_report()
-        report.assigned_section = 'ADM'
         summary = report.internal_comments.get_or_create(is_summary=True)[0]
         summary.author = system_user.username
         summary.note = reason_for_closing


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1859

## What does this change?

- 🌎 Auto-close currently reassigns to ADM
- ⛔ We want to keep the original assignment in case it's reopened
- ✅ This commit removes the reassignment to ADM

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
