### PR TITLE
Include the inmate number in letterhead.

### DIFF
--- a/crt_portal/cts_forms/templates/referral_info.html
+++ b/crt_portal/cts_forms/templates/referral_info.html
@@ -102,6 +102,10 @@
     <br />
     <h2>Complainant Contact Address</h2>
     <p>
+      {% if report.contact_inmate_number %}
+      <span>Inmate Number: #{{ report.contact_inmate_number|default:"—" }}</span>
+      <br />
+      {% endif %}
       <span>{{ report.contact_address_line_1|default:"—" }}</span>
       <br />
       <span>{{ report.contact_address_line_2|default:"—" }}</span>

--- a/crt_portal/templates/letterhead.html
+++ b/crt_portal/templates/letterhead.html
@@ -1,6 +1,6 @@
 {% if report.contact_first_name or report.contact_last_name or report.contact_address_line_1 or report.contact_city or report.contact_state or report.contact_zip or report.contact_email %}
 <p id="form-letterhead--addressee">
-  {% if report.contact_first_name %}{{ report.contact_first_name }}{% endif %} {% if report.contact_last_name %}{{ report.contact_last_name }}{% endif %}
+  {% if report.contact_first_name %}{{ report.contact_first_name }}{% endif %} {% if report.contact_last_name %}{{ report.contact_last_name }}{% endif %} {% if report.contact_inmate_number %}#{{ report.contact_inmate_number }}{% endif %}
   {% if report.contact_address_line_1 %}
     <br />
     {{ report.contact_address_line_1 }}


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1911

## What does this change?

- 🌎 Printed mail to inmates needs the number to reach them
- ⛔ Right now it's not included
- ✅ This commit includes it if present

## Screenshots (for front-end PR):

[Report 335245-GSD (complainant).pdf](https://github.com/user-attachments/files/16353679/Report.335245-GSD.complainant.pdf)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
