### PR TITLE
[CRT-Portal: 2026] Add form letter variables: complainant_name, organization_name

### DIFF
--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -246,8 +246,10 @@ class ResponseTemplatePreviewBase:
     def _make_example_context(self):
         to_be_translated = {
             'addressee': 'Addressee Name',
+            'complainant_name': 'Complainant Name',
             'date_of_intake': 'Date of Intake',
             'outgoing_date': 'Outgoing Date',
+            'organization_name': 'Organization Name',
             'section_name': 'Section',
         }
 

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -1172,6 +1172,8 @@ class ResponseTemplate(models.Model):
         return Context({
             'record_locator': report.public_id,
             'addressee': report.addressee,
+            'complainant_name': report.contact_first_name + " " + report.contact_last_name,
+            'organization_name': report.location_name,
             'date_of_intake': format_date(report_create_date_est, format='long', locale='en_US'),
             'outgoing_date': format_date(today, locale='en_US'),  # required for paper mail
             'section_name': section_choices.get(report.assigned_section, "no section"),

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -1172,7 +1172,7 @@ class ResponseTemplate(models.Model):
         return Context({
             'record_locator': report.public_id,
             'addressee': report.addressee,
-            'complainant_name': report.contact_first_name + " " + report.contact_last_name,
+            'complainant_name': f'{report.contact_first_name} {report.contact_last_name}',
             'organization_name': report.location_name,
             'date_of_intake': format_date(report_create_date_est, format='long', locale='en_US'),
             'outgoing_date': format_date(today, locale='en_US'),  # required for paper mail

--- a/crt_portal/cts_forms/templates/template_help.md
+++ b/crt_portal/cts_forms/templates/template_help.md
@@ -19,12 +19,14 @@ All of our templates support a few special variables. They are:
 | `addressee`              | Dear John Doe                | The salutation "Dear FirstName LastName" (sans comma) |
 | `contact_address_line_1` | 1 Demo Street                | The recipient's first address line                    |
 | `contact_address_line_2` | Apt 5                        | The recipient's second address line                   |
+| `complainant_name`    | John Doe  | The complainant's first and last name |
 | `contact_email`          | john@civilrights.justice.gov | The recipient's email address                         |
 | `date_of_intake`         | February 29, 1988            | The day the report was submitted                      |
+| `organization_name`   | Santa's Workshop  | The name of the organization or location that is subject to the complaint |
 | `outgoing_date`          | February 31, 1988            | The day this reply is being sent (today)              |
-| `section_name`           | Voting                       | The section of the user sending the reply             |
 | `record_locator`         | 12345-XYZ                    | The identifier (record locator) of the report         |
 | `referral_text`          | Ministry of Magic            | The referral_variable set on the ReferralContact |
+| `section_name`           | Voting                       | The section of the user sending the reply             |
 
 ### How do I use them?
 

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -103,7 +103,7 @@ class APIPreviewResponseFormTests(TestCase):
         )
 
         self.assertContains(response, 'hello, <em><span class="variable">Addressee Name</span></em>')
-    
+
     def test_preview_response_with_complainant_name(self):
         """Makes sure our route for previewing markdown files works."""
         self.client.login(username="DELETE_USER", password="")  # nosec

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -92,22 +92,6 @@ class APIPreviewResponseFormTests(TestCase):
         )
 
         self.assertContains(response, 'hello, <span class="variable">Addressee Name</span>')
-    
-        response2 = self.client.post(
-            self.url,
-            {"body": "hello, {{ complainant_name }}"}
-        )
-        print("Test: ", str(response2))
-
-        self.assertContains(response2, 'hello, <span class="variable">Addressee Name</span>')
-        
-        response3 = self.client.post(
-            self.url,
-            {"body": "hello, {{ organization_name }}"}
-        )
-
-        self.assertContains(response3, 'hello, <span class="variable">Location Name</span>')
-
 
     def test_preview_response_html(self):
         """Makes sure our route for previewing markdown files works."""
@@ -119,6 +103,28 @@ class APIPreviewResponseFormTests(TestCase):
         )
 
         self.assertContains(response, 'hello, <em><span class="variable">Addressee Name</span></em>')
+    
+    def test_preview_response_with_complainant_name(self):
+        """Makes sure our route for previewing markdown files works."""
+        self.client.login(username="DELETE_USER", password="")  # nosec
+
+        response = self.client.post(
+            self.url,
+            {"body": "hello, {{ complainant_name }}"}
+        )
+
+        self.assertContains(response, 'hello, <span class="variable">Complainant Name</span>')
+
+    def test_preview_response_with_organization_name(self):
+        """Makes sure our route for previewing markdown files works."""
+        self.client.login(username="DELETE_USER", password="")  # nosec
+
+        response = self.client.post(
+            self.url,
+            {"body": "hello, {{ organization_name }}"}
+        )
+
+        self.assertContains(response, 'hello, <span class="variable">Organization Name</span>')
 
     def test_unauthenticated_post(self):
         """Only logged in users should be able to preview templates."""

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -92,6 +92,21 @@ class APIPreviewResponseFormTests(TestCase):
         )
 
         self.assertContains(response, 'hello, <span class="variable">Addressee Name</span>')
+    
+        response2 = self.client.post(
+            self.url,
+            {"body": "hello, {{ complainant_name }}"}
+        )
+
+        self.assertContains(response2, 'hello, <span class="variable">Addressee Name</span>')
+        
+        response3 = self.client.post(
+            self.url,
+            {"body": "hello, {{ organization_name }}"}
+        )
+
+        self.assertContains(response3, 'hello, <span class="variable">Location Name</span>')
+
 
     def test_preview_response_html(self):
         """Makes sure our route for previewing markdown files works."""

--- a/crt_portal/cts_forms/tests/test_api.py
+++ b/crt_portal/cts_forms/tests/test_api.py
@@ -97,6 +97,7 @@ class APIPreviewResponseFormTests(TestCase):
             self.url,
             {"body": "hello, {{ complainant_name }}"}
         )
+        print("Test: ", str(response2))
 
         self.assertContains(response2, 'hello, <span class="variable">Addressee Name</span>')
         


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/orgs/usdoj-crt/projects/3/views/2?pane=issue&itemId=87672954&issue=usdoj-crt%7Ccrt-portal-management%7C2026)

## What does this change?

1. Adds form letter variables for:

complainant_name
organization_name

These are added to the Context object for the ResponseTemplate model, allowing them to be referenced in the form letter markdown.

2. Adds a couple of assertions in test_api.py to ensure these variables work as intended

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
