### PR TITLE
Fix Jupyterhub auth issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,6 @@ services:
     build:
       dockerfile: jupyterhub.Dockerfile
     command: jupyterhub --config '/srv/jupyterhub/jupyterhub_config.py'
-    depends_on:
-      - db
-      - web
 
   web:
     hostname: web

--- a/jupyterhub/jupyterhub_config.py
+++ b/jupyterhub/jupyterhub_config.py
@@ -197,15 +197,11 @@ class PortalOAuthenticator(GenericOAuthenticator):
 
 c.JupyterHub.authenticator_class = PortalOAuthenticator
 
+PortalOAuthenticator.manage_groups = True
+PortalOAuthenticator.user_auth_state_key = "oauth_user"
+PortalOAuthenticator.auth_state_groups_key = 'oauth_user.groups'
 PortalOAuthenticator.allowed_groups = {'jupyter_editor'}
 PortalOAuthenticator.admin_groups = {'jupyter_superuser'}
-
-# Generate a code_challenge, which is an extra security step imposed by django-oauth-toolkit.
-# For more info: https://django-oauth-toolkit.readthedocs.io/en/stable/getting_started.html
-code_verifier = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(random.randint(43, 128)))
-code_verifier = base64.urlsafe_b64encode(code_verifier.encode('utf-8'))
-code_challenge = hashlib.sha256(code_verifier).digest()
-code_challenge = base64.urlsafe_b64encode(code_challenge).decode('utf-8').replace('=', '')
 
 web_external_hostname = os.environ.get('WEB_EXTERNAL_HOSTNAME')
 web_internal_hostname = os.environ.get('WEB_INTERNAL_HOSTNAME')
@@ -217,15 +213,6 @@ jupyter_external_hostname = (
 
 PortalOAuthenticator.client_id = os.environ.get('OAUTH_PROVIDER_CLIENT_ID')
 PortalOAuthenticator.client_secret = os.environ.get('OAUTH_PROVIDER_CLIENT_SECRET')
-
-PortalOAuthenticator.extra_authorize_params = {
-    'code_challenge': code_challenge,
-    'code_challenge_method': 'S256',
-}
-
-PortalOAuthenticator.token_params = {
-    'code_verifier': code_verifier,
-}
 
 PortalOAuthenticator.login_service = 'DOJ CRT Portal'
 PortalOAuthenticator.basic_auth = False


### PR DESCRIPTION
## What does this change?

- 🌎 Jupyterhub uses OAuth, with the portal as the provider. The portal (django-oauth-toolkit) requires PKCE, and Jupyterhub (oauthenticator) didn't previously support it.It was manually configured using code_challenge and verifier params
- ⛔ Oauthenticator updated to support PKCE natively, and enabled it by default. This conflicted with our manual workaround, breaking authentication
- ✅ This commit removes the manual workaround, allowing oauthenticator's PKCE to work

This also removes docker dependencies of jupyterhub on the portal and DB. Technically they're required, but it forces them to stop and start everytime jupyterhub stops/starts, which makes iteration on jupyterhub_config.py take a lot longer.

## Screenshots (for front-end PR):

N/A - login works locally, and wasn't before!

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
