### PR TITLE
Saved Search bug fix

### DIFF
--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1812,6 +1812,9 @@ class SavedSearchActionView(LoginRequiredMixin, View):
                 'section_filter': section_filter,
                 'id': saved_search.pk,
                 'saved_search_view': f'&saved_search_view={saved_search_view}',
+                'notification_choices': NOTIFICATION_PREFERENCE_CHOICES,
+                'notification_preferences': notification_preferences,
+                'group_data': group_data,
             }
 
             try:


### PR DESCRIPTION
[Bug - Editing Saved Searches #1944](https://github.com/usdoj-crt/crt-portal-management/issues/1944)

## What does this change?
This PR fixes a bug where if you try to save changes to a saved search without making any changes you get an error.
## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
