### PR TITLE
Prevent dashboard group deletion

### DIFF
--- a/crt_portal/cts_forms/management/commands/update_ipynb_examples.py
+++ b/crt_portal/cts_forms/management/commands/update_ipynb_examples.py
@@ -308,6 +308,4 @@ class Command(BaseCommand):  # pragma: no cover
 
         total_created, total_deleted = self._update_files(diff)
 
-        created_groups = self._maybe_remake_dashboard_groups(total_deleted or total_created)
-
-        self.stdout.write(self.style.SUCCESS(f'Added {total_created}, deleted {total_deleted} Jupyter objects from filesystem, and created {created_groups} dashboard groups'))
+        self.stdout.write(self.style.SUCCESS(f'Added {total_created}, deleted {total_deleted} Jupyter objects from filesystem'))


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

This PR removes the code that clears out dashboard groups so they persist

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
