### PR TITLE
Add the ability to list all report contact emails

### DIFF
--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -67,10 +67,7 @@ def render_complainant_mail(*, report, template, action) -> Mail:
     html_message = render_to_string(html_source,
                                     {'content': content, 'report': report})
 
-    if not report.contact_email:
-        all_recipients = []
-    else:
-        all_recipients = [report.contact_email]
+    all_recipients = report.contact_emails
 
     allowed_recipients = remove_disallowed_recipients(all_recipients)
     disallowed_recipients = list(set(all_recipients) - set(allowed_recipients))
@@ -302,8 +299,8 @@ def mail_to_complainant(report, template, purpose=TMSEmail.MANUAL_EMAIL, dry_run
     """
     if not rendered:
         rendered = render_complainant_mail(report=report, template=template, action='email')
-    if not rendered.recipients:
-        logger.info(f'{report.contact_email} not in allowed domains, not attempting to deliver email response template #{template.id} to report: {report.id}')
+    if rendered.disallowed_recipients:
+        logger.info(f'Some recipients were not in allowed domains for #{template.id} for report: {report.id}')
 
     send_results = send_tms(rendered, report=report, purpose=purpose, dry_run=dry_run)
     logger.info(f'Sent email response template #{template.id} to report: {report.id}')

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -1,5 +1,6 @@
 """All models need to be added to signals.py for proper logging."""
-from typing import Optional
+from typing import Optional, List
+import itertools
 import logging
 import time
 import uuid
@@ -716,6 +717,19 @@ class Report(models.Model):
         print(f'Redacted report {self.public_id}')
         self.save()
         return
+
+    @cached_property
+    def contact_emails(self) -> List[str]:
+        emails = [self.contact_email] if self.contact_email else []
+        for additional_contact in itertools.count(2):
+            try:
+                email = getattr(self, f'contact_{additional_contact}_email')
+            except AttributeError:
+                break
+            if not email:
+                continue
+            emails.append(email)
+        return emails
 
     @cached_property
     def last_incident_date(self):

--- a/crt_portal/cts_forms/tests/test_models.py
+++ b/crt_portal/cts_forms/tests/test_models.py
@@ -55,6 +55,39 @@ class ReportSimpleTests(SimpleTestCase):
         expected = "Thank you for your report"
         self.assertEqual(report.addressee, expected)
 
+    def test_contact_emails(self):
+        report: Report = ReportFactory.build()
+        report.contact_email = 'one@example.com'
+        report.contact_2_email = 'two@example.com'
+        report.contact_3_email = 'three@example.com'
+        report.contact_4_email = 'four@example.com'
+        self.assertEqual(report.contact_emails, [
+            'one@example.com',
+            'two@example.com',
+            'three@example.com',
+            'four@example.com',
+        ])
+
+    def test_missing_contact_emails(self):
+        report: Report = ReportFactory.build()
+        report.contact_email = 'one@example.com'
+        report.contact_2_email = ''
+        report.contact_3_email = ''
+        report.contact_4_email = 'four@example.com'
+        self.assertEqual(report.contact_emails, [
+            'one@example.com',
+            'four@example.com',
+        ])
+
+    def test_no_contact_emails(self):
+        report: Report = ReportFactory.build()
+        report.contact_email = ''
+        report.contact_2_email = ''
+        report.contact_3_email = ''
+        report.contact_4_email = ''
+
+        self.assertEqual(report.contact_emails, [])
+
 
 class ScheduledNotificationTests(TestCase):
     @classmethod

--- a/crt_portal/utils/pdf.py
+++ b/crt_portal/utils/pdf.py
@@ -59,11 +59,16 @@ def _render_markdown(content: str) -> str:
 
 
 def _make_cover_page(email: TMSEmail) -> str:
+    if isinstance(email.recipient, list):
+        formatted_recipient = ', '.join(email.recipient)
+    else:
+        formatted_recipient = email.recipient
+
     meta = {
         'TMS ID': email.tms_id,
         'Report ID': email.report.id,
         'Subject': email.subject,
-        'Recipient': email.recipient,
+        'Recipient(s)': formatted_recipient,
         'Created at': email.created_at,
         'Completed at': email.completed_at,
         'Status': email.status,
@@ -75,8 +80,9 @@ def _make_cover_page(email: TMSEmail) -> str:
         '|--------|--------|',
         *[f'| {key} | {value} |' for key, value in meta.items()],
     ])
+
     return _render_markdown(f"""
-The following email message (with Granicus TMS id {email.tms_id}) was sent by the Civil Rights Division to {email.recipient} on {email.completed_at}:
+The following email message (with Granicus TMS id {email.tms_id}) was sent by the Civil Rights Division to {formatted_recipient} on {email.completed_at}:
 
 {meta_template}
     """)


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/2057

## What does this change?

- 🌎 Reports previously had a concept of a single contact email
- ⛔ We added more, which needs to be added to our mail sending
- ✅ This commit adds a utility property that forms a list of all contact emails to be used when sending mail.
- 🔮 Future commits will update cts_forms/mail.py to use this new list to send emails to multiple folks at once.

## Screenshots (for front-end PR):

N/A - see unit tests

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
