### PR TITLE
update form_letter.js to call reset when modal is canceled

### DIFF
--- a/crt_portal/cts_forms/tests/integration_authed/contact_complainant.py
+++ b/crt_portal/cts_forms/tests/integration_authed/contact_complainant.py
@@ -35,7 +35,7 @@ def test_contact_complainant_modal(page, *, report):
     assert modal.locator('#intake_letter_html').text_content() == ''
 
     page.locator('button').filter(has_text="Contact complainant").click()
-    
+
     modal.locator('select').filter(has_text='English').select_option('Spanish')
     modal.locator('select').filter(has_text='[Select response letter]').select_option('CRT - No capacity')
 

--- a/crt_portal/cts_forms/tests/integration_authed/contact_complainant.py
+++ b/crt_portal/cts_forms/tests/integration_authed/contact_complainant.py
@@ -31,6 +31,17 @@ def test_contact_complainant_modal(page, *, report):
     modal.locator('#intake_letter_html').filter(has_text='Dear Testing Tester').wait_for()
     assert modal.locator('.optionals').is_hidden()
 
+    modal.locator('button').filter(has_text="Cancel").click()
+    assert modal.locator('#intake_letter_html').text_content() == ''
+
+    page.locator('button').filter(has_text="Contact complainant").click()
+    
+    modal.locator('select').filter(has_text='English').select_option('Spanish')
+    modal.locator('select').filter(has_text='[Select response letter]').select_option('CRT - No capacity')
+
+    modal.locator('#intake_description').filter(has_text='Your Civil Rights Division Report').wait_for()
+    modal.locator('#intake_letter_html').filter(has_text='Dear Testing Tester').wait_for()
+
     for label in ['Send', 'Print letter', 'Copy letter']:
         assert modal.locator('button').filter(has_text=label).is_enabled()
     report.screenshot(page, full_page=True, caption='Users can select a language and a response letter from the dropdowns. The letter will be populated with the complainant\'s name, the date the report was submitted, etc. The content of these templates can be changed by application administrators.')

--- a/crt_portal/static/js/form_letter.js
+++ b/crt_portal/static/js/form_letter.js
@@ -47,9 +47,6 @@
   };
   contact.addEventListener('click', showModal);
 
-  var cancel_modal = document.getElementById('intake_template_cancel');
-  root.CRT.cancelModal(modal, cancel_modal);
-
   var copy = modal.querySelector('#intake_copy');
   var print = modal.querySelector('#intake_print');
   var letter = modal.querySelector('#intake_letter');
@@ -76,6 +73,9 @@
       send_email.setAttribute('disabled', 'disabled');
     }
   };
+
+  let cancel_modal = document.getElementById('intake_template_cancel');
+  root.CRT.cancelModal(modal, cancel_modal, null, reset);
 
   const description = modal.querySelector('#intake_description');
   const selects = modal.querySelectorAll('.intake-select');

--- a/crt_portal/static/js/form_letter.js
+++ b/crt_portal/static/js/form_letter.js
@@ -74,8 +74,8 @@
     }
   };
 
-  let cancel_modal = document.getElementById('intake_template_cancel');
-  root.CRT.cancelModal(modal, cancel_modal, null, reset);
+  const cancelModal = document.getElementById('intake_template_cancel');
+  root.CRT.cancelModal(modal, cancelModal, null, reset);
 
   const description = modal.querySelector('#intake_description');
   const selects = modal.querySelectorAll('.intake-select');


### PR DESCRIPTION
[Link to GitHub issue.](https://github.com/usdoj-crt/crt-portal-management/issues/1235)

## What does this change?

Fixes a bug where the contact complainant modal wasn't clearing when the cancel button was used.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
