### PR TITLE
Add logic to prevent empty filters from being added

### DIFF
--- a/crt_portal/static/js/filters.js
+++ b/crt_portal/static/js/filters.js
@@ -96,15 +96,17 @@
       }
 
       var valueToList = wrapValue(paramValue);
-      var paramsString = valueToList
-        .reduce(function(accum, value) {
-          accum.push(makeQueryParam(key, value));
-          newParamKeys.push(key);
-          return accum;
-        }, [])
-        .join('&');
+      if (valueToList[0] !== '') {
+        var paramsString = valueToList
+          .reduce(function(accum, value) {
+              accum.push(makeQueryParam(key, value));
+              newParamKeys.push(key);
+            return accum;
+          }, [])
+          .join('&');
 
-      memo.push(paramsString);
+        memo.push(paramsString);
+      }
 
       return memo;
     }, []);

--- a/crt_portal/static/js/filters.js
+++ b/crt_portal/static/js/filters.js
@@ -99,8 +99,8 @@
       if (valueToList[0] !== '') {
         var paramsString = valueToList
           .reduce(function(accum, value) {
-              accum.push(makeQueryParam(key, value));
-              newParamKeys.push(key);
+            accum.push(makeQueryParam(key, value));
+            newParamKeys.push(key);
             return accum;
           }, [])
           .join('&');


### PR DESCRIPTION
[Bug - All filters selected after keyword search #1945](https://github.com/usdoj-crt/crt-portal-management/issues/1945)

## What does this change?
This PR attempts to fix a bug where empty filters are being applied on the report table page.
Note that this bug cannot be reproduced consistently so comprehensive testing was not possible

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
