### PR TITLE
Update disposition bulk actions

### DIFF
--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/actions/bulk_actions.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/actions/bulk_actions.html
@@ -109,26 +109,27 @@
             {{ bulk_disposition_form.create_date }}
           </div>
         </div>
-        {% if shared_report_fields.retention_schedule == 'Multiple' or shared_report_fields.expiration_date == 'Multiple' %}
-          <p>The selected reports have multiple retention schedules and/or expiration dates.</p>
-          <p>All reports must have the same retention schedule and expiration date to be batched.</p>
+        {% if shared_report_fields.retention_schedule == 'Multiple' or shared_report_fields.expiration_date == 'Multiple' or shared_report_fields.assigned_section == 'Multiple' %}
+          <p>The selected reports have multiple retention schedules, assigned sections and/or expiration dates.</p>
+          <p>All reports must have the same retention schedule, expiration date and assigned section to be batched.</p>
         {% endif %}
         <input type="hidden" value="{{ all_ids_count }}" name="disposed_count" id="disposed_count" />
         {% if selected_all %}
             <button class="usa-button button--warning display-flex align-center"
                     id="show_warning_section"
+                    {% if shared_report_fields.retention_schedule == 'Multiple' or shared_report_fields.expiration_date == 'Multiple' or shared_report_fields.assigned_section == 'Multiple' %}disabled{% endif %}
             >
             Approve Disposal of {{ all_ids_count }} record{{ all_ids_count|pluralize:"s" }}
             </button>
         {% else %}
           <button class="usa-button{% if show_warning %} button--warning display-flex align-center{% endif %}"
                 {% if show_warning %}id="show_warning_section_partial"{% endif %}
-                {% if shared_report_fields.retention_schedule == 'Multiple' or shared_report_fields.expiration_date == 'Multiple' %}disabled{% endif %}
+                {% if shared_report_fields.retention_schedule == 'Multiple' or shared_report_fields.expiration_date == 'Multiple' or shared_report_fields.assigned_section == 'Multiple' %}disabled{% endif %}
                 type="submit"
                 id="submit_report_count"
                 name="selected_ids"
           >
-            Approve Disposal of {{ all_ids_count }} record{{ all_ids_count|pluralize:"s" }}
+            Approve Disposal of {{ ids_count }} record{{ ids_count|pluralize:"s" }}
           </button>
         {% endif %}
         </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/actions/index.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/actions/index.html
@@ -29,7 +29,7 @@
         <div class="complaint-actions display-flex flex-justify-center grid-offset-1 margin-top-2">
           {% include 'forms/complaint_view/disposition/actions/bulk_print.html' with reports=print_reports %}
         </div>
-        {% if not action %}
+        {% if action == 'batch' %}
         <div class="grid-row grid-gap-2">
           <div class="complaint-actions tablet:grid-col-5 grid-offset-1">
             {% include 'forms/complaint_view/disposition/actions/bulk_actions.html' %}

--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/complaints_table.html
@@ -181,11 +181,11 @@
       </div>
       <div class="selection-submit">
         <button type="submit" id="actions" label="actions" class="usa-button" value="batch" name="action">Batch <span id="selection-action-count-btn" class="selection-action-count-btn">1 record</span> for Disposal</button>
-        <button type="submit" id="actions" label="actions" class="usa-button" value="batch-all" name="action">Batch 500 records for Disposal</button>
+        <button type="submit" id="actions" label="actions" class="usa-button" value="batch-all" name="action">Batch <span id="selection-action-count-btn" class="selection-action-count-all-btn">2</span> records for Disposal</button>
         <button data-ga-event-name="complaints bulk print" type="submit" name="action" value="print" id="actions" label="actions" class="usa-button bulk-submit-ga">
           <span class="usa-tooltip" data-position="right" data-classes="display-inline" title="This may take a while if many reports are selected.">Print</span>
         </button>
-        <div class="margin-left-4 selection-warning">
+        <div class="selection-warning" hidden>
           <p>Bulk actions are capped at 500 records.</p>
         </div>
       </div>

--- a/crt_portal/cts_forms/templates/forms/complaint_view/disposition/complaints_table.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/disposition/complaints_table.html
@@ -28,6 +28,7 @@
               >
               <label class="usa-checkbox__label crt-checkbox__label checkbox-all" aria-label="Select all records"></label>
             </div>
+            <span id="visible_reports" value="{{ page_format.per_page }}"></span>
             <span id="total_reports" value="{{ page_format.count }}"></span>
           </th>
           {% endif %}
@@ -160,7 +161,7 @@
     </table>
   </div>
   <div class="selection-action-notification" hidden>
-    <div class="display-flex flex-align-center">
+    <div class="display-flex flex-align-center selected-some" hidden>
       <div>
         <img src="{% static 'img/ic_successconfirmation-white.svg' %}" alt="action available on selection" class="icon">
       </div>
@@ -168,14 +169,26 @@
         <span id="selection-action-count" class="selection-action-count">1 record</span> selected
       </h2>
       <div class="selection-submit">
-        <button type="submit" id="actions" label="actions" class="usa-button">Batch for Disposal</button>
+        <button type="submit" id="actions" label="actions" class="usa-button" value="batch">Batch for Disposal</button>
         <button data-ga-event-name="complaints bulk print" type="submit" name="action" value="print" id="actions" label="actions" class="usa-button bulk-submit-ga">
           <span class="usa-tooltip" data-position="right" data-classes="display-inline" title="This may take a while if many reports are selected.">Print</span>
         </button>
       </div>
     </div>
-    <div class="margin-left-4 selection-warning" hidden>
-      <p>The count has been adjusted to the bulk change cap of 500 records.</p>
+    <div class="display-flex flex-align-center selected-all" hidden>
+      <div>
+        <img src="{% static 'img/ic_successconfirmation-white.svg' %}" alt="action available on selection" class="icon">
+      </div>
+      <div class="selection-submit">
+        <button type="submit" id="actions" label="actions" class="usa-button" value="batch" name="action">Batch <span id="selection-action-count-btn" class="selection-action-count-btn">1 record</span> for Disposal</button>
+        <button type="submit" id="actions" label="actions" class="usa-button" value="batch-all" name="action">Batch 500 records for Disposal</button>
+        <button data-ga-event-name="complaints bulk print" type="submit" name="action" value="print" id="actions" label="actions" class="usa-button bulk-submit-ga">
+          <span class="usa-tooltip" data-position="right" data-classes="display-inline" title="This may take a while if many reports are selected.">Print</span>
+        </button>
+        <div class="margin-left-4 selection-warning">
+          <p>Bulk actions are capped at 500 records.</p>
+        </div>
+      </div>
     </div>
   </div>
 </form>

--- a/crt_portal/static/js/complaint_actions.js
+++ b/crt_portal/static/js/complaint_actions.js
@@ -25,6 +25,31 @@
     }
   }
 
+  function updateBatchRecordCount(index, parentTable, selectAllCheckbox, visibleReports) {
+    const actionNotificationEls = dom.getElementsByClassName('selection-action-notification');
+    const actionNotificationEl = actionNotificationEls[index];
+    const countEl = actionNotificationEl.getElementsByClassName('selection-action-count')[0];
+    const count = parentTable.querySelectorAll('td input.usa-checkbox__input:checked').length;
+    const selectedAll = dom.querySelector('.selected-all');
+    const selectedSome = dom.querySelector('.selected-some');
+    if (count === 0) {
+      actionNotificationEl.hidden = true;
+    } else if (selectAllCheckbox.checked) {
+      const selectedAllBtn = actionNotificationEl.querySelector('.selection-action-count-btn');
+      selectedSome.hidden = true;
+      selectedAll.hidden = false;
+      const numReports = visibleReports.getAttribute('value');
+      selectedAllBtn.innerText = numReports + ' records';
+      actionNotificationEl.hidden = false;
+    } else {
+      selectedSome.hidden = false;
+      selectedAll.hidden = true;
+      const recordsPlural = count === 1 ? ' record' : ' records';
+      countEl.innerText = count + recordsPlural;
+      actionNotificationEl.hidden = false;
+    }
+  }
+
   function addCheckAllListener(selectAllCheckbox, allCheckboxes) {
     selectAllCheckbox.addEventListener('click', event => {
       const checked = event.target.checked;
@@ -37,6 +62,7 @@
   }
 
   function addCheckboxListener(checkbox, index, parentTable, selectAllCheckbox) {
+    const visibleReports = parentTable.querySelector('#visible_reports');
     checkbox.addEventListener('click', event => {
       const target = event.target;
       const parent = target.parentNode.parentNode.parentNode;
@@ -48,7 +74,11 @@
           selectAllCheckboxes[index].checked = false;
         }
       }
-      updateRecordCount(index, parentTable, selectAllCheckbox);
+      if (visibleReports) {
+        updateBatchRecordCount(index, parentTable, selectAllCheckbox, visibleReports);
+      } else {
+        updateRecordCount(index, parentTable, selectAllCheckbox);
+      }
     });
   }
 

--- a/crt_portal/static/js/complaint_actions.js
+++ b/crt_portal/static/js/complaint_actions.js
@@ -32,14 +32,22 @@
     const count = parentTable.querySelectorAll('td input.usa-checkbox__input:checked').length;
     const selectedAll = dom.querySelector('.selected-all');
     const selectedSome = dom.querySelector('.selected-some');
+    const totalReports = parentTable.querySelector('#total_reports');
+    const warning = actionNotificationEl.querySelector('.selection-warning');
     if (count === 0) {
       actionNotificationEl.hidden = true;
     } else if (selectAllCheckbox.checked) {
       const selectedAllBtn = actionNotificationEl.querySelector('.selection-action-count-btn');
+      const selectedAllExtraBtn = actionNotificationEl.querySelector(
+        '.selection-action-count-all-btn'
+      );
       selectedSome.hidden = true;
       selectedAll.hidden = false;
       const numReports = visibleReports.getAttribute('value');
       selectedAllBtn.innerText = numReports + ' records';
+      const numReportsExtra = totalReports.getAttribute('value');
+      warning.hidden = numReportsExtra < 500;
+      selectedAllExtraBtn.innerText = numReportsExtra > 500 ? 500 : numReportsExtra;
       actionNotificationEl.hidden = false;
     } else {
       selectedSome.hidden = false;


### PR DESCRIPTION
[Disposition - Update bulk selection values #1960](https://github.com/usdoj-crt/crt-portal-management/issues/1960)

## What does this change?
This PR updates the bulk actions for the disposition page to allow users to select the reports visible on the page or the first 500 reports or less when they select all

![Image](https://github.com/user-attachments/assets/846dd41b-f8e9-4580-a653-a7da8c458787)

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
