### PR TITLE
Bump quota to 7G

### DIFF
--- a/manifest_dev.yaml
+++ b/manifest_dev.yaml
@@ -5,7 +5,7 @@ applications:
   - route: crt-portal-django-dev.app.cloud.gov
   - route: crt-portal-django-dev.apps.internal
   memory: 512M
-  disk_quota: 6G
+  disk_quota: 7G
   instances: 1
   env:
     ENV: DEVELOP

--- a/manifest_staging.yaml
+++ b/manifest_staging.yaml
@@ -5,7 +5,7 @@ applications:
   - route: crt-portal-django-stage.app.cloud.gov
   - route: crt-portal-django-stage.apps.internal
   memory: 512M
-  disk_quota: 6G
+  disk_quota: 7G
   instances: 2
   env:
     ENV: STAGE


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/2039

## What does this change?

- 🌎 As part of 3.13.0 update, packages updated as well
- ⛔ They now take more than 7G while installing
- ✅ This commit bumps quota to allow for extra size

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
