### PR TITLE
Update mail.py to expect multiple recipients

### DIFF
--- a/crt_portal/cts_forms/mail.py
+++ b/crt_portal/cts_forms/mail.py
@@ -67,10 +67,7 @@ def render_complainant_mail(*, report, template, action) -> Mail:
     html_message = render_to_string(html_source,
                                     {'content': content, 'report': report})
 
-    if not report.contact_email:
-        all_recipients = []
-    else:
-        all_recipients = [report.contact_email]
+    all_recipients = report.contact_emails
 
     allowed_recipients = remove_disallowed_recipients(all_recipients)
     disallowed_recipients = list(set(all_recipients) - set(allowed_recipients))
@@ -302,8 +299,8 @@ def mail_to_complainant(report, template, purpose=TMSEmail.MANUAL_EMAIL, dry_run
     """
     if not rendered:
         rendered = render_complainant_mail(report=report, template=template, action='email')
-    if not rendered.recipients:
-        logger.info(f'{report.contact_email} not in allowed domains, not attempting to deliver email response template #{template.id} to report: {report.id}')
+    if rendered.disallowed_recipients:
+        logger.info(f'Some recipients were not in allowed domains for #{template.id} for report: {report.id}')
 
     send_results = send_tms(rendered, report=report, purpose=purpose, dry_run=dry_run)
     logger.info(f'Sent email response template #{template.id} to report: {report.id}')

--- a/crt_portal/utils/pdf.py
+++ b/crt_portal/utils/pdf.py
@@ -59,11 +59,16 @@ def _render_markdown(content: str) -> str:
 
 
 def _make_cover_page(email: TMSEmail) -> str:
+    if isinstance(email.recipient, list):
+        formatted_recipient = ', '.join(email.recipient)
+    else:
+        formatted_recipient = email.recipient
+
     meta = {
         'TMS ID': email.tms_id,
         'Report ID': email.report.id,
         'Subject': email.subject,
-        'Recipient': email.recipient,
+        'Recipient(s)': formatted_recipient,
         'Created at': email.created_at,
         'Completed at': email.completed_at,
         'Status': email.status,
@@ -75,8 +80,9 @@ def _make_cover_page(email: TMSEmail) -> str:
         '|--------|--------|',
         *[f'| {key} | {value} |' for key, value in meta.items()],
     ])
+
     return _render_markdown(f"""
-The following email message (with Granicus TMS id {email.tms_id}) was sent by the Civil Rights Division to {email.recipient} on {email.completed_at}:
+The following email message (with Granicus TMS id {email.tms_id}) was sent by the Civil Rights Division to {formatted_recipient} on {email.completed_at}:
 
 {meta_template}
     """)


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/2057

## What does this change?

- 🌎 Currently we only send to multiple recipients in referrals
- ⛔ We need to start sending to multiple for normal contact, as well
- ✅ This commit extends mail.py to expect multiple recipients on normal contact workflows

Note that status checks still work as intended for "overall recipient lists".

In the event of send failures, debugging individual recipients is possible through the admin panel.

## Screenshots (for front-end PR):

N/A

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
