### PR TITLE
Check jupyter tasks hourly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -763,7 +763,7 @@ workflows:
       - prod-jupyter-tasks
     triggers:
       - schedule:
-          cron: '0 2,8,14,20 * * *' # run four times per day
+          cron: '0 * * * *' # run every hour
           filters:
             branches:
               only: master


### PR DESCRIPTION
## What does this change?

- 🌎 This job checks whether to run jupyter dashboards. If they're not due to run, it skips them and completes quickly
- ⛔ It was scheduled to run every four hours on prod, but we want hourly resolution
- ✅ This commit runs the check hourly

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
