### PR TITLE
Truncate matching description groups.

### DIFF
--- a/crt_portal/cts_forms/tests/test_filters.py
+++ b/crt_portal/cts_forms/tests/test_filters.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import User
 from actstream import registry
 from actstream.models import actor_stream
 from django.http import QueryDict
-from django.test import SimpleTestCase, TestCase, TransactionTestCase
+from django.test import SimpleTestCase, TestCase, TransactionTestCase, RequestFactory
 import pytz
 
 from ..filters import get_report_filter_from_search, report_filter, report_grouping, filter_by_similar
@@ -244,7 +244,8 @@ class ReportFilterTests(TestCase):
         self.assertEqual(reports.count(), 2)
 
     def test_grouping(self):
-        group_queries, _ = report_grouping(QueryDict('grouping="matching-descriptions"'))
+        request = RequestFactory().get('/form/view?grouping=matching-descriptions')
+        group_queries, _ = report_grouping(request)
         self.assertEqual(len(group_queries), 2)
         self.assertEqual(group_queries[0]['qs'].count(), 2)
 

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -279,7 +279,7 @@ def index_view(request):
 
 
 def render_group_view(request, profile_form, selected_assignee_id, selected_campaign_uuid, grouping):
-    group_queries, filters = report_grouping(request.GET)
+    group_queries, filters = report_grouping(request)
     group_params = json.loads(request.GET.get('group_params', "[]").replace("'", '"'))
     group_view_data = []
     updated_group_queries = []


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1873

## What does this change?

- 🌎 It's possible to try to group by all matching descriptions without filters
- ⛔ This times out, because there are a lot of matching descriptions
- ✅ This commit patches that by truncating to 10 groups, and showing a warning

## Screenshots (for front-end PR):

![Image](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/db14084e-5014-44d6-908c-9a4ad668dae2)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
