### PR TITLE
Save the status filter for disposition

### DIFF
--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -702,7 +702,7 @@ def get_batch_data(disposition_batches, all_args_encoded):
 
 def get_batch_view_data(request):
     disposition_batches = ReportDispositionBatch.objects.all()
-    status_filter = request.GET.get('status', None)
+    status_filter = request.GET.get('status', request.COOKIES.get('disposition_view_batch_status', ''))
     if status_filter:
         disposition_batches = disposition_batches.filter(status=status_filter)
     per_page = request.GET.get('per_page', request.COOKIES.get('complaint_view_per_page', 15))
@@ -734,6 +734,7 @@ def get_batch_view_data(request):
         'return_url_args': all_args_encoded,
         'data': data,
         'statuses': statuses,
+        'status': status_filter,
     }
 
 
@@ -746,7 +747,9 @@ def disposition_view(request):
     profile_form = get_profile_form(request)
     if disposition_status == 'batches':
         final_data = get_batch_view_data(request)
-        return render(request, 'forms/complaint_view/disposition/index.html', final_data)
+        response = render(request, 'forms/complaint_view/disposition/index.html', final_data)
+        response.set_cookie('disposition_view_batch_status', final_data.get('status'))
+        return response
     if params.get('status'):
         params.pop('status')
     report_query, query_filters = report_filter(params)

--- a/crt_portal/static/js/disposition_filters.js
+++ b/crt_portal/static/js/disposition_filters.js
@@ -6,7 +6,7 @@
     disposition_status: '',
     retention_schedule: '',
     expiration_date: '',
-    status: ''
+    status: Cookies.get('disposition_view_batch_status') || ''
   };
 
   function filterController() {
@@ -73,6 +73,7 @@
     root.CRT.clearFiltersView({
       el: clearAllEl,
       onClick: () => {
+        Cookies.remove('disposition_view_batch_status');
         const updates = {
           retention_schedule: '',
           expiration_date: '',
@@ -85,9 +86,16 @@
   }
 
   function init() {
-    if (root.location.search === '') {
-      root.location.search = '?disposition_status=past';
+    const search = new URLSearchParams(root.location.search);
+    if (search.size === 0) {
+      search.set('disposition_status', 'past');
     }
+    if (!search.has('status') && root.CRT.initialFilterState['status']) {
+      search.set('status', root.CRT.initialFilterState['status']);
+    }
+
+    root.history.replaceState({}, null, `?${search.toString()}`);
+
     const updates = root.CRT.getQueryParams(
       root.location.search,
       Object.keys(root.CRT.initialFilterState)


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1879

## What does this change?

- 🌎 Currently when working through disposition tasks, the status filteri s not preserved
- ⛔ This means that users need to re-set the filter each time
- ✅ This commit stores the filter in a cookie, so that it's saved between pages

## Screenshots (for front-end PR):

![Image](https://github.com/usdoj-crt/crt-portal-management/assets/15126660/829c82d3-d34c-4854-930f-d4a093add9d4)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
