### PR TITLE
Fix bulk action bug

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -915,14 +915,15 @@ class ReportDispositionBatch(models.Model):
         # Creating a new queryset by filtering by id so we can update the
         # batched_for_disposal field after limiting the record number to 500
         ids = queryset.values_list('pk', flat=True)
-        Report.objects.filter(pk__in=list(ids)).update(batched_for_disposal=True)
+        queryset = Report.objects.filter(pk__in=list(ids))
+        queryset.update(batched_for_disposal=True)
         ReportDisposition.objects.bulk_create([
             ReportDisposition(
                 schedule=report.retention_schedule,
                 batch=self,
                 public_id=report.public_id)
             for report
-            in queryset.all().select_related('retention_schedule').only('retention_schedule', 'public_id')
+            in queryset.all().only('retention_schedule', 'public_id')
         ])
 
     def redact_reports(self):


### PR DESCRIPTION
[500 error on large disposition batch #2006](https://github.com/usdoj-crt/crt-portal-management/issues/2006)

## What does this change?
This PR fixes a bug where when a bulk action is to add records to a batch, no records are added to the batch.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
