### PR TITLE
Make it easier to debug the disposition workflow

### DIFF
--- a/crt_portal/cts_forms/management/commands/force_disposition.py
+++ b/crt_portal/cts_forms/management/commands/force_disposition.py
@@ -1,21 +1,26 @@
-from datetime import datetime
+import os
 
 from django.core.management.base import BaseCommand
 from cts_forms.model_variables import BATCH_APPROVED_STATUS, BATCH_ARCHIVED_STATUS
 from cts_forms.models import ReportDispositionBatch
 
 
-class Command(BaseCommand):
-    help = 'Dispose of reports that have been approved for disposal.'
+class Command(BaseCommand):  # pragma: no cover
+    help = "Ignore proposed disposal date and force disposal disposition batches"
 
     def handle(self, *args, **options):
+        environment = os.environ.get('ENV', 'UNDEFINED')
+        if environment not in ['LOCAL', 'UNDEFINED', 'STAGE', 'DEVELOP']:
+            self.stdout.write(self.style.NOTICE(f'Cannot force disposition in {environment}'))
+            return
 
         disposable_batches = ReportDispositionBatch.objects.filter(
             status=BATCH_APPROVED_STATUS,
-            proposed_disposal_date__lte=datetime.now()
         )
 
         for batch in disposable_batches:
             batch.redact_reports()
             batch.status = BATCH_ARCHIVED_STATUS
             batch.save()
+
+        self.stdout.write(self.style.SUCCESS('Approved dispositions have been forced to Archived.'))

--- a/crt_portal/cts_forms/management/commands/reset_disposition.py
+++ b/crt_portal/cts_forms/management/commands/reset_disposition.py
@@ -1,0 +1,23 @@
+import os
+from django.core.management.base import BaseCommand
+from cts_forms.models import ReportDisposition, ReportDispositionBatch, Report
+
+
+class Command(BaseCommand):  # pragma: no cover
+    help = "Reset the disposition objects on dev or staging for testing"
+
+    def handle(self, *args, **options):
+        environment = os.environ.get('ENV', 'UNDEFINED')
+        if environment not in ['LOCAL', 'UNDEFINED', 'STAGE', 'DEVELOP']:
+            self.stdout.write(self.style.NOTICE(f'Cannot reset disposition in {environment}'))
+            return
+
+        # They'll still be redacted, but if we don't undisposed them they'll give errors when linking to the disposition batch.
+        reports = Report.all_objects.filter(disposed=True)
+        reports.update(disposed=False)
+        Report.objects.bulk_update(reports, ['disposed'])
+
+        ReportDisposition.objects.all().delete()
+        ReportDispositionBatch.objects.all().delete()
+
+        self.stdout.write(self.style.SUCCESS('Disposition objects have been reset. Note that reports will still be redacted'))

--- a/crt_portal/cts_forms/templates/forms/complaint_view/side_nav.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/side_nav.html
@@ -1,3 +1,6 @@
+{% load get_env %}
+{% load get_request %}
+
 <div class="side-nav">
 <div class="side-nav-content">
     <a href="#" class="menu-slider">
@@ -22,5 +25,12 @@
         <span>New record</span>
     </a>
     {% include 'forms/complaint_view/side_nav_options.html' with page=page %}
+
+    {% environment as env %}
+    {% get_request_user as user %}
+    {% if env != "PRODUCTION" and user.is_superuser  %}
+    <span>TEST SITE ADMINISTRATION</span>
+    {% include 'forms/complaint_view/side_nav_test_site.html' with page=page %}
+    {% endif %}
   </div>
 </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/side_nav_test_site.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/side_nav_test_site.html
@@ -1,0 +1,23 @@
+<div class="title">
+    <ul class="usa-nav__primary usa-accordion">
+      <li class="usa-nav__primary-item">
+        <a onclick="return confirm('This will make 50 fake reports with random statuses, data, disposition, tms responses, etc. Are you sure?')" class="crt-landing--menu_link reporting-header {% if page == 'report_records' %} selected {% endif %}" href="/form/test-site-command?next=/form/view&command=create_mock_reports&arg=50">
+          Create mock reports
+        </a>
+      </li>
+
+      {% if page == 'disposition' %}
+      <li class="usa-nav__primary-item">
+        <a onclick="return confirm('This will delete all disposition batches, and un-dispose any reports, as if we never tried disposing anything. Are you sure?')" class="crt-landing--menu_link reporting-header {% if page == 'report_records' %} selected {% endif %}" href="/form/test-site-command?next=/form/disposition&command=reset_disposition">
+          Reset disposition
+        </a>
+      </li>
+      <li class="usa-nav__primary-item">
+        <a onclick="return confirm('This will force the disposition of approved batches, regardless of when they are actually scheduled to be deleted. Are you sure?')" class="crt-landing--menu_link reporting-header {% if page == 'report_records' %} selected {% endif %}" href="/form/test-site-command?next=/form/disposition&command=force_disposition">
+          Dispose approved batches
+        </a>
+      </li>
+      {% endif %}
+
+    </ul>
+  </div>

--- a/crt_portal/cts_forms/templatetags/get_request.py
+++ b/crt_portal/cts_forms/templatetags/get_request.py
@@ -1,0 +1,9 @@
+from django import template
+from utils import request_utils
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_request_user():
+    return request_utils.get_user()

--- a/crt_portal/cts_forms/urls.py
+++ b/crt_portal/cts_forms/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from .views import (ActionsView, SavedSearchActionView, SavedSearchView, data_piecemeal_view, index_view, data_view, dashboard_view, dashboard_activity_log_view, disposition_view, RoutingGuideView, DispositionGuideView, DispositionActionsView, DispositionBatchActionsView, ShowView, ProFormView,
                     SaveCommentView, TrendView, ResponseView, SearchHelperView,
-                    PrintView, ProfileView, ReportAttachmentView, ReportDataView, DataExport, RemoveReportAttachmentView, unsubscribe_view, notification_view)
+                    PrintView, ProfileView, ReportAttachmentView, ReportDataView, DataExport, RemoveReportAttachmentView, unsubscribe_view, notification_view, test_site_view)
 from .forms import ProForm
 
 app_name = 'crt_forms'
@@ -39,4 +39,5 @@ urlpatterns = [
     path('disposition/batch/<uuid:id>/', DispositionBatchActionsView.as_view(), name='disposition-batch-actions'),
     path('notifications/unsubscribe', unsubscribe_view, name='crt-forms-notifications-unsubscribe'),
     path('notifications/', notification_view, name='crt-forms-notifications'),
+    path('test-site-command/', test_site_view, name='crt-test-site-command'),
 ]

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -4,9 +4,12 @@ This is where to put views that need authentication.
  - Add a test to ensure authentication
  - Be mindful of any naming collision with public URLs in settings
 """
+import contextlib
+import io
 import json
 import logging
 import mimetypes
+import os
 import urllib.parse
 
 import boto3
@@ -18,6 +21,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import SuspiciousOperation, BadRequest
+from django.core.management import call_command
 from django.core.paginator import Paginator
 from django.db.models import F, Subquery, OuterRef, Value, CharField, DateField, Case, When
 from django.http import Http404, HttpResponse, QueryDict
@@ -826,6 +830,42 @@ def notification_view(request):
     return _notification_change(request)
 
 
+@login_required
+def test_site_view(request):
+    environment = os.environ.get('ENV', 'UNDEFINED')
+    if environment not in ['LOCAL', 'UNDEFINED', 'STAGE', 'DEVELOP']:
+        return HttpResponse(status=416)
+    if request.method != 'GET':
+        return HttpResponse(status=405)
+
+    command_name = request.GET.get('command', '')
+    if not command_name:
+        return HttpResponse(status=400)
+
+    if command_name not in [
+        'create_mock_reports',
+        'reset_disposition',
+        'force_disposition'
+    ]:
+        return HttpResponse(status=400)
+
+    args = request.GET.getlist('arg')
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        call_command(command_name, *args)
+    output = stdout.getvalue()
+    error = stderr.getvalue()
+    output_part = f"<p>Command output:</p><pre>{output}</pre>" if output else ''
+    error_part = f"<p>Command error:</p><pre>{error}</pre>" if error else ''
+    message = f"<p>Command <strong>{command_name}</strong> executed.</p> {output_part} {error_part}"
+    messages.add_message(request,
+                         messages.WARNING,
+                         mark_safe(message))
+
+    return redirect(request.GET.get('next', '/form/view'))
+
+
 def _notification_get(request):
     if hasattr(request.user, 'notification_preference'):
         preferences = request.user.notification_preference
@@ -1190,6 +1230,8 @@ class DispositionActionsView(LoginRequiredMixin, FormView):
         shared_report_fields = {}
         keys = ['assigned_section', 'retention_schedule', 'status', 'expiration_date']
         for key, value in self.get_shared_report_values(requested_query, keys):
+            if key == 'expiration_date' and value == '-01-01':
+                continue
             shared_report_fields[key] = value
         shared_report_fields['date_range'] = self.get_report_date_range(requested_query)
         # Limit the count to 500 here because we have to display all the reports we're batching in a table
@@ -1359,7 +1401,7 @@ class DispositionBatchActionsView(LoginRequiredMixin, FormView):
         batch = get_object_or_404(ReportDispositionBatch, pk=id)
         report_dispo_objects = ReportDisposition.objects.filter(batch=batch)
         report_public_ids = report_dispo_objects.values_list('public_id', flat=True)
-        reports = Report.all_objects.filter(public_id__in=report_public_ids).order_by('pk')
+        reports = Report.objects.filter(public_id__in=report_public_ids).order_by('pk')
         report_ids = list(reports.values_list('pk', flat=True))
         first_report = reports.first()
         page = request.GET.get('page', 1)

--- a/crt_portal/utils/request_utils.py
+++ b/crt_portal/utils/request_utils.py
@@ -11,11 +11,15 @@ def get_client_ip(request):
     return ip
 
 
-def get_user_section():
+def get_user():
     current_request = CrequestMiddleware.get_request()
-    user = current_request.user
+    return current_request.user
+
+
+def get_user_section():
+    user = get_user()
     if hasattr(user, 'profile'):
-        return current_request.user.profile.section
+        return user.profile.section
     return None
 
 


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1924

## What does this change?

- 🌎 Disposition includes a few steps, approvals, statuses, etc
- ⛔ It is difficult to reset the disposition records to get a clean slate for testing workflows on dev and staging
- ✅ This commit introduces utilities for dealing with this, and fixes a few bugs.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
