### PR TITLE
Show when a report has been disposed

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -416,16 +416,16 @@ class ReportManager(models.Manager):
         return super(ReportManager, self).get_queryset().filter(disposed=False)
 
 
-class DisposedReportManager(models.Manager):
+class AllReportManager(models.Manager):
     def get_queryset(self):
-        return super(DisposedReportManager, self).get_queryset().filter(disposed=True)
+        return super(AllReportManager, self).get_queryset().filter(disposed=True)
 
 
 # NOTE: If you add fields to report, they'll automatically be set to empty on the edit form. Make sure to address any additions in ReportEditForm as well!
 class Report(models.Model):
 
     objects = ReportManager()
-    disposed_objects = DisposedReportManager()
+    all_objects = AllReportManager()
 
     PRIMARY_COMPLAINT_DEPENDENT_FIELDS = {
         'workplace': ['public_or_private_employer', 'employer_size'],

--- a/crt_portal/cts_forms/tests/test_models.py
+++ b/crt_portal/cts_forms/tests/test_models.py
@@ -240,7 +240,7 @@ class ReportTests(TestCase):
         report.save()
         report.redact()
         self.assertFalse(Report.objects.filter(pk=report.pk).exists())
-        self.assertTrue(Report.disposed_objects.filter(pk=report.pk).exists())
+        self.assertTrue(Report.all_objects.filter(pk=report.pk).exists())
 
     def test_report_disposes(self):
         Tag.objects.create(name='test tag')


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1914

## What does this change?

- 🌎 We dispose of reports now!
- ⛔ We don't let users know when a report 404's because of disposition
- ✅ This commit lets them know on the list page and on the /form/view page

## Screenshots (for front-end PR):

![Image](https://github.com/user-attachments/assets/ff04f2c3-8d0c-4845-b85c-287efd146dfc)

![Image](https://github.com/user-attachments/assets/81d555b2-659a-4db8-8431-8a0604455f2d)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
