### PR TITLE
Limit API to only send responses from allowed templates

### DIFF
--- a/crt_portal/api/views.py
+++ b/crt_portal/api/views.py
@@ -480,7 +480,7 @@ class ResponseAction(APIView):
         template_id = request.data.get('template_id')
         if template_id is None:
             return JsonResponse({'response': 'Referral email failed to send: No template id provided!'}, status=400)
-        template = get_object_or_404(ResponseTemplate, pk=template_id)
+        template = get_object_or_404(ResponseTemplate, pk=template_id, show_in_dropdown=True)
         action = request.data['action']
         recipient = request.data.get('recipient', None)
         complainant_letter, agency_letter = build_letters(


### PR DESCRIPTION
[Link to issue.](https://github.com/usdoj-crt/crt-portal-management/issues/2098)

## What does this change?

Addresses freki-w036-8

## Screenshots (for front-end PR):

## Checklist:

### Author

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for, document, and establish a testing plan for any behavior that may vary across environments or is otherwise difficult to test.
+ [ ] Check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

### Reviewer

+ [ ] If this is a story, run locally and check to make sure all Acceptance Criteria are met. (If any criteria are unclear, ask about them.).
+ [ ] Check for any behavior that may vary across environments or is difficult to test, and ensure that it is well-understood, documented, and that there is a testing plan in place.
+ [ ] Re-check for [accessibility](https://github.com/usdoj-crt/crt-portal/blob/develop/docs/a11y_plan.md).
+ [ ] [Tests pass](https://github.com/USDOJ/crt-portal/#tests).

## Notes for reviewer:

See [PR instructions doc](https://github.com/usdoj/crt-portal/blob/master/docs/pull_requests.md) for full pull request review instructions.
