### PR TITLE
Add logic to try to fix empty filter bug

### DIFF
--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -1,5 +1,6 @@
 # Class to handle filtering Reports by supplied query params,
 # provided they are valid filterable model properties.
+import logging
 from typing import Tuple, Dict, Any
 
 import re
@@ -200,7 +201,7 @@ def report_filter(querydict):
         filter_list = querydict.getlist(field)
 
         field_options = filter_options[field]
-        if len(filter_list) <= 0:
+        if len(filter_list) <= 0 or (len(filter_list) == 1 and filter_list[0] == ''):
             continue
 
         filters[field] = querydict.getlist(field)

--- a/crt_portal/cts_forms/filters.py
+++ b/crt_portal/cts_forms/filters.py
@@ -1,6 +1,5 @@
 # Class to handle filtering Reports by supplied query params,
 # provided they are valid filterable model properties.
-import logging
 from typing import Tuple, Dict, Any
 
 import re


### PR DESCRIPTION
[Bug - All filters selected after keyword search
#1945](https://github.com/usdoj-crt/crt-portal-management/issues/1945)

## What does this change?
This PR is another attempt to fix the blank filter bug by excluding empty filters from the report query
## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
