### PR TITLE
Revert "Bump h11 from 0.14.0 to 0.16.0 in /jupyterhub"

### DIFF
--- a/jupyterhub/Pipfile.lock
+++ b/jupyterhub/Pipfile.lock
@@ -589,12 +589,11 @@
         },
         "h11": {
             "hashes": [
-                "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1",
-                "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
+                "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d",
+                "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"
             ],
-            "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==0.16.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.14.0"
         },
         "httpcore": {
             "hashes": [


### PR DESCRIPTION
Reverts usdoj-crt/crt-portal#2061