### PR TITLE
Update Eeoc Office to order by the order field

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1160,7 +1160,7 @@ def get_phone_form_config(section):
                         Select(attrs={'class': 'usa-input usa-select'}),
                         {
                             'label': 'EEOC Office',
-                            'choices': EeocOffice.objects.filter(show=True).annotate(display=Concat(F('name'), Value(' '), F('address_line_2'), Value(' '), F('address_city'), Value(', '), F('address_state'))).values_list('pk', 'display').order_by('name'),
+                            'choices': EeocOffice.objects.filter(show=True).annotate(display=Concat(F('name'), Value(' '), F('address_line_2'), Value(' '), F('address_city'), Value(', '), F('address_state'))).values_list('pk', 'display').order_by('order'),
                         }),
             FieldConfig('eeoc_charge_number',
                         TextInput(attrs={'class': 'usa-input'}),


### PR DESCRIPTION
Unticketed

## What does this change?
Changes EEoC Office field to order by the 'order' field in its model rather than by its alphabetical 'name'

## Screenshots (for front-end PR):
Example: The Atlanta district office has an order of 0, and the Savannah local office has an order of 1. Philadelphia office has an order of 2, so despite being alphabetically before Savannah, it shows up afterwards.
<img width="480" alt="Screenshot 2025-01-14 at 11 52 41 AM" src="https://github.com/user-attachments/assets/211ec006-ebe2-491b-a1ec-58026cfda51e" />

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
