### PR TITLE
Fix notification management link

### DIFF
--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -101,7 +101,7 @@ def _render_notification_mail(*,
     md = markdown.markdown(message, extensions=['extra', 'sane_lists', 'admonition', 'nl2br', CustomHTMLExtension(), RelativeToAbsoluteLinkExtension(for_intake=True)])
     html_message = render_to_string('notification.html', {
         'content': md,
-        'unsubscribe_link': '/'.join([get_site_prefix(for_intake=True), 'form/notifications/unsubscribe'])
+        'unsubscribe_link': '/'.join([get_site_prefix(for_intake=True), 'form/notifications']),
     })
 
     allowed_recipients = remove_disallowed_recipients(recipients)
@@ -164,7 +164,7 @@ def _render_scheduled_notification_mail(scheduled: ScheduledNotification) -> Mai
 
     html_message = render_to_string('scheduled_notification.html', {
         'digests': digests,
-        'unsubscribe_link': '/'.join([get_site_prefix(for_intake=True), 'form/notifications/unsubscribe'])
+        'unsubscribe_link': '/'.join([get_site_prefix(for_intake=True), 'form/notifications']),
     })
 
     recipients = [scheduled.recipient.email]

--- a/crt_portal/cts_forms/templates/notification.html
+++ b/crt_portal/cts_forms/templates/notification.html
@@ -69,7 +69,7 @@
 
       <p>Portal Team</p>
 
-      <p><em>please do not reply to this message - click <a href="{{ unsubscribe_link }}">here</a> to unsubscribe</em></p>
+      <p><em>please do not reply to this message.</em></p> To manage your portal notifications, click <a href="{{ unsubscribe_link }}">here</a></em></p>
 
     </div>
   </body>


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1971

## What does this change?

- 🌎 We'd previously linked to a "unsubscribe from everything" url
- ⛔ That URL has been replaced by the notification management page
- ✅ This commit replaces the link in emails with the new page

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
