### PR TITLE
Prevent re-batching fully rejected batches

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/batches_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/batches_table.html
@@ -29,6 +29,8 @@
             <tr class="tr--hover{% cycle ' stripe' '' %}">
               {% if can_approve_disposition %}
               {% if datum.batch.status == 'rejected' %}
+              {{datum.batch.all_rejected}}
+              {% if not datum.batch.all_rejected %}
               <td>
                 <div class="usa-checkbox td-checkbox">
                   <input type="checkbox"
@@ -41,7 +43,21 @@
                 </div>
               </td>
               {% else %}
-                <td></td>
+              <td>
+                <div class="usa-checkbox td-checkbox">
+                  <span class="usa-tooltip" title="This entire batch has been rejected and cannot be re-used">
+                    <input type="checkbox"
+                           class="usa-checkbox__input"
+                           disabled="disabled"
+                           id="checkbox-{{ datum.batch.uuid }}"
+                    >
+                    <label class="usa-checkbox__label crt-checkbox__label" for="checkbox-{{ datum.batch.uuid }}" aria-label="This entire batch has been rejected and cannot be re-used {{ datum.batch.uuid }}"></label>
+                  </span>
+                </div>
+              </td>
+              {% endif %}
+              {% else %}
+              <td></td>
               {% endif %}
               {% endif %}
               <td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/batches_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/batches_table.html
@@ -44,13 +44,13 @@
               {% else %}
               <td>
                 <div class="usa-checkbox td-checkbox">
-                  <span class="usa-tooltip" title="This entire batch has been rejected and cannot be re-used">
+                  <span class="usa-tooltip" title="All reports in this batch have been rejected so a new batch cannot be generated">
                     <input type="checkbox"
                            class="usa-checkbox__input"
                            disabled="disabled"
                            id="checkbox-{{ datum.batch.uuid }}"
                     >
-                    <label class="usa-checkbox__label crt-checkbox__label" for="checkbox-{{ datum.batch.uuid }}" aria-label="This entire batch has been rejected and cannot be re-used {{ datum.batch.uuid }}"></label>
+                    <label class="usa-checkbox__label crt-checkbox__label" for="checkbox-{{ datum.batch.uuid }}" aria-label="All reports in this batch have been rejected so a new batch cannot be generated (batch {{ datum.batch.uuid }})"></label>
                   </span>
                 </div>
               </td>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/batches_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/batches_table.html
@@ -29,7 +29,6 @@
             <tr class="tr--hover{% cycle ' stripe' '' %}">
               {% if can_approve_disposition %}
               {% if datum.batch.status == 'rejected' %}
-              {{datum.batch.all_rejected}}
               {% if not datum.batch.all_rejected %}
               <td>
                 <div class="usa-checkbox td-checkbox">

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -702,7 +702,7 @@ def get_batch_data(disposition_batches, all_args_encoded):
 
 def get_batch_view_data(request):
     disposition_batches = ReportDispositionBatch.objects.all()
-    status_filter = request.GET.get('status', None)
+    status_filter = request.GET.get('status', request.COOKIES.get('disposition_view_batch_status', ''))
     if status_filter:
         disposition_batches = disposition_batches.filter(status=status_filter)
     per_page = request.GET.get('per_page', request.COOKIES.get('complaint_view_per_page', 15))
@@ -734,6 +734,7 @@ def get_batch_view_data(request):
         'return_url_args': all_args_encoded,
         'data': data,
         'statuses': statuses,
+        'status': status_filter,
     }
 
 
@@ -746,7 +747,9 @@ def disposition_view(request):
     profile_form = get_profile_form(request)
     if disposition_status == 'batches':
         final_data = get_batch_view_data(request)
-        return render(request, 'forms/complaint_view/disposition/index.html', final_data)
+        response = render(request, 'forms/complaint_view/disposition/index.html', final_data)
+        response.set_cookie('disposition_view_batch_status', final_data.get('status'))
+        return response
     if params.get('status'):
         params.pop('status')
     report_query, query_filters = report_filter(params)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -30,7 +30,6 @@ from tms.models import TMSEmail
 from datetime import datetime
 from django.db.models.functions import ExtractYear, Cast, Concat
 
-
 from .attachments import ALLOWED_FILE_EXTENSIONS
 from .filters import report_filter, dashboard_filter, report_grouping
 from .forms import (
@@ -710,6 +709,7 @@ def get_batch_view_data(request):
     page = request.GET.get('page', 1)
     sort_expr, sorts = other_sort(request.GET.getlist('sort'), 'batch')
     disposition_batches = disposition_batches.annotate(retention_schedule=Subquery(ReportDisposition.objects.filter(batch=OuterRef("pk")).values_list('schedule', flat=True).distinct()))
+    disposition_batches = disposition_batches.annotate(all_rejected=Subquery(ReportDisposition.objects.filter(batch=OuterRef("pk")).order_by('rejected').values_list('rejected', flat=True)[:1]))
     disposition_batches = disposition_batches.order_by(*sort_expr)
     statuses = map(lambda choice: choice[1].lower(), BATCH_STATUS_CHOICES)
     paginator = Paginator(disposition_batches, per_page)

--- a/crt_portal/static/js/disposition_filters.js
+++ b/crt_portal/static/js/disposition_filters.js
@@ -6,7 +6,7 @@
     disposition_status: '',
     retention_schedule: '',
     expiration_date: '',
-    status: ''
+    status: Cookies.get('disposition_view_batch_status') || ''
   };
 
   function filterController() {
@@ -73,6 +73,7 @@
     root.CRT.clearFiltersView({
       el: clearAllEl,
       onClick: () => {
+        Cookies.remove('disposition_view_batch_status');
         const updates = {
           retention_schedule: '',
           expiration_date: '',
@@ -85,9 +86,16 @@
   }
 
   function init() {
-    if (root.location.search === '') {
-      root.location.search = '?disposition_status=past';
+    const search = new URLSearchParams(root.location.search);
+    if (search.size === 0) {
+      search.set('disposition_status', 'past');
     }
+    if (!search.has('status') && root.CRT.initialFilterState['status']) {
+      search.set('status', root.CRT.initialFilterState['status']);
+    }
+
+    root.history.replaceState({}, null, `?${search.toString()}`);
+
     const updates = root.CRT.getQueryParams(
       root.location.search,
       Object.keys(root.CRT.initialFilterState)


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1879

## What does this change?

- 🌎 When a batch is partially rejected, it shows up in a list for re-creation with the non-rejected reports
- ⛔ Batches that are fully rejected also show up in that list
- ✅ This commit disables the button (with a tooltip explaining why) that allows for the recreation

## Screenshots (for front-end PR):

![Image](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/47c980e3-38ed-49d8-ac60-b2120161b346)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
