### PR TITLE
Tie notification link to saved search results

### DIFF
--- a/crt_portal/cts_forms/tests/integration_authed/notifications.py
+++ b/crt_portal/cts_forms/tests/integration_authed/notifications.py
@@ -71,25 +71,33 @@ def _get_email_content(page):
 @console.raise_errors(ignore='404')
 def test_notifications_send(page):
     login_as_superuser(page)
+    report_id = admin_models.create_report(
+        page,
+        crt_reciept_month='12',
+        crt_reciept_day='25',
+        crt_reciept_year='2000',
+        intake_format_2='phone',
+        primary_complaint='something_else',
+    )
     username, _ = get_test_credentials()
 
     _set_user(page, username, '', 'individual')
-    page.goto('/form/view/1')
+    page.goto(f'/form/view/{report_id}')
     _set_assignee(page, '')
     _set_assignee(page, username)
     assert page.locator('.usa-alert--success').filter(has_text=f'{username} will not be notified because they do not have an email address listed').is_visible()
 
     _set_user(page, username, 'notifications_test@example.com', 'individual')
-    page.goto('/form/view/1')
+    page.goto(f'/form/view/{report_id}')
     _set_assignee(page, '')
     _set_assignee(page, username)
     assert page.locator('.usa-alert--success').filter(has_text=f'{username} will be notified').is_visible()
     sent = _get_email_content(page)
-    assert 'You have been assigned [Report 1](/form/view/1)' in sent['body']
-    assert sent['subject'] == '[CRT Portal] Assigned: Report 1'
+    assert f'You have been assigned [Report {report_id}](/form/view/{report_id})' in sent['body']
+    assert sent['subject'] == f'[CRT Portal] Assigned: Report {report_id}'
 
     _set_user(page, username, 'notifications_test@example.com', 'weekly')
-    page.goto('/form/view/1')
+    page.goto(f'/form/view/{report_id}')
     _set_assignee(page, '')
     _set_assignee(page, username)
     assert page.locator('.usa-alert--success').filter(has_text=f'{username} will be notified').is_visible()


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1915

## What does this change?

- 🌎 Saved search results currently go to the search edit page
- ⛔ It'd make more sense for them to just show the results
- ✅ This commit changes to show the new results

## Screenshots (for front-end PR):

![Image](https://github.com/user-attachments/assets/fc72924a-b819-4d2d-b340-ee2f0c659fdd)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
