### PR TITLE
Silence an exception when no juypter notebooks are run

### DIFF
--- a/jupyterhub/helpers/table_contents_manager.py
+++ b/jupyterhub/helpers/table_contents_manager.py
@@ -157,6 +157,9 @@ class TableContentsManager(ContentsManager):
             cursor.execute(query.as_string(connection))
 
     def update_fields(self, pks, *, fields_and_values=None, metadata_fields_and_values=None):
+        if not pks:
+            return
+
         if fields_and_values:
             self.__update('analyticsfile', pks, fields_and_values, id_field='id')
 


### PR DESCRIPTION
## What does this change?

Fixes Jupyter update failure when no dashboards are run.

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
