### PR TITLE
Fake delete disposed reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,7 +508,7 @@ jobs:
       - *wait-for-tasks
       - run:
           name: dispose of reports
-          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py dispose_reports" --name send-scheduled-notifications -m 512M -k 7G
+          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py dispose_reports" --name dispose-reports -m 512M -k 7G
 
   dev-maintenance-tasks:
     docker:
@@ -556,7 +556,7 @@ jobs:
       - *wait-for-tasks
       - run:
           name: dispose of reports
-          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py dispose_reports" --name send-scheduled-notifications -m 512M -k 7G
+          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py dispose_reports" --name dispose-reports -m 512M -k 7G
 
   dev-jupyter-tasks:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ wait-for-tasks: &wait-for-tasks
   run:
     name: Wait for maintenance tasks to complete
     command: |
-      sleep 300  # (Five minutes)
+      sleep 120  # (Two minutes)
 
 jobs:
   build_and_test: # runs not using Workflows must have a `build` job as entry point
@@ -505,6 +505,10 @@ jobs:
       - run:
           name: send scheduled notifications
           command: cf run-task crt-portal-django  -c "python crt_portal/manage.py send_scheduled_notifications" --name send-scheduled-notifications -m 512M -k 7G
+      - *wait-for-tasks
+      - run:
+          name: dispose of reports
+          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py dispose_reports" --name send-scheduled-notifications -m 512M -k 7G
 
   dev-maintenance-tasks:
     docker:
@@ -549,6 +553,10 @@ jobs:
       - run:
           name: send scheduled notifications
           command: cf run-task crt-portal-django  -c "python crt_portal/manage.py send_scheduled_notifications" --name send-scheduled-notifications -m 512M -k 7G
+      - *wait-for-tasks
+      - run:
+          name: dispose of reports
+          command: cf run-task crt-portal-django  -c "python crt_portal/manage.py dispose_reports" --name send-scheduled-notifications -m 512M -k 7G
 
   dev-jupyter-tasks:
     docker:

--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -37,6 +37,7 @@ ENABLE_DEBUG_TOOLBAR = os.environ.get('ENABLE_DEBUG_TOOLBAR', False)
 MAINTENANCE_MODE = os.environ.get('MAINTENANCE_MODE', False)
 VOTING_MODE = os.environ.get('VOTING_MODE', False)
 
+REDACT_REPORTS = environment != 'PRODUCTION'
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/

--- a/crt_portal/cts_forms/management/commands/dispose_reports.py
+++ b/crt_portal/cts_forms/management/commands/dispose_reports.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from django.core.management.base import BaseCommand
+from cts_forms.model_variables import BATCH_APPROVED_STATUS, BATCH_ARCHIVED_STATUS
+from cts_forms.models import ReportDispositionBatch
+
+
+class Command(BaseCommand):
+    help = 'Dispose of reports that have been approved for disposal.'
+
+    def handle(self, *args, **options):
+
+        disposable_batches = ReportDispositionBatch.objects.filter(
+            status=BATCH_APPROVED_STATUS,
+            proposed_disposal_date__lte=datetime.now()
+        )
+
+        for batch in disposable_batches:
+            batch.redact_reports()
+        batch.status = BATCH_ARCHIVED_STATUS
+        batch.save()

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -937,7 +937,6 @@ class ReportDispositionBatch(models.Model):
         with transaction.atomic():
             batch = cls.objects.create(disposed_by=user,
                                        disposed_count=queryset.count())
-            queryset.all().update(disposed=True)
             ReportDisposition.objects.bulk_create([
                 ReportDisposition(
                     schedule=report.retention_schedule,

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -917,7 +917,10 @@ class ReportDispositionBatch(models.Model):
 
     def redact_reports(self):
         """Deletes (blanks out) all reports in the batch."""
-        for report in self.disposed_reports.all():
+        public_ids = self.disposed_reports.values_list('public_id', flat=True)
+        reports = Report.objects.filter(public_id__in=public_ids).all()
+
+        for report in reports:
             report.redact()
 
     @classmethod

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -12,9 +12,10 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVectorField
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, FieldDoesNotExist
 from django.core.validators import MaxValueValidator, RegexValidator
 from django.db import connection, models, transaction
+from django.db.models import fields
 from django.template import Context, Template
 from django.urls import reverse
 from django.utils import translation
@@ -403,8 +404,22 @@ class Tag(models.Model):
         return self.name
 
 
+class ReportManager(models.Manager):
+    def get_queryset(self):
+        return super(ReportManager, self).get_queryset().filter(disposed=False)
+
+
+class DisposedReportManager(models.Manager):
+    def get_queryset(self):
+        return super(DisposedReportManager, self).get_queryset().filter(disposed=True)
+
+
 # NOTE: If you add fields to report, they'll automatically be set to empty on the edit form. Make sure to address any additions in ReportEditForm as well!
 class Report(models.Model):
+
+    objects = ReportManager()
+    disposed_objects = DisposedReportManager()
+
     PRIMARY_COMPLAINT_DEPENDENT_FIELDS = {
         'workplace': ['public_or_private_employer', 'employer_size'],
         'education': ['public_or_private_school'],
@@ -544,6 +559,80 @@ class Report(models.Model):
 
     class Meta:
         indexes = [GinIndex(fields=['violation_summary_search_vector'])]
+
+    def redact(self):
+        """Removes all information from the report besides its ID"""
+
+        if self.litigation_hold:
+            logger.error(f'Attempted to redact report {self.public_id} while on litigation hold.')
+            return
+
+        self.disposed = True
+
+        if not settings.REDACT_REPORTS:
+            self.save()
+            return
+
+        ignore = [
+            'id',
+            'public_id',
+            'modified_date',
+            'retention_schedule',
+            'batched_for_disposal',
+            'disposed',
+            'email_report_count',
+        ]
+
+        to_redact = [
+            field
+            for field in self._meta.get_fields()
+            if field.name not in ignore
+        ]
+
+        for field in to_redact:
+            # Clear out this field, no matter what type it is:
+
+            if field.is_relation:
+                if field.one_to_one:
+                    getattr(self, field.name).delete()
+                    continue
+
+                if field.one_to_many or field.name == 'internal_comments':
+                    try:
+                        setattr(self, field.name, None)
+                    except TypeError:
+                        getattr(self, field.name).all().delete()
+                    continue
+
+                if field.many_to_many:
+                    try:
+                        getattr(self, field.name).clear()
+                    except FieldDoesNotExist:
+                        pass
+                    continue
+
+            if field.null:
+                setattr(self, field.name, None)
+                continue
+
+            if field.blank:
+                blank = {
+                    fields.CharField: '',
+                    fields.TextField: '',
+                    fields.IntegerField: 0,
+                    fields.BooleanField: False,
+                    fields.DateTimeField: datetime.fromtimestamp(0),
+                }.get(type(field))
+                setattr(self, field.name, blank)
+                continue
+
+            if hasattr(field, 'default') and field.default != fields.NOT_PROVIDED:
+                setattr(self, field.name, field.default)
+                continue
+
+        print(f'Redacted report {self.public_id}')
+        self.save()
+        return
 
     @cached_property
     def last_incident_date(self):
@@ -825,6 +914,11 @@ class ReportDispositionBatch(models.Model):
             for report
             in queryset.all().select_related('retention_schedule').only('retention_schedule', 'public_id')
         ])
+
+    def redact_reports(self):
+        """Deletes (blanks out) all reports in the batch."""
+        for report in self.disposed_reports.all():
+            report.redact()
 
     @classmethod
     def dispose(cls, queryset):

--- a/crt_portal/cts_forms/tests/test_models.py
+++ b/crt_portal/cts_forms/tests/test_models.py
@@ -207,7 +207,6 @@ class ReportTests(TestCase):
             original.public_id
             for original in reports.all()
         })
-        self.assertTrue(all(original.disposed for original in reports))
 
     class DistrictEdgeCase(SimpleNamespace):
         city_user_enters: str

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1398,6 +1398,8 @@ class DispositionBatchActionsView(LoginRequiredMixin, FormView):
                 report_dispo_object.save()
             batch = form.save(commit=False)
             batch.save()
+            if batch.status == 'approved':
+                batch.redact_reports()
             if batch.status in ['approved', 'verified']:
                 message = f'Batch #{batch.uuid} has been {batch.status} for disposal.'
                 messages.add_message(request, messages.SUCCESS, message)

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1398,8 +1398,6 @@ class DispositionBatchActionsView(LoginRequiredMixin, FormView):
                 report_dispo_object.save()
             batch = form.save(commit=False)
             batch.save()
-            if batch.status == 'approved':
-                batch.redact_reports()
             if batch.status in ['approved', 'verified']:
                 message = f'Batch #{batch.uuid} has been {batch.status} for disposal.'
                 messages.add_message(request, messages.SUCCESS, message)


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1880

## What does this change?

- 🌎 When disposition is reached reports should be deleted
- ⛔ They are currently not
- ✅ This commit adds logic for deleting (redacting) reports on dev and staging, and hiding them on prod

## Screenshots (for front-end PR):

N/A - backend PR, the reports disappear

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
