### PR TITLE
Fix scheduled notifications not sending

### DIFF
--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -151,6 +151,7 @@ def _render_scheduled_notification_mail(scheduled: ScheduledNotification) -> Mai
     digests = [
         _render_digests(kind, scheduled)
         for kind in ['assigned_to', *saved_search_groups]
+        if kind in scheduled.notifications
     ]
 
     html_message = render_to_string('scheduled_notification.html', {


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1883

## What does this change?

- 🌎 We send scheduled notification digests
- ⛔ The code currently expects digests to have all kinds (assigned_to, etc) of notifications, but they don't
- ✅ This commit fixes the code to skip over digest kinds that don't exist
- 🔮 Future commits may need to fix more errors, as this must be tested in staging

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
