### PR TITLE
Set jupyter log level to INFO (default is WARN)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -763,7 +763,7 @@ workflows:
       - prod-jupyter-tasks
     triggers:
       - schedule:
-          cron: '0 * * * *' # run every hour
+          cron: '0 0,6,12,18 * * *' # run four times per day
           filters:
             branches:
               only: master

--- a/jupyterhub/run_scheduled_refresh.py
+++ b/jupyterhub/run_scheduled_refresh.py
@@ -13,8 +13,6 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 NOTEBOOK_DIR = os.path.join(BASE_DIR)
 SCHEDULES_PATH = os.path.join(NOTEBOOK_DIR, 'schedules.json')
 
-logging.getLogger().setLevel(logging.INFO)
-
 
 def main(dry_run=False):
     manager = TableContentsManager()
@@ -69,10 +67,10 @@ def _execute_one(notebook, manager, dry_run=False) -> Optional[int]:
     path = notebook.get(('file', 'path'))
 
     if dry_run:
-        logging.info(f'Dry run - skipping execution of {path}')
+        logging.warning(f'Dry run - skipping execution of {path}')
         return notebook
 
-    logging.info(f'Pulling source code for {path}')
+    logging.warning(f'Pulling source code for {path}')
     try:
         source_code = manager.get(path)
     except Exception as e:
@@ -99,11 +97,11 @@ def _execute_one(notebook, manager, dry_run=False) -> Optional[int]:
         logging.warning(f'Failed to execute {path}: Invalid notebook')
         return None
     try:
-        logging.info(f'Executing notebook {path}')
+        logging.warning(f'Executing notebook {path}')
         result, _ = processor.preprocess(notebook, metadata)
 
         source_code['content'] = result
-        logging.info(f'Saving notebook {path}')
+        logging.warning(f'Saving notebook {path}')
         manager.save(source_code, path)
     except Exception as e:
         logging.error(f'Failed to execute {path}: {e}')
@@ -120,4 +118,4 @@ def _execute_all(notebooks, manager, dry_run=False) -> List[Optional[int]]:
 
 
 if __name__ == '__main__':
-    logging.info('Updated the following notebooks', main())
+    logging.warning('Updated the following notebooks', main())

--- a/jupyterhub/run_scheduled_refresh.py
+++ b/jupyterhub/run_scheduled_refresh.py
@@ -13,6 +13,8 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 NOTEBOOK_DIR = os.path.join(BASE_DIR)
 SCHEDULES_PATH = os.path.join(NOTEBOOK_DIR, 'schedules.json')
 
+logging.getLogger().setLevel(logging.INFO)
+
 
 def main(dry_run=False):
     manager = TableContentsManager()


### PR DESCRIPTION
[Link to ZenHub issue.](link-goes-here)

## What does this change?

Sets Jupyter log level to INFO

Right now, Jupyter is only logging WARN logs (we want to see them all for debugging)

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
