### PR TITLE
replace PdfMerger with PdfWriter

### DIFF
--- a/crt_portal/tms/views.py
+++ b/crt_portal/tms/views.py
@@ -182,7 +182,7 @@ class PdfReportView(LoginRequiredMixin, View):
         del request  # unused
 
         report = get_object_or_404(Report, id=report_id)
-        combined = pypdf.PdfMerger()
+        combined = pypdf.PdfWriter()
         for email in report.emails.exclude(purpose=TMSEmail.AUTO_EMAIL).order_by('-created_at'):
             try:
                 combined.append(pdf.convert_tms_to_pdf(email))

--- a/crt_portal/utils/pdf.py
+++ b/crt_portal/utils/pdf.py
@@ -93,7 +93,7 @@ def convert_tms_to_pdf(email: TMSEmail) -> io.BytesIO:
      }}
     """)
 
-    pdf = pypdf.PdfMerger()
+    pdf = pypdf.PdfWriter()
     pdf.append(convert_html_to_pdf(cover_page, stylesheets=[header_style]))
     pdf.append(convert_html_to_pdf(email.sent_content, stylesheets=[header_style]))
     out = io.BytesIO()
@@ -144,7 +144,7 @@ The following reports were disposed by the Civil Rights Division on {batch.dispo
      }}
     """)
 
-    pdf = pypdf.PdfMerger()
+    pdf = pypdf.PdfWriter()
     pdf.append(convert_html_to_pdf(page, stylesheets=[header_style]))
     out = io.BytesIO()
     pdf.write(out)


### PR DESCRIPTION
[Link to ZenHub issue.](https://github.com/orgs/usdoj-crt/projects/3/views/2?pane=issue&itemId=90393826&issue=usdoj-crt%7Ccrt-portal-management%7C2045)

## What does this change?
1. Replace PdfMerger with PdfWriter.

Context:
PdfMerger was deprecated and removed from the pypdf framework as of 5.0.0. According to the deprecation error, we need to use PdfWriter instead.

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
