### PR TITLE
Populate a district number when creating a record on the VOT proform

### DIFF
--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -142,7 +142,9 @@ class ReportEdit(generics.CreateAPIView):
         form.instance.refresh_from_db()
 
         form.update_activity_stream(request.user)
-
+        if created:
+            form.instance.district = form.instance.assign_district()
+            form.instance.save()
         server_changes = [] if public_id else ['public_id']
         server_data = {'public_id': form.instance.public_id}
         verb = 'created' if created else 'updated'

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1092,8 +1092,8 @@ PHONE_FORM_CONFIG = [
                 HiddenInput(attrs={'value': 'phone'}),
                 'Intake Format'),
     FieldConfig('district',
-            HiddenInput(),
-            'District Number'),
+                HiddenInput(),
+                'District Number'),
 ]
 
 

--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1091,6 +1091,9 @@ PHONE_FORM_CONFIG = [
     FieldConfig('intake_format',
                 HiddenInput(attrs={'value': 'phone'}),
                 'Intake Format'),
+    FieldConfig('district',
+            HiddenInput(),
+            'District Number'),
 ]
 
 


### PR DESCRIPTION
[Populate a district number when creating a record on the VOT proform #1957](https://github.com/usdoj-crt/crt-portal-management/issues/1957)

## What does this change?
Currently district numbers are not being added to newly created reports from the VOT proform. This PR fixes that.
## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
