### PR TITLE
Save notification preference when sending

### DIFF
--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -226,6 +226,7 @@ def send_tms(message: Mail, *, report: Optional[Report], purpose: str, dry_run: 
 def notify_scheduled(scheduled: ScheduledNotification):
     """Sends a set of scheduled notifications as a digest."""
     scheduled.was_sent = True
+    scheduled.save()
 
     if not scheduled.recipient.email:
         logger.info(f'Not sending digest notification (no email address for {scheduled.recipient})')


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1971

## What does this change?

Attempts to fix saved search notifications continuing to send despite the user being unsubscribed.

The only reason I can see this happening is if `was_sent` remains false (confirmed in admin panel that it seems to).

This explicitly saves the object. Future PRs might be needed, since this doesn't definitively prove a fix.

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
