### PR TITLE
Fix disposition tab filter bug

### DIFF
--- a/crt_portal/static/js/disposition_filters.js
+++ b/crt_portal/static/js/disposition_filters.js
@@ -9,6 +9,18 @@
     status: Cookies.get('disposition_view_batch_status') || ''
   };
 
+  function clearFilters(tab) {
+    Cookies.remove('disposition_view_batch_status');
+    const updates = {
+      retention_schedule: '',
+      expiration_date: '',
+      status: '',
+      disposition_status: tab.value
+    };
+    root.CRT.mutateFilterDataWithUpdates(root.CRT.filterDataModel, updates);
+    root.CRT.formView.doSearch(root.CRT.formEl);
+  }
+
   function filterController() {
     root.CRT.formEl = dom.getElementById('sort-page-form');
 
@@ -86,6 +98,13 @@
   }
 
   function init() {
+    const tabs = dom.querySelectorAll('li > button[type="submit"]');
+    tabs.forEach(tab => {
+      tab.onclick = (e) => {
+        e.preventDefault();
+        clearFilters(tab);
+      }
+    })
     const search = new URLSearchParams(root.location.search);
     if (search.size === 0) {
       search.set('disposition_status', 'past');

--- a/crt_portal/static/js/disposition_filters.js
+++ b/crt_portal/static/js/disposition_filters.js
@@ -100,11 +100,11 @@
   function init() {
     const tabs = dom.querySelectorAll('li > button[type="submit"]');
     tabs.forEach(tab => {
-      tab.onclick = (e) => {
+      tab.onclick = e => {
         e.preventDefault();
         clearFilters(tab);
-      }
-    })
+      };
+    });
     const search = new URLSearchParams(root.location.search);
     if (search.size === 0) {
       search.set('disposition_status', 'past');


### PR DESCRIPTION
[Records appearing in tabs before the appropriate time #2007](https://github.com/usdoj-crt/crt-portal-management/issues/2007)

## What does this change?
Currently there is a bug where if you apply filters on one of the tabs on the disposition page and then switch tabs the filters remain and override the tab switch. This PR fixes that.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
