### PR TITLE
Unlock cloudfoundry cli version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -668,11 +668,9 @@ workflows:
               only: master
 
       - deploy-dev:
-          requires:
-            - build_and_test
           filters:
             branches:
-              only: develop
+              only: kk/revert-cf
 
       - deploy-stage:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ install-cf8: &install-cf8
   run:
     name: Install CF8
     command: |
-      curl -A "" -L -o cf8.deb 'https://github.com/cloudfoundry/cli/releases/download/v8.8.3/cf8-cli-installer_8.8.3_x86-64.deb'
+      curl -A "" -L -o cf8.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=v8&source=github'
       sudo dpkg -i cf8.deb
       rm cf8.deb
       cf8 api https://api.fr.cloud.gov
@@ -259,7 +259,7 @@ jobs:
       - run:
           name: install cf8
           command: |
-            curl -A "" -L -o cf8.deb 'https://github.com/cloudfoundry/cli/releases/download/v8.8.3/cf8-cli-installer_8.8.3_x86-64.deb'
+            curl -A "" -L -o cf8.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=v8&source=github'
             dpkg -i cf8.deb
             rm cf8.deb
             cf8 api https://api.fr.cloud.gov
@@ -326,7 +326,7 @@ jobs:
       - run:
           name: install cf8
           command: |
-            curl -A "" -L -o cf8.deb 'https://github.com/cloudfoundry/cli/releases/download/v8.8.3/cf8-cli-installer_8.8.3_x86-64.deb'
+            curl -A "" -L -o cf8.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=v8&source=github'
             dpkg -i cf8.deb
             rm cf8.deb
             cf8 api https://api.fr.cloud.gov
@@ -389,7 +389,7 @@ jobs:
       - run:
           name: install cf8
           command: |
-            curl -A "" -L -o cf8.deb 'https://github.com/cloudfoundry/cli/releases/download/v8.8.3/cf8-cli-installer_8.8.3_x86-64.deb'
+            curl -A "" -L -o cf8.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=v8&source=github'
             dpkg -i cf8.deb
             rm cf8.deb
             cf8 api https://api.fr.cloud.gov
@@ -668,9 +668,11 @@ workflows:
               only: master
 
       - deploy-dev:
+          requires:
+            - build_and_test
           filters:
             branches:
-              only: kk/revert-cf
+              only: develop
 
       - deploy-stage:
           requires:


### PR DESCRIPTION
## What does this change?

- Cloudfoundry CLI was pointing to a specific version because of a bug in their URL redirects
- They've fixed the issue
- This unlocks the version, pointing back to the cloundfoundry redirect URL.

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
