### PR TITLE
Force same-origin policy

### DIFF
--- a/crt_portal/crt_portal/settings.py
+++ b/crt_portal/crt_portal/settings.py
@@ -419,6 +419,8 @@ SESSION_COOKIE_HTTPONLY = True
 # See https://django-csp.readthedocs.io/en/latest/configuration.html
 # Note we are on 4.0+
 
+SECURE_CROSS_ORIGIN_OPENER_POLICY = 'same-origin'
+
 CONTENT_SECURITY_POLICY = {
     'EXCLUDE_URL_PREFIXES': ['/admin'],  # Allow admin panel functionality (which is trusted content that uses inline sources)
     'DIRECTIVES': {


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/2063

## What does this change?

- 🌎 Django security middleware is supposed to set same-origin
- ⛔ OWASP is reporting this isn't happening
- ✅ This commit forces the setting to same-origin
- 🔮 Future commits may offer further corrections if this doesn't help on dev

## Screenshots (for front-end PR):

<img width="1128" alt="image" src="https://github.com/user-attachments/assets/9f9972f7-d5f1-4b01-aba7-eecd1d057f9c" />

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
