### PR TITLE
Add Attachments Widget to ELS-CRU Proform

### DIFF
--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -185,6 +185,7 @@ class ReportEdit(generics.CreateAPIView):
                     attachment.report = report
                     attachment.save()
                 except ReportAttachment.DoesNotExist:
+                    print(f"ReportEdit: WARNING: Failed to assign attachment: {attachment_id} to report: {form_id}. The ReportAttachment object does not exist.")
                     continue
 
         all_changes = form.changed_data + server_changes

--- a/crt_portal/cts_forms/templates/forms/complaint_view/side_nav.html
+++ b/crt_portal/cts_forms/templates/forms/complaint_view/side_nav.html
@@ -26,13 +26,13 @@
         <div hidden class="add-modal">
           <p><a href="/form/new/pro/VOT">New Election Intake Form</a></p>
           <hr/>
-          <p><a href="/form/new/pro/ELS-CRU">Case Referal Unit Intake Form</a></p>
+          <p><a href="/form/new/pro/ELS-CRU">Complaint Referral Intake Form</a></p>
           <hr/>
           <p><a href="/form/new">General Intake Form</a></p>
         </div>
     </div>
     <ul class="subnav">
-      <li><a href="/form/new/pro/ELS-CRU">Case Referal Unit Intake Form</a></li>
+      <li><a href="/form/new/pro/ELS-CRU">Complaint Referral Intake Form</a></li>
       <li><a href="/form/new/pro/VOT">New Election Intake Form</a></li>
       <li><a href="/form/new">General Intake Form</a></li>
     </ul>

--- a/crt_portal/cts_forms/templates/forms/phone_pro_template.html
+++ b/crt_portal/cts_forms/templates/forms/phone_pro_template.html
@@ -251,6 +251,9 @@
       {{form.working_group}}
       {{form.intake_format}}
       {{form.pk}}
+      {% if working_group == "ELS-CRU" %}
+      <input type="hidden" id="pro_form_attachment" name="pro_form_attachment"></input>
+      {% endif %}
     </div>
   </div>
 </div>
@@ -297,6 +300,21 @@
 </div>
 </div>
 </form>
+{% if working_group == "ELS-CRU" %}
+<div class="grid-row">
+  <div class="intake-content grid-col-8">
+    <div class="response-wrapper"></div>
+    <div class="crt-portal-card">
+      <div class="crt-portal-card__content">
+        <h2 class="text-primary-darker" id="date">Attachments</h2>
+        <div class="display-flex flex-align-end grid-row">
+          {% include "forms/snippets/file_upload.html" with title="Attachments" %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
 
 {% endblock %}
 {% if ENABLED_FEATURES.nav_updates %}
@@ -325,6 +343,7 @@
 <script src="{% static 'js/report_phone.min.js' %}"></script>
 <script src="{% static 'js/async_report_edit.min.js' %}"></script>
 <script src="{% static 'js/state_hide_show.min.js' %}"></script>
+<script src="{% static 'js/pro_form_attachments.min.js' %}"></script>
 {% if ENABLED_FEATURES.nav_updates %}
     <script src="{% static 'js/side_nav_slider.min.js' %}"></script>
 {% endif %}

--- a/crt_portal/cts_forms/templates/forms/phone_pro_template.html
+++ b/crt_portal/cts_forms/templates/forms/phone_pro_template.html
@@ -36,7 +36,7 @@
  
       {% if working_group == "ELS-CRU" %}
       <hr>
-      {% include 'partials/start_expandable.html' with title='Charging Party of Aggrieved Individual' expanded="true" %}
+      {% include 'partials/start_expandable.html' with title='Charging Party or Aggrieved Individual' expanded="true" %}
       {% endif %}
 
       <div class="grid-row margin-top-2">

--- a/crt_portal/cts_forms/views.py
+++ b/crt_portal/cts_forms/views.py
@@ -2202,6 +2202,12 @@ def phone_pro_form_view(request, report_id=None, working_group=None):
         case "ELS-CRU":
             title = "CRU Intake Form"
 
+    attachment_data = request.POST.get('pro_form_attachment', None)
+    attachments = None
+    if attachment_data:
+        attachment_ids = attachment_data.split(',')[:-1]
+        attachments = list(map(lambda id: get_object_or_404(ReportAttachment, pk=int(id)), attachment_ids))
+
     return render(
         request,
         'forms/phone_pro_template.html',
@@ -2240,6 +2246,9 @@ def phone_pro_form_view(request, report_id=None, working_group=None):
             'form': form,
 
             'working_group': working_group,
+
+            'pro_form_attachments': attachments,
+
         }
     )
 

--- a/crt_portal/static/js/pro_form_attachments.js
+++ b/crt_portal/static/js/pro_form_attachments.js
@@ -106,7 +106,9 @@
       event.preventDefault();
       removeFile(event);
     };
-    violationSummary.value = 'See attachment.';
+    if (violationSummary) {
+      violationSummary.value = 'See attachment.';
+    }
     if (attachmentInput.value == 'None') {
       attachmentInput.value = data.id + ',';
     } else {


### PR DESCRIPTION
[Link to issue](https://github.com/usdoj-crt/crt-portal-management/issues/2056)

## What does this change?

Adds attachments functionality to ELS-CRU Proform.
See the above ticket for more information.

## Screenshots (for front-end PR):

<img width="803" alt="Screenshot 2025-03-14 at 3 13 14 PM" src="https://github.com/user-attachments/assets/6febbc09-2afc-46e5-963a-e695f011b835" />
<img width="811" alt="Screenshot 2025-03-14 at 3 13 30 PM" src="https://github.com/user-attachments/assets/ccdb5690-3aba-4fb4-bf91-4ffb8ea35a6d" />

## Checklist:

### Author

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [x] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [x] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [x] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [x] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [x] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
