### PR TITLE
Fix archived disposition batches

### DIFF
--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -427,7 +427,7 @@ class ReportManager(models.Manager):
 
 class AllReportManager(models.Manager):
     def get_queryset(self):
-        return super(AllReportManager, self).get_queryset().filter(disposed=True)
+        return super(AllReportManager, self).get_queryset()
 
 
 # NOTE: If you add fields to report, they'll automatically be set to empty on the edit form. Make sure to address any additions in ReportEditForm as well!

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -1532,7 +1532,7 @@ class DispositionBatchActionsView(LoginRequiredMixin, FormView):
         batch = get_object_or_404(ReportDispositionBatch, pk=id)
         report_dispo_objects = ReportDisposition.objects.filter(batch=batch)
         report_public_ids = report_dispo_objects.values_list('public_id', flat=True)
-        reports = Report.objects.filter(public_id__in=report_public_ids).order_by('pk')
+        reports = Report.all_objects.filter(public_id__in=report_public_ids).order_by('pk')
         reports = reports.annotate(retention_year=F('retention_schedule__retention_years'),
                                    expiration_year=F('retention_year') + ExtractYear('closed_date') + 1,
                                    expiration_date=Cast(Concat(F('expiration_year'), Value('-'), Value('01'), Value('-'), Value('01'), output_field=CharField()), output_field=DateField()),
@@ -1578,11 +1578,11 @@ class DispositionBatchActionsView(LoginRequiredMixin, FormView):
             rejected_report_ids = request.POST.get('rejected_report_ids', '').split(',')
             rejected_report_dispo_queryset = ReportDisposition.objects.filter(public_id__in=rejected_report_ids)
             rejected_public_ids = rejected_report_dispo_queryset.values_list('public_id', flat=True)
-            Report.objects.filter(public_id__in=rejected_public_ids).update(report_disposition_status='rejected', batched_for_disposal=False)
+            Report.all_objects.filter(public_id__in=rejected_public_ids).update(report_disposition_status='rejected', batched_for_disposal=False)
 
             approved_report_dispo_queryset = ReportDisposition.objects.filter(batch=batch).exclude(public_id__in=rejected_report_ids)
             approved_public_ids = approved_report_dispo_queryset.values_list('public_id', flat=True)
-            Report.objects.filter(public_id__in=approved_public_ids).update(report_disposition_status='approved', batched_for_disposal=True)
+            Report.all_objects.filter(public_id__in=approved_public_ids).update(report_disposition_status='approved', batched_for_disposal=True)
             approved_report_dispo_queryset.update(rejected=False)
 
             batch = form.save(commit=False)


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/2028

## What does this change?

- 🌎 Clicking an archived disposition batch should go to the list of reports that were disposed
- ⛔ Right now it breaks, because the reports have been disposed and don't appear as part of Report.objects
- ✅ This commit uses Report.all_objects instead, to skip the filter on disposed=False

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
