### PR TITLE
Fix the current date on the phone pro form

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -16,7 +16,6 @@ from django.db.models.functions import Cast
 from django.db.models import IntegerField as IntField
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from django.utils import timezone as dtimezone
 from django.conf import settings
 from actstream.models import Action
 
@@ -1057,33 +1056,30 @@ PHONE_FORM_CONFIG = [
                 'What did the person believe happened?'),
     FieldConfig('crt_reciept_month',
                 TextInput(attrs={
-                    'class': 'usa-input usa-input--small',
+                    'class': 'autotoday usa-input usa-input--small',
                     'type': 'text',
                     'maxlength': 2,
                     'pattern': '[0-9]*',
                     'inputmode': 'numeric',
-                    'value': dtimezone.now().month,
                 }),
                 'Month'),
     FieldConfig('crt_reciept_day',
                 TextInput(attrs={
-                    'class': 'usa-input usa-input--small',
+                    'class': 'autotoday usa-input usa-input--small',
                     'type': 'text',
                     'maxlength': 2,
                     'pattern': '[0-9]*',
                     'inputmode': 'numeric',
-                    'value': dtimezone.now().day,
                 }),
                 'Day'),
     FieldConfig('crt_reciept_year',
                 TextInput(attrs={
-                    'class': 'usa-input usa-input--medium',
+                    'class': 'autotoday usa-input usa-input--medium',
                     'type': 'text',
                     'minlength': 4,
                     'maxlength': 4,
                     'pattern': '[0-9]*',
                     'inputmode': 'numeric',
-                    'value': dtimezone.now().year,
                 }),
                 'Year'),
 

--- a/crt_portal/cts_forms/templates/forms/phone_pro_template.html
+++ b/crt_portal/cts_forms/templates/forms/phone_pro_template.html
@@ -184,7 +184,6 @@
 <script src="{% static 'vendor/shepherd.min.js'%}"></script>
 <script src="{% static 'js/modal.min.js' %}"></script>
 <script src="{% static 'js/pro_form_show_hide.min.js' %}"></script>
-<script src="{% static 'js/autofill_current_date.min.js' %}"></script>
 <script src="{% static 'js/word_count.min.js' %}"></script>
 <script src="{% static 'vendor/intlTelInput.min.js' %}"></script>
 <script src="{% static 'js/report_phone.min.js' %}"></script>
@@ -194,4 +193,5 @@
     <script src="{% static 'js/side_nav_slider.min.js' %}"></script>
 {% endif %}
 <script type="module" src="{% static 'js/tour.min.js'%}"></script>
+<script src="{% static 'js/autofill_current_date.min.js' %}"></script>
 {% endblock %}

--- a/crt_portal/static/js/autofill_current_date.js
+++ b/crt_portal/static/js/autofill_current_date.js
@@ -1,12 +1,13 @@
 (function(root, dom) {
   root.CRT = root.CRT || {};
 
-  function autofillTodaysDate(inputEls) {
+  function autofillTodaysDate(inputEls, overwrite) {
     const today = new Date();
     const day = today.getDate(),
       month = today.getMonth() + 1,
       year = today.getFullYear();
     [...inputEls].forEach(inputEl => {
+      if (!overwrite && inputEl.value) return;
       const inputName = inputEl.getAttribute('name');
       if (inputName.includes('month')) {
         inputEl.value = month;
@@ -21,12 +22,14 @@
   document.querySelectorAll('.autofill_today_btn').forEach(autofillButton => {
     autofillButton.addEventListener('click', event => {
       const inputs = event.target.parentElement.getElementsByTagName('input');
-      autofillTodaysDate(inputs);
+      autofillTodaysDate(inputs, true);
     });
   });
 
-  document.querySelectorAll('.autotoday').forEach(input => {
-    autofillTodaysDate([input]);
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.autotoday').forEach(input => {
+      autofillTodaysDate([input], false);
+    });
   });
 
   return root;

--- a/crt_portal/static/js/autofill_current_date.js
+++ b/crt_portal/static/js/autofill_current_date.js
@@ -1,27 +1,33 @@
 (function(root, dom) {
   root.CRT = root.CRT || {};
 
-  function autofillTodaysDate(event) {
-    var inputEL = event.target.parentElement.getElementsByTagName('input');
-    var today = new Date();
-    var day = today.getDate(),
+  function autofillTodaysDate(inputEls) {
+    const today = new Date();
+    const day = today.getDate(),
       month = today.getMonth() + 1,
       year = today.getFullYear();
-    for (i = 0; i < inputEL.length; i++) {
-      if (inputEL[i].getAttribute('name').includes('month')) {
-        inputEL[i].value = month;
-      } else if (inputEL[i].getAttribute('name').includes('day')) {
-        inputEL[i].value = day;
-      } else if (inputEL[i].getAttribute('name').includes('year')) {
-        inputEL[i].value = year;
+    [...inputEls].forEach(inputEl => {
+      const inputName = inputEl.getAttribute('name');
+      if (inputName.includes('month')) {
+        inputEl.value = month;
+      } else if (inputName.includes('day')) {
+        inputEl.value = day;
+      } else if (inputName.includes('year')) {
+        inputEl.value = year;
       }
-    }
+    });
   }
 
-  var autofill_btns = document.getElementsByClassName('autofill_today_btn');
-  for (i = 0; i < autofill_btns.length; i++) {
-    autofill_btns[i].addEventListener('click', autofillTodaysDate);
-  }
+  document.querySelectorAll('.autofill_today_btn').forEach(autofillButton => {
+    autofillButton.addEventListener('click', event => {
+      const inputs = event.target.parentElement.getElementsByTagName('input');
+      autofillTodaysDate(inputs);
+    });
+  });
+
+  document.querySelectorAll('.autotoday').forEach(input => {
+    autofillTodaysDate([input]);
+  });
 
   return root;
 })(window, document);


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/1999

## What does this change?

- 🌎 The phone pro form autopopulates the current date
- ⛔ That date is calculated when the app instance starts, meaning that if the app instance runs a for a few days, the "today" date becomes invalid
- ✅ This commit calculates the date on the frontend, instead, so it's always accurate to the client

## Screenshots (for front-end PR):

<img width="419" alt="image" src="https://github.com/user-attachments/assets/6ff3235d-5d35-4b3f-a15b-0ce0b8d1c6ef">

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
