### PR TITLE
Automatically add personal description when attachment is added to proform

### DIFF
--- a/crt_portal/static/js/pro_form_attachments.js
+++ b/crt_portal/static/js/pro_form_attachments.js
@@ -17,6 +17,7 @@
       removeFile(event);
     };
   });
+  const violationSummary = document.querySelector('#id_0-violation_summary');
   addAttachmentEl.onclick = function(event) {
     event.preventDefault();
     fileEl.click();
@@ -105,6 +106,7 @@
       event.preventDefault();
       removeFile(event);
     };
+    violationSummary.value = 'See attachment.'
     if (attachmentInput.value == 'None') {
       attachmentInput.value = data.id + ',';
     } else {

--- a/crt_portal/static/js/pro_form_attachments.js
+++ b/crt_portal/static/js/pro_form_attachments.js
@@ -106,7 +106,7 @@
       event.preventDefault();
       removeFile(event);
     };
-    violationSummary.value = 'See attachment.'
+    violationSummary.value = 'See attachment.';
     if (attachmentInput.value == 'None') {
       attachmentInput.value = data.id + ',';
     } else {


### PR DESCRIPTION
[Remove personal description in the proform or auto-populate "see attachment"
#1889](https://github.com/usdoj-crt/crt-portal-management/issues/1889)

## What does this change?
This PR automatically adds "See attachment." when an attachment is added on the proform
## Screenshots (for front-end PR):
![Image](https://github.com/user-attachments/assets/9ffee9f8-c88f-41bc-a2a3-e71a82e928dd)
## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
