### PR TITLE
Add footer pdfs per 2084

### DIFF
--- a/crt_portal/cts_forms/templates/partials/footer.html
+++ b/crt_portal/cts_forms/templates/partials/footer.html
@@ -12,6 +12,19 @@
       <div id="contact-crt" class="usa-footer__contact">
         <div class="usa-footer__section">
           <div class="usa-footer__icon">
+            <img src="{% static "img/mail.svg" %}" alt="mail" class="icon">
+          </div>
+          <div id="address-footer" class="usa-footer__links">
+            <p>{% trans 'Send Printed Report Form (<a target="_blank" href="https://www.ada.gov/assets/pdfs/file-a-complaint.pdf">Regular Format</a> | <a target="_blank" href="https://www.ada.gov/assets/pdfs/file-a-complaint-lg.pdf">Large Format</a>) To:' %}</p>
+            <p>U.S. Department of Justice</p>
+            <p>Civil Rights Division</p>
+            <p>950 Pennsylvania Avenue, NW</p>
+            <p>Washington, D.C. 20530-0001</p>
+          </div>
+        </div>
+
+        <div class="usa-footer__section">
+          <div class="usa-footer__icon">
             <img src="{% static "img/phone.svg" %}" alt="phone" class="icon">
           </div>
           <div id="phone-footer" class="usa-footer__links">


### PR DESCRIPTION
https://github.com/usdoj-crt/crt-portal-management/issues/2084

## What does this change?

Re-add PDF versions of forms.

Note that these versions are hosted on ADA, so that PR will need to deploy first.

## Screenshots (for front-end PR):

<img width="539" alt="image" src="https://github.com/user-attachments/assets/92af147e-35f8-4491-b252-523a6e8b6f41" />

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
