### PR TITLE
[CRU] Bugfix for saving checkbox values

### DIFF
--- a/crt_portal/static/js/async_report_edit.js
+++ b/crt_portal/static/js/async_report_edit.js
@@ -59,6 +59,10 @@
 
     json.changed_data.forEach(key => {
       const value = json.form[key];
+      // If value is undefined, we don't want to reset the element on the form
+      if (!value) {
+        return;
+      }
 
       const element = form.querySelector(`[name="${key}"]`);
       if (!element) {

--- a/crt_portal/static/js/async_report_edit.js
+++ b/crt_portal/static/js/async_report_edit.js
@@ -60,24 +60,26 @@
     json.changed_data.forEach(key => {
       const value = json.form[key];
 
-      // We are making the assumption that if value is an array,
-      // we are corresponding to a group of checkbox elements
-      if (Array.isArray(value)) {
-        form.querySelectorAll(`[name="${key}"]`).forEach(box => (box.checked = false));
-        value.forEach(val => {
-          form
-            .querySelectorAll(`[name="${key}"][value="${val}"]`)
-            .forEach(box => (box.checked = true));
-        });
+      const element = form.querySelector(`[name="${key}"]`);
+      if (!element) {
+        console.error(`On Display OK: Element with name ${key} not found`);
         return;
       }
 
-      const element = form.querySelector(`[name="${key}"]`);
-      if (!element) {
-        console.error(`Element with name ${key} not found`);
-        return;
+      switch (element.type) {
+        case 'checkbox':
+          form.querySelectorAll(`[name="${key}"]`).forEach(box => (box.checked = false));
+          if (Array.isArray(value)) {
+            value.forEach(val => {
+              form
+                .querySelectorAll(`[name="${key}"][value="${val}"]`)
+                .forEach(box => (box.checked = true));
+            });
+          }
+          break;
+        default:
+          element.value = value;
       }
-      element.value = value;
     });
   }
 
@@ -90,19 +92,31 @@
     formData.delete('csrfmiddlewaretoken');
 
     const formattedData = {};
-
     for (const [key, value] of formData) {
-      if (Object.keys(formattedData).includes(key)) {
-        if (!Array.isArray(formattedData[key])) {
-          let existingValue = formattedData[key];
-          formattedData[key] = [existingValue];
-        }
-        if (!value) {
-          continue;
-        }
-        formattedData[key].push(value);
-      } else {
-        formattedData[key] = value;
+      if (!value) {
+        continue;
+      }
+      // We need to do Array.from because document.getElementsByName returns a NodeList, not an Array
+      const elements = Array.from(document.getElementsByName(key));
+
+      // We are assuming that checkbox elements will always be formatted
+      // as a list of values (an Array). We get only the first matching element's type
+      // because we are assuming that all elements with the same name should have the same type.
+      if (!Array.isArray(elements) || !elements.length) {
+        console.error(`On Save: Element with name ${key} not found`);
+        return;
+      }
+
+      const firstElement = elements[0];
+      switch (firstElement.type) {
+        case 'checkbox':
+          if (!Object.keys(formattedData).includes(key)) {
+            formattedData[key] = [];
+          }
+          formattedData[key].push(value);
+          break;
+        default:
+          formattedData[key] = value;
       }
     }
 


### PR DESCRIPTION
Unticketed

## What does this change do?
Bugfix for CRU proform saving.

1. Fixes a bug in the save fuction where selecting checkbox values with only a single value did not get set to an Array properly.
2. Fixes a bug in the displayOk function where clearing the value of an element that had an existing value would set that elements value to "undefined".

## Screenshots (for front-end PR):
![cruproformbugfix](https://github.com/user-attachments/assets/a0f5faa7-371a-45d4-a484-c2fe7982a528)

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
